### PR TITLE
feat(clusterbook-cluster-gen): kind clusterType + lbRange support (0.2.0)

### DIFF
--- a/kubernetes/clusterbook-cluster-gen/examples/kind.k
+++ b/kubernetes/clusterbook-cluster-gen/examples/kind.k
@@ -1,0 +1,35 @@
+# Example: a kind cluster registered with clusterbook-operator.
+#
+# Usage:
+#   kcl run main.k examples/kind.k
+#
+# Renders a ClusterbookCluster with `spec.clusterType: kind`,
+# `spec.lbRange.{start,stop}` for the cilium-lb pool, and
+# `spec.kubeconfigSecretRef.key: kubeconfig`. networkKey,
+# providerConfigRef, and createDNS are intentionally omitted —
+# the operator carves the LB range from the docker bridge and
+# does not allocate a VIP for kind clusters.
+
+_name = "kinde-dev2"
+_clusterName = "kinde-dev2"
+_clusterType = "kind"
+
+# The docker-bridge IP range the cilium-lb-kind ApplicationSet
+# carves into a CiliumLoadBalancerIPPool.
+_lbRangeStart = "172.18.255.200"
+_lbRangeStop = "172.18.255.250"
+
+_kubeconfigSecretName = "kinde-dev2"  # pragma: allowlist secret
+_kubeconfigSecretNamespace = "argocd"  # pragma: allowlist secret
+_kubeconfigSecretKey = "kubeconfig"  # pragma: allowlist secret
+
+_releaseOnDelete = True
+
+_clusterLabels = {
+    "auto-project" = "true"
+    "kind-platform" = "true"
+    "kind-platform/cilium-install" = "true"
+    "kind-platform/cilium-lb" = "true"
+    "kind-platform/cert-manager-install" = "true"
+    "kind-platform/cert-manager-selfsigned" = "true"
+}

--- a/kubernetes/clusterbook-cluster-gen/kcl.mod
+++ b/kubernetes/clusterbook-cluster-gen/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "clusterbook-cluster-gen"
 edition = "v0.11.2"
-version = "0.1.0"
+version = "0.2.0"

--- a/kubernetes/clusterbook-cluster-gen/main.k
+++ b/kubernetes/clusterbook-cluster-gen/main.k
@@ -7,10 +7,25 @@ _namespace = option("namespace") or ""
 _labels = option("labels") or {}
 _annotations = option("annotations") or {}
 
-# Spec — required clusterbook fields
-_networkKey = option("networkKey") or "10.31.101"
+# Spec — clusterbook fields. networkKey + providerConfigRef apply to
+# default/classic clusters; for clusterType=kind they are intentionally
+# omitted from the rendered manifest (the operator allocates differently).
+_clusterType = option("clusterType") or ""
+_isKind = _clusterType == "kind"
+
+_networkKey = option("networkKey") or ("10.31.101" if not _isKind else "")
 _clusterName = option("clusterName") or _name
 _argocdNamespace = option("argocdNamespace") or "argocd"
+
+# kind-only LB IP range (docker-bridge carve-out). Both -DlbRangeStart and
+# -DlbRangeStop must be provided to render a non-empty lbRange; otherwise it
+# is omitted and clusterbook-operator will reject a kind CR without it.
+_lbRangeStart = option("lbRangeStart") or ""
+_lbRangeStop = option("lbRangeStop") or ""
+_lbRange = schema.LbRange {
+    start = _lbRangeStart
+    stop = _lbRangeStop
+} if _lbRangeStart and _lbRangeStop else Undefined
 
 # DNS / server URL behavior
 _createDNS = option("createDNS")
@@ -58,11 +73,13 @@ _metadata = schema.ObjectMeta {
 _useExisting = True if _existingSecretRef else False
 
 _spec = schema.ClusterbookClusterSpec {
-    networkKey = _networkKey
+    networkKey = _networkKey if _networkKey and not _isKind else Undefined
     clusterName = _clusterName
-    providerConfigRef = _providerConfigRef
+    providerConfigRef = _providerConfigRef if not _isKind else Undefined
+    clusterType = _clusterType if _clusterType else Undefined
+    lbRange = _lbRange
     argocdNamespace = _argocdNamespace if _argocdNamespace else Undefined
-    createDNS = _createDNS if _createDNS != None else Undefined
+    createDNS = _createDNS if _createDNS != None and not _isKind else Undefined
     preserveKubeconfigServer = _preserveKubeconfigServer if _preserveKubeconfigServer != None else Undefined
     useFQDNAsServer = _useFQDNAsServer if _useFQDNAsServer != None else Undefined
     serverSubdomain = _serverSubdomain if _serverSubdomain else Undefined

--- a/kubernetes/clusterbook-cluster-gen/schema.k
+++ b/kubernetes/clusterbook-cluster-gen/schema.k
@@ -13,10 +13,19 @@ schema SecretRef:
 schema ProviderConfigRef:
     name: str
 
+schema LbRange:
+    start: str
+    stop: str
+
 schema ClusterbookClusterSpec:
-    networkKey: str
+    # networkKey and providerConfigRef apply to default/classic clusters only;
+    # for clusterType=kind, both are omitted and lbRange is required by the
+    # operator instead.
+    networkKey?: str
     clusterName: str
-    providerConfigRef: ProviderConfigRef
+    providerConfigRef?: ProviderConfigRef
+    clusterType?: str
+    lbRange?: LbRange
     argocdNamespace?: str
     createDNS?: bool
     preserveKubeconfigServer?: bool
@@ -32,6 +41,14 @@ schema ClusterbookClusterSpec:
         # exactly one of kubeconfigSecretRef or existingSecretRef must be set
         (1 if kubeconfigSecretRef else 0) + (1 if existingSecretRef else 0) == 1, \
             "exactly one of kubeconfigSecretRef or existingSecretRef must be set"
+        # non-kind (default/classic/unset) clusters must carry both networkKey and providerConfigRef
+        clusterType == "kind" or (networkKey and providerConfigRef), \
+            "default/classic clusterType requires networkKey and providerConfigRef"
+        # kind clusters must not carry networkKey or providerConfigRef
+        not (clusterType == "kind" and networkKey), \
+            "clusterType=kind must not set networkKey"
+        not (clusterType == "kind" and providerConfigRef), \
+            "clusterType=kind must not set providerConfigRef"
 
 schema ClusterbookCluster:
     apiVersion: str = "clusterbook.stuttgart-things.com/v1alpha1"


### PR DESCRIPTION
## Summary
- **Renderer-side companion to #48.** That issue's schema fix landed in `models/clusterbook-cluster/` (commit 9d97c91), but the actual KCL module pinned by downstream consumers (Backstage `create-argocd-cluster` form via `ghcr.io/stuttgart-things/clusterbook-cluster-gen:0.1.0`) is `kubernetes/clusterbook-cluster-gen/`, which is a **separate hand-rolled module**. Without these renderer changes, `-DclusterType=kind` and `-DlbRangeStart/Stop` are silently dropped, producing a default-type manifest that clusterbook-operator accepts but mis-allocates (real networkKey IP, no LB range — confirmed live with stuttgart-things/stuttgart-things `kinde-dev2` PR #2142).
- Bumps module version `0.1.0` → `0.2.0`.

## Changes
- `schema.k`: new `LbRange` schema. New optional `clusterType` and `lbRange` on `ClusterbookClusterSpec`. `networkKey` and `providerConfigRef` relaxed to optional (kind clusters carry neither). Tightened semantic checks: non-kind clusters require networkKey + providerConfigRef; kind clusters must not carry either.
- `main.k`: read `clusterType`, `lbRangeStart`, `lbRangeStop` via `option()`. Build `lbRange` only when both endpoints are non-empty. When `clusterType == "kind"`, suppress `networkKey`/`providerConfigRef`/`createDNS` so the rendered shape matches what `clusterbook-operator >= v0.16.0` expects.
- `examples/kind.k`: new companion to `examples/philly.k` recreating `kinde-dev2` with `clusterType=kind`, `lbRange` (`172.18.255.200`-`172.18.255.250`), and `kubeconfigSecretRef.key=kubeconfig`.
- `kcl.mod`: version `0.2.0`.

## Verification
Locally rendered both examples after the changes:

```
kcl run main.k examples/philly.k    # default-type — same shape as 0.1.0 (regression check)
kcl run main.k examples/kind.k      # new: clusterType=kind, lbRange.{start,stop}, no networkKey/providerConfigRef
```

## Post-merge
1. `kcl mod push` (or whatever the publish workflow is) to push `clusterbook-cluster-gen:0.2.0` to ghcr.
2. Bump the pinned `oci_source` default in `stuttgart-things/stuttgart-things` Backstage `create-argocd-cluster/template.yaml` from `:0.1.0` → `:0.2.0` and add `lb_range_start` / `lb_range_stop` form inputs (companion PR opens separately).
3. Re-render `kinde-dev2`: `cluster.yaml` will then include `clusterType: kind` + `lbRange`; clusterbook-operator stamps the cluster Secret with `cluster-type=kind` + `lb-range-{start,stop}` annotations; `cilium-lb-kinde-dev2` ApplicationSet that's currently failing on empty values will sync.

Refs: #48, stuttgart-things/stuttgart-things#2134

🤖 Generated with [Claude Code](https://claude.com/claude-code)