### PR TITLE
fix: default xplane-vault-auth namespace to oxr.metadata.namespace

### DIFF
--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.6.0" }

--- a/crossplane/xplane-vault-auth/main.k
+++ b/crossplane/xplane-vault-auth/main.k
@@ -1,11 +1,13 @@
 import xplane_vault_auth_base as vault_auth
 
 _params = option("params") or {}
-_spec = _params?.oxr?.spec or {}
+_oxr = _params?.oxr or {}
+_spec = _oxr?.spec or {}
+_meta = _oxr?.metadata or {}
 
 _clusterName = _spec?.clusterName or "default"
 _vaultAddr = _spec?.vaultAddr or "https://vault.example.com"
-_namespace = _spec?.namespace or "default"
+_namespace = _spec?.namespace or _meta?.namespace or "default"
 _vaultTokenSecret = _spec?.vaultTokenSecret or "vault"
 _vaultTokenSecretKey = _spec?.vaultTokenSecretKey or "terraform.tfvars"
 _providerConfigName = _spec?.providerConfigName or _clusterName


### PR DESCRIPTION
## Summary

- Fall back to `oxr.metadata.namespace` when `spec.namespace` is not set, so Crossplane v2 consumers don't have to duplicate the XR namespace in the spec.
- Bumps `xplane-vault-auth` to `0.3.1` (already pushed to `ghcr.io/stuttgart-things/xplane-vault-auth:0.3.1`).

## Test plan
- [x] Renders correctly when only `oxr.metadata.namespace` is set
- [x] Renders correctly when both are set (spec.namespace wins)
- [x] Renders correctly when neither is set (defaults to `default`)

Generated with [Claude Code](https://claude.com/claude-code)