### PR TITLE
fix: expand variable blocks to multi-line for opentofu compatibility

### DIFF
--- a/crossplane/xplane-vault-auth-base/kcl.mod
+++ b/crossplane/xplane-vault-auth-base/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth-base"
 edition = "v0.11.0"
-version = "0.7.0"
+version = "0.7.1"
 description = "KCL library for creating Vault Kubernetes authentication backends as Crossplane v2 namespaced OpenTofu Workspaces"
 
 [dependencies]

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -64,15 +64,47 @@ resource "vault_kubernetes_auth_backend_role" "service_account" {
   token_policies                   = var.token_policies
 }
 
-variable "auth_name"                        { type = string }
-variable "cluster_name"                     { type = string }
-variable "vault_addr"                       { type = string }
-variable "skip_tls_verify"                  { type = bool   default = false }
-variable "vault_token"                      { type = string sensitive = true }
-variable "token_policies"                   { type = list(string) default = [] }
-variable "token_ttl"                        { type = number default = 3600 }
-variable "bound_service_account_names"      { type = list(string) default = ["default"] }
-variable "bound_service_account_namespaces" { type = list(string) default = ["default"] }
+variable "auth_name" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "vault_addr" {
+  type = string
+}
+
+variable "skip_tls_verify" {
+  type    = bool
+  default = false
+}
+
+variable "vault_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "token_policies" {
+  type    = list(string)
+  default = []
+}
+
+variable "token_ttl" {
+  type    = number
+  default = 3600
+}
+
+variable "bound_service_account_names" {
+  type    = list(string)
+  default = ["default"]
+}
+
+variable "bound_service_account_namespaces" {
+  type    = list(string)
+  default = ["default"]
+}
 
 output "auth_backend_path" {
   value = vault_auth_backend.kubernetes.path
@@ -105,13 +137,37 @@ resource "vault_kubernetes_auth_backend_config" "kubernetes" {
   depends_on = [vault_auth_backend.kubernetes]
 }
 
-variable "kubernetes_host"        { type = string }
-variable "sa_secret_name"         { type = string }
-variable "sa_secret_namespace"    { type = string }
-variable "sa_ca_cert_key"         { type = string default = "ca.crt" }
-variable "sa_token_key"           { type = string default = "token" }
-variable "disable_iss_validation" { type = bool   default = true }
-variable "disable_local_ca_jwt"   { type = bool   default = true }
+variable "kubernetes_host" {
+  type = string
+}
+
+variable "sa_secret_name" {
+  type = string
+}
+
+variable "sa_secret_namespace" {
+  type = string
+}
+
+variable "sa_ca_cert_key" {
+  type    = string
+  default = "ca.crt"
+}
+
+variable "sa_token_key" {
+  type    = string
+  default = "token"
+}
+
+variable "disable_iss_validation" {
+  type    = bool
+  default = true
+}
+
+variable "disable_local_ca_jwt" {
+  type    = bool
+  default = true
+}
 """
 
 _listToJson = lambda items: [str] -> str {

--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
-xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.7.0" }
+xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.7.1" }

--- a/crossplane/xplane-vault-auth/kcl.mod.lock
+++ b/crossplane/xplane-vault-auth/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-vault-auth-base]
     name = "xplane-vault-auth-base"
-    full_name = "xplane-vault-auth-base_0.7.0"
-    version = "0.7.0"
-    sum = "rVsXcMkr+fXTiHQI/SwNIoDvVRYrhDgkwbjEBcz5ndo="
+    full_name = "xplane-vault-auth-base_0.7.1"
+    version = "0.7.1"
+    sum = "+7w9wryxEFzR3+3nYol1B1l7pvvxxkYm7vKtrEmoeWg="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-vault-auth-base"
-    oci_tag = "0.7.0"
+    oci_tag = "0.7.1"


### PR DESCRIPTION
## Summary

OpenTofu's HCL parser is stricter than terraform's and rejects single-line \`variable\` blocks with multiple arguments like \`{ type = bool default = false }\`, producing \`Invalid single-argument block definition\`. This only surfaced during end-to-end testing of the migrated \`bootstrap/vault-auth\` composition on a real cluster — the schema-level tests pass because they don't invoke tofu.

Fixed by expanding every \`variable\` block in the library's inline HCL template to multi-line form.

Verified end-to-end on a Crossplane v2 + provider-opentofu v1.0.3 + function-kcl v0.12.1 setup (k3s). With this change:
- Two \`Workspace\` CRs reconcile to \`Synced=True, Ready=True\`
- Vault gains \`auth/vcluster-tink2-dev/\` and \`auth/vcluster-tink2-cicd/\` Kubernetes auth backends
- Role under \`auth/vcluster-tink2-dev/role/dev\` shows the expected bound SAs, token policies, and TTL

Bumps:
- \`ghcr.io/stuttgart-things/xplane-vault-auth-base:0.7.1\`
- \`ghcr.io/stuttgart-things/xplane-vault-auth:0.4.1\`

Generated with [Claude Code](https://claude.com/claude-code)