### PR TITLE
feat: add optional backend_config rendering to xplane-vault-auth-base

### DIFF
--- a/crossplane/xplane-vault-auth-base/kcl.mod
+++ b/crossplane/xplane-vault-auth-base/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth-base"
 edition = "v0.11.0"
-version = "0.5.0"
+version = "0.6.0"
 description = "KCL library for creating Vault Kubernetes authentication backends as Crossplane v2 namespaced OpenTofu Workspaces"
 
 [dependencies]

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -1,8 +1,20 @@
 # Library module — not runnable standalone.
 # Generates Crossplane v2 namespaced OpenTofu Workspaces that configure
-# Vault Kubernetes auth backends.
+# Vault Kubernetes auth backends (optionally with backend_config).
 
 import crossplane_provider_opentofu.v1beta1 as otf
+
+schema K8sAuthBackendConfig:
+    # Renders a `vault_kubernetes_auth_backend_config` for this auth. The
+    # resource's CA cert and token reviewer JWT are read at tofu-apply time
+    # via the kubernetes TF provider `data "kubernetes_secret"` from a
+    # Secret in the cluster running opentofu-provider.
+    secretName: str
+    secretNamespace?: str   # defaults to the Workspace namespace
+    caCertKey?: str = "ca.crt"
+    tokenKey?: str = "token"
+    disableIssValidation?: bool = True
+    disableLocalCaJwt?: bool = True
 
 schema K8sAuth:
     name: str
@@ -11,7 +23,10 @@ schema K8sAuth:
     skipTlsVerify?: bool = False
     tokenPolicies?: [str] = ["read-secrets"]
     tokenTtl?: int = 3600
+    boundServiceAccountNames?: [str] = ["default"]
     boundServiceAccountNamespaces?: [str] = ["default"]
+    # If set, the generated Workspace also renders vault_kubernetes_auth_backend_config.
+    backendConfig?: K8sAuthBackendConfig
     labels?: {str: str}
     annotations?: {str: str}
 
@@ -25,9 +40,11 @@ schema VaultConfig:
     vaultTokenSecretKey?: str = "terraform.tfvars"
     providerConfigName?: str = "default"
     providerConfigKind?: "ClusterProviderConfig" | "ProviderConfig" = "ClusterProviderConfig"
+    # Required if any K8sAuth in k8sAuths has backendConfig set.
+    kubernetesHost?: str
 
-# HCL for a single Vault Kubernetes auth backend + role.
-_terraformCode = r"""provider "vault" {
+# Base HCL: vault provider + auth_backend + auth_backend_role.
+_baseHcl = r"""provider "vault" {
   address         = var.vault_addr
   skip_tls_verify = var.skip_tls_verify
   token           = var.vault_token
@@ -41,7 +58,7 @@ resource "vault_auth_backend" "kubernetes" {
 resource "vault_kubernetes_auth_backend_role" "service_account" {
   backend                          = vault_auth_backend.kubernetes.path
   role_name                        = var.auth_name
-  bound_service_account_names      = [var.auth_name]
+  bound_service_account_names      = var.bound_service_account_names
   bound_service_account_namespaces = var.bound_service_account_namespaces
   token_ttl                        = var.token_ttl
   token_policies                   = var.token_policies
@@ -54,6 +71,7 @@ variable "skip_tls_verify"                  { type = bool   default = false }
 variable "vault_token"                      { type = string sensitive = true }
 variable "token_policies"                   { type = list(string) default = [] }
 variable "token_ttl"                        { type = number default = 3600 }
+variable "bound_service_account_names"      { type = list(string) default = ["default"] }
 variable "bound_service_account_namespaces" { type = list(string) default = ["default"] }
 
 output "auth_backend_path" {
@@ -65,12 +83,71 @@ output "auth_role_name" {
 }
 """
 
+# Optional HCL: kubernetes provider + SA secret data source + backend_config.
+_backendConfigHcl = r"""
+provider "kubernetes" {}
+
+data "kubernetes_secret" "sa" {
+  metadata {
+    name      = var.sa_secret_name
+    namespace = var.sa_secret_namespace
+  }
+}
+
+resource "vault_kubernetes_auth_backend_config" "kubernetes" {
+  backend                = vault_auth_backend.kubernetes.path
+  kubernetes_host        = var.kubernetes_host
+  kubernetes_ca_cert     = data.kubernetes_secret.sa.data[var.sa_ca_cert_key]
+  token_reviewer_jwt     = data.kubernetes_secret.sa.data[var.sa_token_key]
+  disable_iss_validation = var.disable_iss_validation
+  disable_local_ca_jwt   = var.disable_local_ca_jwt
+
+  depends_on = [vault_auth_backend.kubernetes]
+}
+
+variable "kubernetes_host"        { type = string }
+variable "sa_secret_name"         { type = string }
+variable "sa_secret_namespace"    { type = string }
+variable "sa_ca_cert_key"         { type = string default = "ca.crt" }
+variable "sa_token_key"           { type = string default = "token" }
+variable "disable_iss_validation" { type = bool   default = true }
+variable "disable_local_ca_jwt"   { type = bool   default = true }
+"""
+
 _listToJson = lambda items: [str] -> str {
     '["' + '","'.join(items) + '"]'
 }
 
+_baseVars = lambda auth: K8sAuth -> [{str:str}] {
+    [
+        {key = "auth_name",                         value = auth.name}
+        {key = "cluster_name",                      value = auth.clusterName}
+        {key = "vault_addr",                        value = auth.vaultAddr}
+        {key = "skip_tls_verify",                   value = "true" if auth.skipTlsVerify else "false"}
+        {key = "token_policies",                    value = _listToJson(auth.tokenPolicies)}
+        {key = "token_ttl",                         value = str(auth.tokenTtl)}
+        {key = "bound_service_account_names",       value = _listToJson(auth.boundServiceAccountNames)}
+        {key = "bound_service_account_namespaces",  value = _listToJson(auth.boundServiceAccountNamespaces)}
+    ]
+}
+
+_backendConfigVars = lambda auth: K8sAuth, config: VaultConfig -> [{str:str}] {
+    bc = auth.backendConfig
+    [
+        {key = "kubernetes_host",        value = config.kubernetesHost or ""}
+        {key = "sa_secret_name",         value = bc.secretName}
+        {key = "sa_secret_namespace",    value = bc.secretNamespace or config.namespace}
+        {key = "sa_ca_cert_key",         value = bc.caCertKey}
+        {key = "sa_token_key",           value = bc.tokenKey}
+        {key = "disable_iss_validation", value = "true" if bc.disableIssValidation else "false"}
+        {key = "disable_local_ca_jwt",   value = "true" if bc.disableLocalCaJwt else "false"}
+    ] if bc else []
+}
+
 # Build one Workspace for a single K8sAuth entry.
 createSingleVaultAuth = lambda auth: K8sAuth, config: VaultConfig -> otf.Workspace {
+    _module = _baseHcl + (_backendConfigHcl if auth.backendConfig else "")
+    _vars = _baseVars(auth) + _backendConfigVars(auth, config)
     otf.Workspace {
         metadata = {
             name = "{}-{}-vault-auth".format(auth.clusterName, auth.name)
@@ -85,17 +162,9 @@ createSingleVaultAuth = lambda auth: K8sAuth, config: VaultConfig -> otf.Workspa
             }
             forProvider = {
                 source = "Inline"
-                module = _terraformCode
+                module = _module
                 inlineFormat = "HCL"
-                vars = [
-                    {key = "auth_name",        value = auth.name}
-                    {key = "cluster_name",     value = auth.clusterName}
-                    {key = "vault_addr",       value = auth.vaultAddr}
-                    {key = "skip_tls_verify",  value = "true" if auth.skipTlsVerify else "false"}
-                    {key = "token_policies",   value = _listToJson(auth.tokenPolicies)}
-                    {key = "token_ttl",        value = str(auth.tokenTtl)}
-                    {key = "bound_service_account_namespaces", value = _listToJson(auth.boundServiceAccountNamespaces)}
-                ]
+                vars = _vars
                 varFiles = [{
                     source = "SecretKey"
                     format = "HCL"

--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
-xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.5.0" }
+xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.6.0" }

--- a/crossplane/xplane-vault-auth/kcl.mod.lock
+++ b/crossplane/xplane-vault-auth/kcl.mod.lock
@@ -25,9 +25,9 @@
     oci_tag = "1.31"
   [dependencies.xplane-vault-auth-base]
     name = "xplane-vault-auth-base"
-    full_name = "xplane-vault-auth-base_0.5.0"
-    version = "0.5.0"
-    sum = "dmf8+01CmYGymujmdJanj/l0XhiaIgHvBsXzsFGlIms="
+    full_name = "xplane-vault-auth-base_0.6.0"
+    version = "0.6.0"
+    sum = "GPRZlT7+Zth+EdNXQHPYkD4ZHoTAgE1oQVcELfkKFYg="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-vault-auth-base"
-    oci_tag = "0.5.0"
+    oci_tag = "0.6.0"

--- a/crossplane/xplane-vault-auth/main.k
+++ b/crossplane/xplane-vault-auth/main.k
@@ -10,17 +10,31 @@ _vaultTokenSecret = _spec?.vaultTokenSecret or "vault"
 _vaultTokenSecretKey = _spec?.vaultTokenSecretKey or "terraform.tfvars"
 _providerConfigName = _spec?.providerConfigName or _clusterName
 _providerConfigKind = _spec?.providerConfigKind or "ClusterProviderConfig"
-_skipTlsVerify = _spec?.skipTlsVerify if "skipTlsVerify" in _spec else True
+_skipTlsVerify = _spec.skipTlsVerify if "skipTlsVerify" in _spec else True
+_kubernetesHost = _spec?.kubernetesHost or ""
+
+_buildBackendConfig = lambda bc: any -> vault_auth.K8sAuthBackendConfig {
+    vault_auth.K8sAuthBackendConfig {
+        secretName = bc?.secretName or "vault-default"
+        secretNamespace = bc?.secretNamespace
+        caCertKey = bc?.caCertKey or "ca.crt"
+        tokenKey = bc?.tokenKey or "token"
+        disableIssValidation = bc.disableIssValidation if bc and "disableIssValidation" in bc else True
+        disableLocalCaJwt = bc.disableLocalCaJwt if bc and "disableLocalCaJwt" in bc else True
+    } if bc else Undefined
+}
 
 _k8sAuths = [
     vault_auth.K8sAuth {
         name = auth?.name or "default"
         clusterName = auth?.clusterName or _clusterName
         vaultAddr = auth?.vaultAddr or _vaultAddr
-        skipTlsVerify = auth?.skipTlsVerify if "skipTlsVerify" in auth else _skipTlsVerify
+        skipTlsVerify = auth.skipTlsVerify if "skipTlsVerify" in auth else _skipTlsVerify
         tokenPolicies = auth?.tokenPolicies or ["read-secrets"]
         tokenTtl = auth?.tokenTtl or 3600
+        boundServiceAccountNames = auth?.boundServiceAccountNames or ["default"]
         boundServiceAccountNamespaces = auth?.boundServiceAccountNamespaces or ["default"]
+        backendConfig = _buildBackendConfig(auth?.backendConfig)
     } for auth in (_spec?.k8sAuths or [
         {"name": "frontend", "tokenPolicies": ["read-secrets"], "tokenTtl": 7200},
         {"name": "backend", "tokenPolicies": ["read-secrets", "write-logs"], "tokenTtl": 3600},
@@ -37,6 +51,7 @@ _config = vault_auth.VaultConfig {
     vaultTokenSecretKey = _vaultTokenSecretKey
     providerConfigName = _providerConfigName
     providerConfigKind = _providerConfigKind
+    kubernetesHost = _kubernetesHost
 }
 
 items = vault_auth.vaultK8sAuth(_config)


### PR DESCRIPTION
## Summary

Extends the vault-auth library so consumers can optionally render `vault_kubernetes_auth_backend_config` alongside the existing `vault_auth_backend` + `vault_kubernetes_auth_backend_role`. This unblocks migrating `crossplane/configurations/bootstrap/vault-auth` to be based on this library instead of its own inline go-templated HCL.

### `xplane-vault-auth-base` 0.6.0

- New schema `K8sAuthBackendConfig { secretName, secretNamespace?, caCertKey?, tokenKey?, disableIssValidation?, disableLocalCaJwt? }`.
- When `K8sAuth.backendConfig` is set, the generated Workspace additionally includes a `kubernetes` TF provider, a `data "kubernetes_secret"` block, and a `vault_kubernetes_auth_backend_config` resource. CA cert and token reviewer JWT are read at tofu-apply time from a K8s Secret (typically a ServiceAccount token secret).
- New `K8sAuth.boundServiceAccountNames` field (default `["default"]`) — previously hardcoded to `[auth.name]`.
- New `VaultConfig.kubernetesHost` field — required when any auth has `backendConfig` set.

### `xplane-vault-auth` 0.3.0

- Threads `backendConfig`, `boundServiceAccountNames`, and `kubernetesHost` through from `oxr.spec`.

Both modules pushed to ghcr:

- `ghcr.io/stuttgart-things/xplane-vault-auth-base:0.6.0`
- `ghcr.io/stuttgart-things/xplane-vault-auth:0.3.0`

## Test plan

- [x] Base lib compiles (`kcl run main.k`)
- [x] Consumer renders default case (no backendConfig) — verified
- [x] Consumer renders with `backendConfig` set — emits kubernetes provider block, data source, backend_config resource, and all backend_config vars — verified
- [ ] Apply against a live Crossplane v2 cluster with provider-opentofu

Generated with [Claude Code](https://claude.com/claude-code)