### PR TITLE
feat(clusterbook-cluster-gen): add clusterAnnotations passthrough (0.3.0)

### DIFF
--- a/kubernetes/clusterbook-cluster-gen/kcl.mod
+++ b/kubernetes/clusterbook-cluster-gen/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "clusterbook-cluster-gen"
 edition = "v0.11.2"
-version = "0.2.0"
+version = "0.3.0"

--- a/kubernetes/clusterbook-cluster-gen/main.k
+++ b/kubernetes/clusterbook-cluster-gen/main.k
@@ -60,6 +60,14 @@ _clusterLabels = option("clusterLabels") or {
     "auto-project" = "true"
 }
 
+# Free-form annotations merged onto the ArgoCD cluster Secret. Useful
+# for AppSets that read chart values via
+# `{{ index .metadata.annotations "..." }}` — e.g. cert-manager-vault-pki
+# reads `clusterbook.stuttgart-things.com/{vault-server, vault-pki-path,
+# vault-token-secret}`. Operator-managed annotations (cluster-name, ip,
+# fqdn, zone, lb-range-*) win on conflict at reconcile time.
+_clusterAnnotations = option("clusterAnnotations") or {}
+
 _releaseOnDelete = option("releaseOnDelete")
 
 _metadata = schema.ObjectMeta {
@@ -87,6 +95,7 @@ _spec = schema.ClusterbookClusterSpec {
     kubeconfigSecretRef = _kubeconfigSecretRef if not _useExisting else Undefined
     existingSecretRef = _existingSecretRef if _useExisting else Undefined
     labels = _clusterLabels if _clusterLabels else Undefined
+    annotations = _clusterAnnotations if _clusterAnnotations else Undefined
     releaseOnDelete = _releaseOnDelete if _releaseOnDelete != None else Undefined
 }
 

--- a/kubernetes/clusterbook-cluster-gen/schema.k
+++ b/kubernetes/clusterbook-cluster-gen/schema.k
@@ -35,6 +35,7 @@ schema ClusterbookClusterSpec:
     kubeconfigSecretRef?: SecretRef
     existingSecretRef?: SecretRef
     labels?: {str: str}
+    annotations?: {str: str}
     releaseOnDelete?: bool
 
     check:


### PR DESCRIPTION
## Summary

Adds `annotations?: {str: str}` to `ClusterbookClusterSpec` and plumbs a new `-DclusterAnnotations` option through `main.k` into the rendered CR's `spec.annotations`. Bumps the module to **0.3.0** (callers pinned at 0.2.0 don't have the new field).

## Motivation

The `cert-manager-vault-pki` AppSet's chart reads three values via cluster Secret annotations (`vault-server`, `vault-pki-path`, `vault-token-secret`). The Backstage form's `deploy_vault_cluster_issuer` toggle creates the prerequisite Secrets, but the ClusterIssuer can't be configured because there's no path from the form to the cluster Secret's annotations today. Hit this validating `create-vault-issuer` against homerun2-dev — had to `kubectl annotate` by hand.

This PR is the renderer half of the fix. Companion: `stuttgart-things/clusterbook-operator#86` adds `Spec.Annotations` to the API + reconciler merge.

## Verified locally

\`\`\`bash
$ kcl run -DclusterAnnotations='{"clusterbook.stuttgart-things.com/vault-server":"https://vault.example.com","clusterbook.stuttgart-things.com/vault-pki-path":"pki/sign/sthings-vsphere"}' | grep -A2 'annotations:'
    annotations:
      clusterbook.stuttgart-things.com/vault-server: https://vault.example.com
      clusterbook.stuttgart-things.com/vault-pki-path: pki/sign/sthings-vsphere

$ kcl run | grep annotations
(no output — empty default, same as 0.2.0)
\`\`\`

## Changes

- `schema.k`: new optional field `annotations?: {str: str}` on `ClusterbookClusterSpec`, between `labels?` and `releaseOnDelete?`.
- `main.k`: new `_clusterAnnotations = option("clusterAnnotations") or {}` + assign to `spec.annotations` only when non-empty.
- `kcl.mod`: version `0.2.0 → 0.3.0`.

Backward compatible — pinned 0.2.0 consumers keep working.

Refs stuttgart-things/blueprints#162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)