### PR TITLE
feat(argocd-application-set): add flexible ApplicationSet generator module

### DIFF
--- a/kubernetes/argocd-application-set/README.md
+++ b/kubernetes/argocd-application-set/README.md
@@ -1,0 +1,236 @@
+# Argo CD ApplicationSet (KCL generator)
+
+Flexible KCL module that renders an Argo CD `ApplicationSet` manifest. Every
+field is overridable via `-D` flags, so the module can be invoked directly
+from the OCI registry without cloning the repo or shipping override files.
+
+Completes the trio with [`argocd-app-project`](../argocd-app-project/) and
+[`argocd-application`](../argocd-application/).
+
+## Quick start (OCI, standalone)
+
+The defaults reproduce the `kro` ApplicationSet with a git-file generator,
+multi-source template (Helm chart + `$values` ref), and Go-template-enabled
+destination substitution:
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0
+```
+
+Override just the name and keep the rest:
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D name=my-appset
+```
+
+Pipe directly to `kubectl`:
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  | kubectl apply -f -
+```
+
+## Parameters
+
+All parameters are passed with `-D <name>=<value>`. Lists and dicts must be
+valid JSON (wrap the whole arg in single quotes).
+
+### Metadata
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | `"kro"` | `metadata.name` |
+| `namespace` | `str` | `"argocd"` | `metadata.namespace` |
+| `labels` | `{str: str}` | `{}` | `metadata.labels` |
+| `annotations` | `{str: str}` | `{}` | `metadata.annotations` |
+| `finalizers` | `[str]` | `[]` | `metadata.finalizers` |
+
+### Templating engine
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `goTemplate` | `bool` | `True` | `spec.goTemplate` |
+| `goTemplateOptions` | `[str]` | `["missingkey=error"]` | `spec.goTemplateOptions` |
+
+### Generators
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `generators` | `[{…}]` | git-file generator for the `kro` example | `spec.generators` — pass as JSON |
+
+Each entry is a generator dict keyed by type (`git`, `list`, `cluster`,
+`matrix`, `merge`, `pullRequest`, `clusters`, `clusterDecisionResource`,
+`scmProvider`, `plugin`, …) — the module passes the structure through to
+Argo unchanged.
+
+### Template metadata (produced `Application.metadata`)
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `templateName` | `str` | `"kro-{{ .cluster.name }}"` | `template.metadata.name` |
+| `templateNamespace` | `str` | `""` (omitted) | `template.metadata.namespace` |
+| `templateLabels` | `{str: str}` | `{"app.kubernetes.io/part-of":"kro","cluster":"{{ .cluster.name }}"}` | `template.metadata.labels` |
+| `templateAnnotations` | `{str: str}` | `{}` (omitted) | `template.metadata.annotations` |
+| `templateFinalizers` | `[str]` | `[]` (omitted) | `template.metadata.finalizers` |
+| `templateMetadata` | `{…}` | derived from above | Entire `template.metadata` dict |
+
+### Template spec (produced `Application.spec`)
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `project` | `str` | `"default"` | `template.spec.project` |
+| `source` | `{…}` | `{}` (omitted) | Single-source `template.spec.source` |
+| `sources` | `[{…}]` | multi-source (Helm chart + `$values` ref) | `template.spec.sources` |
+| `destServer` | `str` | `"{{ .cluster.server }}"` | `template.spec.destination.server` |
+| `destName` | `str` | `""` (omitted) | `template.spec.destination.name` |
+| `destNamespace` | `str` | `"{{ .kro.namespace }}"` | `template.spec.destination.namespace` |
+| `destination` | `{…}` | derived from above | Entire `template.spec.destination` dict |
+| `prune` | `bool` | `True` | `template.spec.syncPolicy.automated.prune` |
+| `selfHeal` | `bool` | `True` | `template.spec.syncPolicy.automated.selfHeal` |
+| `allowEmpty` | `bool` | omitted | `template.spec.syncPolicy.automated.allowEmpty` |
+| `automated` | `{…}` | derived | `template.spec.syncPolicy.automated` |
+| `syncOptions` | `[str]` | `["CreateNamespace=true","ServerSideApply=true","Replace=true"]` | `template.spec.syncPolicy.syncOptions` |
+| `retry` | `{…}` | `{}` (omitted) | `template.spec.syncPolicy.retry` |
+| `templateSyncPolicy` | `{…}` | derived | Entire `template.spec.syncPolicy` |
+| `templateSpec` | `{…}` | derived | Entire `template.spec` |
+
+### Whole template override
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `template` | `{metadata,spec}` | derived | Replace the whole `spec.template` in one go |
+
+### Top-level extras
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `syncPolicyTopLevel` | `{…}` | `{}` (omitted) | `spec.syncPolicy` (appset-level, e.g. `preserveResourcesOnDeletion`) |
+| `strategy` | `{…}` | `{}` (omitted) | `spec.strategy` (rolling sync) |
+| `preservedFields` | `{…}` | `{}` (omitted) | `spec.preservedFields` |
+| `templatePatch` | `str` | `""` (omitted) | `spec.templatePatch` |
+
+## Common `-D` recipes
+
+### Fan out a single-source app to a list of clusters
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D name=multi-cluster-guestbook \
+  -D 'generators=[{"list":{"elements":[
+        {"cluster":"dev","url":"https://1.2.3.4","namespace":"guestbook-dev"},
+        {"cluster":"prod","url":"https://5.6.7.8","namespace":"guestbook-prod"}
+      ]}}]' \
+  -D templateName='{{ .cluster }}-guestbook' \
+  -D 'templateLabels={"cluster":"{{ .cluster }}"}' \
+  -D 'sources=[]' \
+  -D 'source={"repoURL":"https://github.com/argoproj/argocd-example-apps.git","path":"guestbook","targetRevision":"HEAD"}' \
+  -D destServer='{{ .url }}' \
+  -D destNamespace='{{ .namespace }}' \
+  -D 'syncOptions=["CreateNamespace=true"]'
+```
+
+### Cluster generator (all Argo-registered clusters)
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D name=cluster-addons \
+  -D 'generators=[{"clusters":{}}]' \
+  -D templateName='addons-{{ .name }}' \
+  -D destServer='{{ .server }}' \
+  -D destNamespace=addons
+```
+
+### Matrix generator combining git directories × clusters
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D name=apps-per-cluster \
+  -D 'generators=[{"matrix":{"generators":[
+        {"git":{"repoURL":"https://github.com/org/repo.git","revision":"HEAD","directories":[{"path":"apps/*"}]}},
+        {"clusters":{}}
+      ]}}]' \
+  -D templateName='{{ path.basename }}-{{ .name }}'
+```
+
+### Disable Go-templating (use `{{values}}`-style handlebars)
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D goTemplate=false \
+  -D 'goTemplateOptions=[]' \
+  -D templateName='{{values}}-app'
+```
+
+### Preserve Applications when the set is deleted
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D 'syncPolicyTopLevel={"preserveResourcesOnDeletion":true}'
+```
+
+### Rolling sync strategy
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D 'strategy={"type":"RollingSync","rollingSync":{"steps":[
+        {"matchExpressions":[{"key":"env","operator":"In","values":["dev"]}]},
+        {"matchExpressions":[{"key":"env","operator":"In","values":["prod"]}],"maxUpdate":"10%"}
+      ]}}'
+```
+
+### Whole-template override (pass the full template dict)
+
+```bash
+kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \
+  -D 'template={"metadata":{"name":"{{ .name }}-app"},"spec":{"project":"default","source":{"repoURL":"…","path":"…","targetRevision":"HEAD"},"destination":{"server":"{{ .server }}","namespace":"default"}}}'
+```
+
+## Tips for `-D` with JSON
+
+- Wrap the whole arg in single quotes so the shell doesn't eat the braces:
+  `-D 'generators=[{"git":{"repoURL":"…"}}]'`.
+- Use double quotes **inside** the JSON (required by the parser).
+- Argo Go-template expressions like `{{ .cluster.name }}` live in string
+  values, so they pass through the JSON parser untouched — just quote them
+  in the shell.
+- To drop a block entirely, pass an empty dict/list: `-D 'sources=[]'`,
+  `-D 'syncPolicyTopLevel={}'`.
+
+## Local development
+
+```bash
+# Clone the repo, then:
+cd kubernetes/argocd-application-set
+
+# Use defaults (renders the kro ApplicationSet)
+kcl run main.k
+
+# Pass overrides on the CLI
+kcl run main.k -D name=my-appset -D templateName='my-{{ .cluster.name }}'
+
+# Or use an override file
+kcl run main.k examples/kro.k
+kcl run main.k examples/list.k
+```
+
+## Publishing to OCI
+
+From the repo root:
+
+```bash
+task push-module MODULE_DIR=kubernetes/argocd-application-set NEW_VERSION=0.1.0
+```
+
+Then check the tag landed:
+
+```bash
+oras repo tags ghcr.io/stuttgart-things/argocd-application-set
+```
+
+## Files
+
+- [main.k](main.k) — `_var = option("…") or <default>` for each field; outputs `items = [_applicationSet]`
+- [schema.k](schema.k) — typed `ApplicationSet`, `ApplicationSetSpec` (with flexible `generators` / `template` passthrough)
+- [examples/kro.k](examples/kro.k) — recreates the target `kro` ApplicationSet
+- [examples/list.k](examples/list.k) — list generator fanning out a single-source app

--- a/kubernetes/argocd-application-set/examples/kro.k
+++ b/kubernetes/argocd-application-set/examples/kro.k
@@ -1,0 +1,58 @@
+# Example: recreate the kro ApplicationSet with a git-file generator
+#
+# Usage:
+#   kcl run main.k examples/kro.k
+
+_name = "kro"
+_namespace = "argocd"
+
+_goTemplate = True
+_goTemplateOptions = ["missingkey=error"]
+
+_generators = [
+    {
+        git = {
+            repoURL = "https://github.com/stuttgart-things/flux.git"
+            revision = "HEAD"
+            files = [
+                {path = "tests/argocd/kro/clusters/*/cluster.yaml"}
+            ]
+        }
+    }
+]
+
+_templateName = "kro-{{ .cluster.name }}"
+_templateLabels = {
+    "app.kubernetes.io/part-of" = "kro"
+    "cluster" = "{{ .cluster.name }}"
+}
+
+_project = "default"
+
+_sources = [
+    {
+        repoURL = "registry.k8s.io/kro/charts"
+        chart = "kro"
+        targetRevision = "{{ .kro.chartVersion }}"
+        helm = {
+            releaseName = "kro"
+            valueFiles = [
+                "$values/tests/argocd/kro/clusters/{{ .cluster.name }}/values.yaml"
+            ]
+        }
+    }
+    {
+        repoURL = "https://github.com/stuttgart-things/flux.git"
+        targetRevision = "HEAD"
+        ref = "values"
+    }
+]
+
+_destServer = "{{ .cluster.server }}"
+_destNamespace = "{{ .kro.namespace }}"
+
+_syncOptions = [
+    "CreateNamespace=true"
+    "ServerSideApply=true"
+    "Replace=true"
+]

--- a/kubernetes/argocd-application-set/examples/list.k
+++ b/kubernetes/argocd-application-set/examples/list.k
@@ -1,0 +1,34 @@
+# Example: simple list generator fanning out an app to multiple clusters
+#
+# Usage:
+#   kcl run main.k examples/list.k
+
+_name = "multi-cluster-guestbook"
+
+_generators = [
+    {
+        list = {
+            elements = [
+                {cluster = "dev", url = "https://1.2.3.4", namespace = "guestbook-dev"}
+                {cluster = "prod", url = "https://5.6.7.8", namespace = "guestbook-prod"}
+            ]
+        }
+    }
+]
+
+_templateName = "{{ .cluster }}-guestbook"
+_templateLabels = {cluster = "{{ .cluster }}"}
+
+_project = "default"
+
+_sources = []
+_source = {
+    repoURL = "https://github.com/argoproj/argocd-example-apps.git"
+    path = "guestbook"
+    targetRevision = "HEAD"
+}
+
+_destServer = "{{ .url }}"
+_destNamespace = "{{ .namespace }}"
+
+_syncOptions = ["CreateNamespace=true"]

--- a/kubernetes/argocd-application-set/kcl.mod
+++ b/kubernetes/argocd-application-set/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "argocd-application-set"
+edition = "v0.11.2"
+version = "0.1.0"

--- a/kubernetes/argocd-application-set/main.k
+++ b/kubernetes/argocd-application-set/main.k
@@ -1,0 +1,143 @@
+# main.k
+import .schema
+
+# Metadata — override via -D or by reassigning in a .k override file
+_name = option("name") or "kro"
+_namespace = option("namespace") or "argocd"
+_labels = option("labels") or {}
+_annotations = option("annotations") or {}
+_finalizers = option("finalizers") or []
+
+# Template engine
+_goTemplate = option("goTemplate")
+_goTemplateOptions = option("goTemplateOptions") or ["missingkey=error"]
+
+# Generators — required, must be provided unless defaults are overridden
+_generators = option("generators") or [
+    {
+        git = {
+            repoURL = "https://github.com/stuttgart-things/flux.git"
+            revision = "HEAD"
+            files = [
+                {path = "tests/argocd/kro/clusters/*/cluster.yaml"}
+            ]
+        }
+    }
+]
+
+# Template — build from convenience vars when `template` is not passed whole
+_templateName = option("templateName") or "kro-{{ .cluster.name }}"
+_templateNamespace = option("templateNamespace") or ""
+_templateLabels = option("templateLabels") or {
+    "app.kubernetes.io/part-of" = "kro"
+    "cluster" = "{{ .cluster.name }}"
+}
+_templateAnnotations = option("templateAnnotations") or {}
+_templateFinalizers = option("templateFinalizers") or []
+
+_project = option("project") or "default"
+
+# Source(s) for the generated Applications
+_source = option("source") or {}
+_sources = option("sources") or [
+    {
+        repoURL = "registry.k8s.io/kro/charts"
+        chart = "kro"
+        targetRevision = "{{ .kro.chartVersion }}"
+        helm = {
+            releaseName = "kro"
+            valueFiles = [
+                "$values/tests/argocd/kro/clusters/{{ .cluster.name }}/values.yaml"
+            ]
+        }
+    }
+    {
+        repoURL = "https://github.com/stuttgart-things/flux.git"
+        targetRevision = "HEAD"
+        ref = "values"
+    }
+]
+
+# Destination
+_destServer = option("destServer") or "{{ .cluster.server }}"
+_destName = option("destName") or ""
+_destNamespace = option("destNamespace") or "{{ .kro.namespace }}"
+_destination = option("destination") or {
+    server = _destServer if _destServer else Undefined
+    name = _destName if _destName else Undefined
+    namespace = _destNamespace
+}
+
+# Sync policy for the generated Applications
+_prune = option("prune")
+_selfHeal = option("selfHeal")
+_allowEmpty = option("allowEmpty")
+_automated = option("automated") or {
+    prune = _prune if _prune != None else True
+    selfHeal = _selfHeal if _selfHeal != None else True
+    allowEmpty = _allowEmpty if _allowEmpty != None else Undefined
+}
+_syncOptions = option("syncOptions") or [
+    "CreateNamespace=true"
+    "ServerSideApply=true"
+    "Replace=true"
+]
+_retry = option("retry") or {}
+_templateSyncPolicy = option("templateSyncPolicy") or {
+    automated = _automated if _automated else Undefined
+    syncOptions = _syncOptions if _syncOptions else Undefined
+    retry = _retry if _retry else Undefined
+}
+
+_templateMetadata = option("templateMetadata") or {
+    name = _templateName
+    namespace = _templateNamespace if _templateNamespace else Undefined
+    labels = _templateLabels if _templateLabels else Undefined
+    annotations = _templateAnnotations if _templateAnnotations else Undefined
+    finalizers = _templateFinalizers if _templateFinalizers else Undefined
+}
+
+_templateSpec = option("templateSpec") or {
+    project = _project
+    source = _source if _source and not _sources else Undefined
+    sources = _sources if _sources else Undefined
+    destination = _destination
+    syncPolicy = _templateSyncPolicy if _templateSyncPolicy else Undefined
+}
+
+_template = option("template") or {
+    metadata = _templateMetadata
+    spec = _templateSpec
+}
+
+# Top-level spec extras
+_syncPolicy = option("syncPolicyTopLevel") or {}
+_strategy = option("strategy") or {}
+_preservedFields = option("preservedFields") or {}
+_templatePatch = option("templatePatch") or ""
+
+_metadata = schema.ObjectMeta {
+    name = _name
+    namespace = _namespace
+    labels = _labels if _labels else Undefined
+    annotations = _annotations if _annotations else Undefined
+    finalizers = _finalizers if _finalizers else Undefined
+}
+
+_spec = schema.ApplicationSetSpec {
+    goTemplate = _goTemplate if _goTemplate != None else True
+    goTemplateOptions = _goTemplateOptions if _goTemplateOptions else Undefined
+    generators = _generators
+    template = _template
+    syncPolicy = _syncPolicy if _syncPolicy else Undefined
+    strategy = _strategy if _strategy else Undefined
+    preservedFields = _preservedFields if _preservedFields else Undefined
+    templatePatch = _templatePatch if _templatePatch else Undefined
+}
+
+_applicationSet = schema.ApplicationSet {
+    metadata = _metadata
+    spec = _spec
+}
+
+items = [_applicationSet]

--- a/kubernetes/argocd-application-set/schema.k
+++ b/kubernetes/argocd-application-set/schema.k
@@ -1,0 +1,27 @@
+# schema.k
+schema ObjectMeta:
+    name: str
+    namespace: str
+    labels?: {str: str}
+    annotations?: {str: str}
+    finalizers?: [str]
+
+# ApplicationSet spec uses flexible nested dicts because generators and
+# templates have dozens of shapes (git, list, cluster, matrix, merge,
+# pullRequest, clusters, clusterDecisionResource, scmProvider, plugin, …).
+# Top-level fields stay typed; nested content is passed through as-is.
+schema ApplicationSetSpec:
+    goTemplate?: bool
+    goTemplateOptions?: [str]
+    generators: [{str:}]
+    template: {str:}
+    syncPolicy?: {str:}
+    strategy?: {str:}
+    preservedFields?: {str:}
+    templatePatch?: str
+
+schema ApplicationSet:
+    apiVersion: str = "argoproj.io/v1alpha1"
+    kind: str = "ApplicationSet"
+    metadata: ObjectMeta
+    spec: ApplicationSetSpec


### PR DESCRIPTION
## Summary
- New KCL generator module at \`kubernetes/argocd-application-set/\` — every ApplicationSet field overridable via \`-D\` so it runs standalone from OCI (\`ghcr.io/stuttgart-things/argocd-application-set:0.1.0\`, already pushed).
- Completes the trio with \`argocd-app-project\` and \`argocd-application\`.
- Schema keeps top-level fields typed; \`generators\` and \`template\` pass through as flexible dicts so every generator type works (git, list, matrix, clusters, scmProvider, plugin, …).
- Defaults reproduce the \`kro\` ApplicationSet (git-file generator, multi-source template with Helm chart + \`\$values\` ref, Go-template destination).

## Usage
Defaults render the \`kro\` example directly:
\`\`\`bash
kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0
\`\`\`

List generator fanning out to multiple clusters:
\`\`\`bash
kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0 \\
  -D name=multi-cluster-guestbook \\
  -D 'generators=[{\"list\":{\"elements\":[{\"cluster\":\"dev\",\"url\":\"https://1.2.3.4\",\"namespace\":\"guestbook-dev\"}]}}]' \\
  -D 'source={\"repoURL\":\"https://github.com/argoproj/argocd-example-apps.git\",\"path\":\"guestbook\",\"targetRevision\":\"HEAD\"}' \\
  -D 'sources=[]' \\
  -D destServer='{{ .url }}' \\
  -D destNamespace='{{ .namespace }}'
\`\`\`

## Test plan
- [x] \`kcl run main.k\` renders the kro target YAML
- [x] \`kcl run main.k examples/kro.k\` reproduces target YAML
- [x] \`kcl run main.k examples/list.k\` renders list-generator variant
- [x] \`kcl run main.k -D name=... -D 'generators=[...]' ...\` applies JSON overrides
- [x] \`kcl run oci://ghcr.io/stuttgart-things/argocd-application-set --tag 0.1.0\` renders from remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)