### PR TITLE
fix(crossplane-provider-helm): republish as 0.1.4 to include helmm subpackage

### DIFF
--- a/models/crossplane-provider-helm/kcl.mod
+++ b/models/crossplane-provider-helm/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "crossplane-provider-helm"
 description = "Crossplane Helm Provider models for KCL"
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
 k8s = "1.32.4"


### PR DESCRIPTION
## Summary

The 0.1.3 OCI artifact at `ghcr.io/stuttgart-things/crossplane-provider-helm:0.1.3` was pushed from a stale local tree earlier today and is missing `models/v1beta1/helmm/helmm_crossplane_io_v1beta1_release.k` — the `helm.m.crossplane.io/v1beta1 Release` schema added in #36. Downstream consumers (e.g. xplane-vault-config upgrading to v2 namespaced MRs) hit `CannotFindModule` against the cached 0.1.3 artifact.

This PR bumps the version to `0.1.4` so it can be republished from clean `main`. The stale `0.1.3` tag is left in place rather than overwritten.

## Test plan

- [ ] `task lint-repository`
- [ ] Push `crossplane-provider-helm` `0.1.4` to `ghcr.io/stuttgart-things/crossplane-provider-helm`
- [ ] Verify the published artifact contains `models/v1beta1/helmm/helmm_crossplane_io_v1beta1_release.k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)