### PR TITLE
feat(argocd-application): add flexible Application generator module

### DIFF
--- a/kubernetes/argocd-application/README.md
+++ b/kubernetes/argocd-application/README.md
@@ -1,0 +1,227 @@
+# Argo CD Application (KCL generator)
+
+Flexible KCL module that renders an Argo CD `Application` manifest. Every
+field is overridable via `-D` flags, so the module can be invoked directly
+from the OCI registry without cloning the repo or shipping override files.
+
+Sibling of [`argocd-app-project`](../argocd-app-project/) — pair the two to
+provision a project and its apps from the same toolchain.
+
+## Quick start (OCI, standalone)
+
+Recreate the `xplane-test-guestbook` Application with a single command:
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=xplane-test-guestbook \
+  -D project=xplane-test \
+  -D destServer=https://10.100.136.192:34360 \
+  -D destNamespace=guestbook
+```
+
+Renders:
+
+```yaml
+items:
+- apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    name: xplane-test-guestbook
+    namespace: argocd
+  spec:
+    project: xplane-test
+    source:
+      repoURL: https://github.com/argoproj/argocd-example-apps.git
+      path: guestbook
+      targetRevision: HEAD
+    destination:
+      server: https://10.100.136.192:34360
+      namespace: guestbook
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+      - CreateNamespace=true
+```
+
+Pipe directly to `kubectl`:
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=xplane-test-guestbook \
+  -D project=xplane-test \
+  -D destServer=https://10.100.136.192:34360 \
+  -D destNamespace=guestbook \
+  | kubectl apply -f -
+```
+
+## Parameters
+
+All parameters are passed with `-D <name>=<value>`. Lists and dicts must be
+valid JSON (wrap the whole arg in single quotes).
+
+### Metadata
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | `"xplane-test-guestbook"` | `metadata.name` |
+| `namespace` | `str` | `"argocd"` | `metadata.namespace` |
+| `labels` | `{str: str}` | `{}` | `metadata.labels` |
+| `annotations` | `{str: str}` | `{}` | `metadata.annotations` |
+| `finalizers` | `[str]` | `[]` | `metadata.finalizers` (e.g. `["resources-finalizer.argocd.argoproj.io"]`) |
+
+### Project & source
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `project` | `str` | `"default"` | AppProject name |
+| `repoURL` | `str` | `"https://github.com/argoproj/argocd-example-apps.git"` | `spec.source.repoURL` |
+| `path` | `str` | `"guestbook"` | `spec.source.path` |
+| `targetRevision` | `str` | `"HEAD"` | `spec.source.targetRevision` |
+| `chart` | `str` | `""` (omitted) | Helm chart name (for Helm repos) |
+| `helm` | `{…}` | `{}` (omitted) | Full Helm source config |
+| `kustomize` | `{…}` | `{}` (omitted) | Full Kustomize source config |
+| `directory` | `{…}` | `{}` (omitted) | Directory source config |
+| `plugin` | `{…}` | `{}` (omitted) | CMP plugin config |
+| `source` | `{…}` | derived from above | Entire `spec.source` dict (overrides all source fields) |
+| `sources` | `[{…}]` | `[]` (omitted) | Multi-source apps — when set, replaces `source` |
+
+### Destination
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `destServer` | `str` | `"https://kubernetes.default.svc"` | `spec.destination.server` |
+| `destName` | `str` | `""` (omitted) | `spec.destination.name` (mutually exclusive with `destServer`) |
+| `destNamespace` | `str` | `"default"` | `spec.destination.namespace` |
+| `destination` | `{…}` | derived from above | Entire `spec.destination` dict |
+
+### Sync policy
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `prune` | `bool` | `True` | `syncPolicy.automated.prune` |
+| `selfHeal` | `bool` | `True` | `syncPolicy.automated.selfHeal` |
+| `allowEmpty` | `bool` | omitted | `syncPolicy.automated.allowEmpty` |
+| `automated` | `{…}` | derived | Entire `syncPolicy.automated` dict |
+| `syncOptions` | `[str]` | `["CreateNamespace=true"]` | `syncPolicy.syncOptions` |
+| `retry` | `{…}` | `{}` (omitted) | `syncPolicy.retry` (`{limit, backoff}`) |
+| `syncPolicy` | `{…}` | derived from above | Entire `syncPolicy` dict |
+
+### Other
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `revisionHistoryLimit` | `int` | omitted | `spec.revisionHistoryLimit` |
+| `info` | `[{name,value}]` | `[]` (omitted) | `spec.info` |
+
+## Common `-D` recipes
+
+### Minimal — in-cluster default project
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=my-app \
+  -D destNamespace=my-app
+```
+
+### Helm chart from a Helm repo
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=kube-prometheus-stack \
+  -D project=monitoring \
+  -D repoURL=https://prometheus-community.github.io/helm-charts \
+  -D chart=kube-prometheus-stack \
+  -D targetRevision=65.1.0 \
+  -D destNamespace=monitoring \
+  -D 'helm={"releaseName":"kps","valueFiles":["values.yaml"]}'
+```
+
+### Pin to a git tag and disable auto-sync
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=pinned-app \
+  -D targetRevision=v1.2.3 \
+  -D 'syncPolicy={}'
+```
+
+### Retry with backoff
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=retrying-app \
+  -D 'retry={"limit":5,"backoff":{"duration":"5s","factor":2,"maxDuration":"3m"}}'
+```
+
+### External cluster by name
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=prod-app \
+  -D destName=prod-cluster \
+  -D destNamespace=prod
+```
+
+### Extra sync options
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=apply-opts \
+  -D 'syncOptions=["CreateNamespace=true","PrunePropagationPolicy=foreground","ApplyOutOfSyncOnly=true"]'
+```
+
+### Add a cleanup finalizer
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \
+  -D name=finalized-app \
+  -D 'finalizers=["resources-finalizer.argocd.argoproj.io"]'
+```
+
+## Tips for `-D` with JSON
+
+- Wrap the whole arg in single quotes: `-D 'helm={"releaseName":"..."}'`.
+- Use double quotes **inside** the JSON (required by the parser).
+- Scalars are plain: `-D name=foo`, `-D destNamespace=guestbook`.
+- To drop a block entirely, pass an empty dict: `-D 'syncPolicy={}'`.
+
+## Local development
+
+```bash
+# Clone the repo, then:
+cd kubernetes/argocd-application
+
+# Use defaults
+kcl run main.k
+
+# Pass overrides on the CLI
+kcl run main.k -D name=xplane-test-guestbook -D project=xplane-test \
+  -D destServer=https://10.100.136.192:34360 -D destNamespace=guestbook
+
+# Or use an override file (reassigns the private _vars)
+kcl run main.k examples/xplane-test-guestbook.k
+kcl run main.k examples/minimal.k
+```
+
+## Publishing to OCI
+
+From the repo root:
+
+```bash
+task push-module MODULE_DIR=kubernetes/argocd-application NEW_VERSION=0.1.0
+```
+
+Then check the tag landed:
+
+```bash
+oras repo tags ghcr.io/stuttgart-things/argocd-application
+```
+
+## Files
+
+- [main.k](main.k) — `_var = option("…") or <default>` for each field; outputs `items = [_application]`
+- [schema.k](schema.k) — typed `Application`, `ApplicationSpec`, `Source`, `Destination`, `SyncPolicy`
+- [examples/xplane-test-guestbook.k](examples/xplane-test-guestbook.k) — recreates the paired AppProject example
+- [examples/minimal.k](examples/minimal.k) — in-cluster default-project variant

--- a/kubernetes/argocd-application/examples/minimal.k
+++ b/kubernetes/argocd-application/examples/minimal.k
@@ -1,0 +1,13 @@
+# Example: minimal in-cluster Application with automated sync
+#
+# Usage:
+#   kcl run main.k examples/minimal.k
+
+_name = "guestbook"
+_namespace = "argocd"
+_project = "default"
+
+_repoURL = "https://github.com/argoproj/argocd-example-apps.git"
+_path = "guestbook"
+
+_destNamespace = "guestbook"

--- a/kubernetes/argocd-application/examples/xplane-test-guestbook.k
+++ b/kubernetes/argocd-application/examples/xplane-test-guestbook.k
@@ -1,0 +1,18 @@
+# Example: recreate the xplane-test-guestbook Application
+#
+# Usage:
+#   kcl run main.k examples/xplane-test-guestbook.k
+
+_name = "xplane-test-guestbook"
+_namespace = "argocd"
+
+_project = "xplane-test"
+
+_repoURL = "https://github.com/argoproj/argocd-example-apps.git"
+_path = "guestbook"
+_targetRevision = "HEAD"
+
+_destServer = "https://10.100.136.192:34360"
+_destNamespace = "guestbook"
+
+_syncOptions = ["CreateNamespace=true"]

--- a/kubernetes/argocd-application/kcl.mod
+++ b/kubernetes/argocd-application/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "argocd-application"
+edition = "v0.11.2"
+version = "0.1.0"

--- a/kubernetes/argocd-application/main.k
+++ b/kubernetes/argocd-application/main.k
@@ -1,0 +1,89 @@
+# main.k
+import .schema
+
+# Metadata — override via -D or by reassigning in a .k override file
+_name = option("name") or "xplane-test-guestbook"
+_namespace = option("namespace") or "argocd"
+_labels = option("labels") or {}
+_annotations = option("annotations") or {}
+_finalizers = option("finalizers") or []
+
+# Project reference
+_project = option("project") or "default"
+
+# Source — override individual fields or the whole dict
+_repoURL = option("repoURL") or "https://github.com/argoproj/argocd-example-apps.git"
+_chart = option("chart") or ""
+_pathOpt = option("path")
+_path = _pathOpt if _pathOpt != None else ("" if _chart else "guestbook")
+_targetRevision = option("targetRevision") or "HEAD"
+_helm = option("helm") or {}
+_kustomize = option("kustomize") or {}
+_directory = option("directory") or {}
+_plugin = option("plugin") or {}
+_source = option("source") or {
+    repoURL = _repoURL
+    path = _path if _path else Undefined
+    targetRevision = _targetRevision if _targetRevision else Undefined
+    chart = _chart if _chart else Undefined
+    helm = _helm if _helm else Undefined
+    kustomize = _kustomize if _kustomize else Undefined
+    directory = _directory if _directory else Undefined
+    plugin = _plugin if _plugin else Undefined
+}
+_sources = option("sources") or []
+
+# Destination
+_destServer = option("destServer") or "https://kubernetes.default.svc"
+_destName = option("destName") or ""
+_destNamespace = option("destNamespace") or "default"
+_destination = option("destination") or {
+    server = _destServer if _destServer else Undefined
+    name = _destName if _destName else Undefined
+    namespace = _destNamespace
+}
+
+# Sync policy
+_prune = option("prune")
+_selfHeal = option("selfHeal")
+_allowEmpty = option("allowEmpty")
+_automated = option("automated") or {
+    prune = _prune if _prune != None else True
+    selfHeal = _selfHeal if _selfHeal != None else True
+    allowEmpty = _allowEmpty if _allowEmpty != None else Undefined
+}
+_syncOptions = option("syncOptions") or ["CreateNamespace=true"]
+_retry = option("retry") or {}
+_syncPolicy = option("syncPolicy") or {
+    automated = _automated if _automated else Undefined
+    syncOptions = _syncOptions if _syncOptions else Undefined
+    retry = _retry if _retry else Undefined
+}
+
+_revisionHistoryLimit = option("revisionHistoryLimit")
+_info = option("info") or []
+
+_metadata = schema.ObjectMeta {
+    name = _name
+    namespace = _namespace
+    labels = _labels if _labels else Undefined
+    annotations = _annotations if _annotations else Undefined
+    finalizers = _finalizers if _finalizers else Undefined
+}
+
+_spec = schema.ApplicationSpec {
+    project = _project
+    source = _source if _source and not _sources else Undefined
+    sources = _sources if _sources else Undefined
+    destination = _destination
+    syncPolicy = _syncPolicy if _syncPolicy else Undefined
+    revisionHistoryLimit = _revisionHistoryLimit if _revisionHistoryLimit != None else Undefined
+    info = _info if _info else Undefined
+}
+
+_application = schema.Application {
+    metadata = _metadata
+    spec = _spec
+}
+
+items = [_application]

--- a/kubernetes/argocd-application/schema.k
+++ b/kubernetes/argocd-application/schema.k
@@ -1,0 +1,74 @@
+# schema.k
+schema ObjectMeta:
+    name: str
+    namespace: str
+    labels?: {str: str}
+    annotations?: {str: str}
+    finalizers?: [str]
+
+schema Destination:
+    server?: str
+    name?: str
+    namespace: str
+
+schema HelmParameter:
+    name: str
+    value: str
+    forceString?: bool
+
+schema SourceHelm:
+    releaseName?: str
+    valueFiles?: [str]
+    values?: str
+    parameters?: [HelmParameter]
+    skipCrds?: bool
+    passCredentials?: bool
+
+schema Source:
+    repoURL: str
+    path?: str
+    targetRevision?: str
+    chart?: str
+    helm?: SourceHelm
+    kustomize?: {str:}
+    directory?: {str:}
+    plugin?: {str:}
+    ref?: str
+
+schema SyncAutomated:
+    prune?: bool
+    selfHeal?: bool
+    allowEmpty?: bool
+
+schema RetryBackoff:
+    duration?: str
+    factor?: int
+    maxDuration?: str
+
+schema SyncRetry:
+    limit?: int
+    backoff?: RetryBackoff
+
+schema SyncPolicy:
+    automated?: SyncAutomated
+    syncOptions?: [str]
+    retry?: SyncRetry
+
+schema Info:
+    name: str
+    value: str
+
+schema ApplicationSpec:
+    project: str
+    source?: Source
+    sources?: [Source]
+    destination: Destination
+    syncPolicy?: SyncPolicy
+    revisionHistoryLimit?: int
+    info?: [Info]
+
+schema Application:
+    apiVersion: str = "argoproj.io/v1alpha1"
+    kind: str = "Application"
+    metadata: ObjectMeta
+    spec: ApplicationSpec


### PR DESCRIPTION
## Summary
- New KCL generator module at \`kubernetes/argocd-application/\` — every Application field overridable via \`-D\` so it runs standalone from OCI (\`ghcr.io/stuttgart-things/argocd-application:0.1.0\`, already pushed).
- Pairs with \`argocd-app-project\` to provision a project and its apps from the same toolchain.
- \`path\` is auto-omitted when \`chart\` is set, so Helm-chart sources render correctly.

## Usage
Standalone, no clone required:
\`\`\`bash
kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 \\
  -D name=xplane-test-guestbook \\
  -D project=xplane-test \\
  -D destServer=https://10.100.136.192:34360 \\
  -D destNamespace=guestbook
\`\`\`

## Test plan
- [x] \`kcl run main.k\` renders defaults
- [x] \`kcl run main.k examples/xplane-test-guestbook.k\` reproduces target YAML
- [x] \`kcl run main.k examples/minimal.k\` renders scoped variant
- [x] \`kcl run main.k -D name=... -D project=... ...\` applies overrides
- [x] \`kcl run oci://ghcr.io/stuttgart-things/argocd-application --tag 0.1.0 ...\` renders from remote
- [x] Helm-chart source omits \`path\`; git source keeps it

🤖 Generated with [Claude Code](https://claude.com/claude-code)