### PR TITLE
feat(clusterbook-cluster): add clusterType + lbRange for kind variant

### DIFF
--- a/models/clusterbook-cluster/README.md
+++ b/models/clusterbook-cluster/README.md
@@ -21,7 +21,7 @@ kcl mod add oci://ghcr.io/stuttgart-things/clusterbook-cluster
 
 # Or add to kcl.mod manually
 [dependencies]
-clusterbook-cluster = { oci = "oci://ghcr.io/stuttgart-things/clusterbook-cluster", tag = "0.0.1" }
+clusterbook-cluster = { oci = "oci://ghcr.io/stuttgart-things/clusterbook-cluster", tag = "0.1.0" }
 ```
 
 ## Usage
@@ -91,6 +91,49 @@ items = [cluster]
 `kubeconfigSecretRef` and `existingSecretRef` are mutually exclusive — exactly
 one must be set.
 
+### ClusterbookCluster (kind / registration-only mode)
+
+For `kind` clusters the operator can skip clusterbook-server calls entirely
+and only emit the Argo CD cluster `Secret` plus user-pinned LB-range
+annotations. `networkKey` and `providerConfigRef` are omitted; the CRD
+requires `preserveKubeconfigServer=true` in this mode (no IP/FQDN allocated
+for `data.server`).
+
+```python
+import clusterbook-cluster.v1alpha1.clusterbook_stuttgart_things_com_v1alpha1_clusterbook_cluster as cbk_mod
+
+cluster = cbk_mod.ClusterbookCluster {
+    metadata = {
+        name = "dev"
+    }
+    spec = {
+        clusterName = "dev"
+        clusterType = "kind"
+        preserveKubeconfigServer = True
+        kubeconfigSecretRef = {
+            name = "kind-dev-kubeconfig"
+            namespace = "argocd"
+            key = "kubeconfig"
+        }
+        argocdNamespace = "argocd"
+        lbRange = {
+            start = "172.18.255.200"
+            stop = "172.18.255.250"
+        }
+        labels = {
+            "auto-project" = "true"
+            "cicd-platform" = "true"
+            "cicd-platform/crossplane" = "true"
+        }
+        releaseOnDelete = True
+    }
+}
+
+items = [cluster]
+```
+
+Requires `clusterbook-operator >= v0.16.0`.
+
 ## Rendering
 
 ```bash
@@ -105,6 +148,12 @@ kcl run examples/clusterbook_cluster.k \
   -D clusterName=denver \
   -D networkKey=10.31.103 \
   -D kubeconfigSecretName=denver-kubeconfig
+
+# Render the kind / registration-only example
+kcl run examples/clusterbook_cluster_kind.k \
+  -D clusterName=dev \
+  -D lbRangeStart=172.18.255.200 \
+  -D lbRangeStop=172.18.255.250
 ```
 
 ## Testing
@@ -118,7 +167,8 @@ Expected output:
 ```
 test_clusterbook_cluster_managed: PASS
 test_clusterbook_cluster_enrich: PASS
-PASS: 2/2
+test_clusterbook_cluster_kind: PASS
+PASS: 3/3
 ```
 
 ## CRD Source

--- a/models/clusterbook-cluster/examples/clusterbook_cluster_kind.k
+++ b/models/clusterbook-cluster/examples/clusterbook_cluster_kind.k
@@ -1,0 +1,58 @@
+"""
+Example: ClusterbookCluster in kind / registration-only mode.
+
+No networkKey + no providerConfigRef → clusterbook-operator skips
+clusterbook-server calls entirely and only writes the ArgoCD cluster Secret
+with cluster-type=kind plus user-pinned lb-range-{start,stop} annotations
+(typically consumed by a CiliumLoadBalancerIPPool on the kind cluster).
+
+preserveKubeconfigServer is required by the CRD in this mode — there is no
+allocated IP/FQDN, so data.server is taken from the kubeconfig verbatim.
+
+Render:
+    kcl run examples/clusterbook_cluster_kind.k
+"""
+import ..v1alpha1.clusterbook_stuttgart_things_com_v1alpha1_clusterbook_cluster as cbk_mod
+
+# Inputs (override via -D key=value)
+clusterName = option("clusterName") or "dev"
+kubeconfigSecretName = option("kubeconfigSecretName") or "kind-${clusterName}-kubeconfig"
+kubeconfigSecretKey = option("kubeconfigSecretKey") or "kubeconfig"
+argocdNamespace = option("argocdNamespace") or "argocd"
+lbRangeStart = option("lbRangeStart") or "172.18.255.200"
+lbRangeStop = option("lbRangeStop") or "172.18.255.250"
+
+cluster = cbk_mod.ClusterbookCluster {
+    metadata = {
+        name = clusterName
+    }
+    spec = {
+        clusterName = clusterName
+        clusterType = "kind"
+        preserveKubeconfigServer = True
+        kubeconfigSecretRef = {
+            name = kubeconfigSecretName
+            namespace = argocdNamespace
+            key = kubeconfigSecretKey
+        }
+        argocdNamespace = argocdNamespace
+        lbRange = {
+            start = lbRangeStart
+            stop = lbRangeStop
+        }
+        labels = {
+            "auto-project" = "true"
+            "cicd-platform" = "true"
+            "cicd-platform/crossplane" = "true"
+            "cicd-platform/openebs" = "true"
+            "cicd-platform/kro" = "true"
+            "cicd-platform/tekton" = "true"
+            "cicd-platform/argo-rollouts" = "false"
+            "cicd-platform/dapr" = "false"
+            "cicd-platform/kargo" = "false"
+        }
+        releaseOnDelete = True
+    }
+}
+
+items = [cluster]

--- a/models/clusterbook-cluster/kcl.mod
+++ b/models/clusterbook-cluster/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "clusterbook-cluster"
 edition = "v0.11.2"
-version = "0.0."
+version = "0.1.0"

--- a/models/clusterbook-cluster/tests/clusterbook_test.k
+++ b/models/clusterbook-cluster/tests/clusterbook_test.k
@@ -74,8 +74,46 @@ test_clusterbook_cluster_enrich = lambda {
     assert cluster.spec.existingSecretRef.namespace == "argocd"
 }
 
+# Test 3: ClusterbookCluster in kind / registration-only mode
+# (no networkKey, no providerConfigRef, with clusterType=kind, lbRange,
+# and kubeconfigSecretRef.key)
+test_clusterbook_cluster_kind = lambda {
+    cluster = cbk_mod.ClusterbookCluster {
+        metadata = {
+            name = "dev"
+        }
+        spec = {
+            clusterName = "dev"
+            clusterType = "kind"
+            preserveKubeconfigServer = True
+            kubeconfigSecretRef = {
+                name = "kind-dev-kubeconfig"
+                namespace = "argocd"
+                key = "kubeconfig"
+            }
+            argocdNamespace = "argocd"
+            lbRange = {
+                start = "172.18.255.200"
+                stop = "172.18.255.250"
+            }
+            labels = {
+                "auto-project" = "true"
+                "cicd-platform" = "true"
+            }
+            releaseOnDelete = True
+        }
+    }
+
+    assert cluster.spec.clusterType == "kind"
+    assert cluster.spec.kubeconfigSecretRef.key == "kubeconfig"
+    assert cluster.spec.lbRange.start == "172.18.255.200"
+    assert cluster.spec.lbRange.stop == "172.18.255.250"
+    assert cluster.spec.preserveKubeconfigServer == True
+}
+
 # Run all tests
 test_clusterbook_cluster_managed()
 test_clusterbook_cluster_enrich()
+test_clusterbook_cluster_kind()
 
 print("All clusterbook schema tests passed")

--- a/models/clusterbook-cluster/v1alpha1/clusterbook_stuttgart_things_com_v1alpha1_clusterbook_cluster.k
+++ b/models/clusterbook-cluster/v1alpha1/clusterbook_stuttgart_things_com_v1alpha1_clusterbook_cluster.k
@@ -50,6 +50,11 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpec:
     clusterName : str, default is Undefined, required
         ClusterName is the cluster identifier registered in clusterbook.
         Used as the ArgoCD cluster name and as the IP reservation key.
+    clusterType : str, default is Undefined, optional
+        ClusterType is a free-form discriminator written to the ArgoCD cluster
+        Secret as the label clusterbook.stuttgart-things.com/cluster-type.
+        Used by ApplicationSet selectors to fan out type-specific platform
+        bundles (e.g. "kind", "vsphere", "talos"). Optional.
     createDNS : bool, default is Undefined, optional
         CreateDNS asks clusterbook to create a wildcard DNS record.
     existingSecretRef : ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecExistingSecretRef, default is Undefined, optional
@@ -60,8 +65,15 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpec:
         Labels are applied to the cluster Secret under the
         clusterbook.stuttgart-things.com/ prefix. Use them as selectors in
         ApplicationSet cluster generators.
-    networkKey : str, default is Undefined, required
-        NetworkKey is the clusterbook network pool (e.g. "10.31.103").
+    lbRange : ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecLbRange, default is Undefined, optional
+        lb range
+    networkKey : str, default is Undefined, optional
+        NetworkKey is the clusterbook network pool (e.g. "10.31.103") used
+        for IP/DNS allocation. Optional only when ClusterType is "kind" — a
+        kind cluster registered without NetworkKey takes the
+        registration-only path: the operator skips clusterbook server calls
+        entirely and only writes the ArgoCD cluster Secret + labels +
+        LBRange annotations. Required for all other cluster types.
     preserveKubeconfigServer : bool, default is Undefined, optional
         PreserveKubeconfigServer keeps data.server on the cluster Secret
         set to whatever the referenced kubeconfig's current-context cluster
@@ -73,7 +85,7 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpec:
         is still made and DNS is still created; IP/FQDN/zone are still
         exposed on the Secret as labels and annotations for ApplicationSet
         selection and templating. Takes precedence over UseFQDNAsServer.
-    providerConfigRef : ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecProviderConfigRef, default is Undefined, required
+    providerConfigRef : ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecProviderConfigRef, default is Undefined, optional
         provider config ref
     releaseOnDelete : bool, default is Undefined, optional
         ReleaseOnDelete releases the clusterbook IP when the CR is deleted.
@@ -97,6 +109,8 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpec:
 
     clusterName: str
 
+    clusterType?: str
+
     createDNS?: bool
 
     existingSecretRef?: ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecExistingSecretRef
@@ -105,11 +119,13 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpec:
 
     labels?: {str:str}
 
-    networkKey: str
+    lbRange?: ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecLbRange
+
+    networkKey?: str
 
     preserveKubeconfigServer?: bool
 
-    providerConfigRef: ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecProviderConfigRef
+    providerConfigRef?: ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecProviderConfigRef
 
     releaseOnDelete?: bool
 
@@ -166,6 +182,41 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecKubeconfigSecr
     namespace: str
 
 
+schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecLbRange:
+    r"""
+    LBRange optionally reserves a contiguous IP range (in addition to the
+    primary allocated IP) intended for LoadBalancer pools — e.g. a Cilium
+    CiliumLoadBalancerIPPool block. Resolved range is exposed on the
+    Secret as the annotations clusterbook.stuttgart-things.com/lb-range-start
+    and /lb-range-stop. Optional.
+
+    Attributes
+    ----------
+    count : int, default is Undefined, optional
+        Count is the number of contiguous IPs to reserve from networkKey in
+        addition to the primary cluster IP. Mutually exclusive with Start/Stop.
+    start : str, default is Undefined, optional
+        Start, Stop pin the range verbatim — typical for kind clusters whose
+        LoadBalancer IPs come from the docker bridge network rather than the
+        clusterbook pool. When set, the operator does NOT reserve them from
+        networkKey, only writes them through to the Secret. Both must be set
+        together. Mutually exclusive with Count.
+    stop : str, default is Undefined, optional
+        stop
+    """
+
+
+    count?: int
+
+    start?: str
+
+    stop?: str
+
+
+    check:
+        count >= 1 if count not in [None, Undefined]
+
+
 schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterSpecProviderConfigRef:
     r"""
     ProviderConfigRef points to a ClusterbookProviderConfig with the
@@ -197,6 +248,13 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterStatus:
         fqdn
     ip : str, default is Undefined, optional
         ip
+    lbRangeStart : str, default is Undefined, optional
+        LBRangeStart, LBRangeStop record the resolved LoadBalancer range so
+        repeat reconciles in operator-allocated mode (spec.lbRange.count > 0)
+        don't re-reserve the range. In user-pinned mode they mirror
+        spec.lbRange.start/stop.
+    lbRangeStop : str, default is Undefined, optional
+        lb range stop
     secretName : str, default is Undefined, optional
         secret name
     zone : str, default is Undefined, optional
@@ -209,6 +267,10 @@ schema ClusterbookStuttgartThingsComV1alpha1ClusterbookClusterStatus:
     fqdn?: str
 
     ip?: str
+
+    lbRangeStart?: str
+
+    lbRangeStop?: str
 
     secretName?: str
 


### PR DESCRIPTION
Closes #48.

## Summary
- Regenerate `models/clusterbook-cluster/v1alpha1` from the latest `clusterbook-operator` CRD: adds `spec.clusterType`, `spec.lbRange.{count,start,stop}`, and `status.lbRangeStart`/`.lbRangeStop`. Relaxes `networkKey` and `providerConfigRef` to optional — current CRD only requires `clusterName`; the kind/non-kind split is enforced by CEL validations server-side (`networkKey` required unless `clusterType=='kind'`, `providerConfigRef.name` required when `networkKey` is set, `preserveKubeconfigServer` required in the kind registration-only path).
- Add `examples/clusterbook_cluster_kind.k` mirroring the in-cluster reference manifest (`clusters/labul/vsphere/platform-sthings/argocd/clusterbook-cluster-dev.yaml`): `clusterType=kind`, `lbRange.start/stop`, `kubeconfigSecretRef.key=kubeconfig`, no `networkKey`/`providerConfigRef`, `preserveKubeconfigServer=true`.
- Add `test_clusterbook_cluster_kind` covering the new fields.
- Bump `kcl.mod` from broken `0.0.` → `0.1.0`; update README with the kind section and the new install pin.

## Test plan
- [x] `kcl test ./...` → `PASS: 3/3`
- [x] `kcl run examples/clusterbook_cluster.k` — existing managed-mode render unchanged
- [x] `kcl run examples/clusterbook_cluster_kind.k` — output matches the upstream `clusterbook-cluster-dev.yaml` shape
- [ ] OCI artifact pushed by maintainer (`task push-module MODULE_DIR=models/clusterbook-cluster NEW_VERSION=0.1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)