### PR TITLE
fix(clusterbook-cluster-gen): quote platform template description

### DIFF
--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
@@ -4,7 +4,7 @@ kind: ClaimTemplate
 metadata:
   name: clusterbook-cluster-platform
   title: Clusterbook Cluster (Platform / Management)
-  description: Register a management cluster and select which network- and storage-platform components to enable. Each selected component is stamped as a "<key>: true" label on the ArgoCD cluster Secret, gating the matching ApplicationSet.
+  description: 'Register a management cluster and select which network- and storage-platform components to enable. Each selected component is stamped as a "<key>: true" label on the ArgoCD cluster Secret, gating the matching ApplicationSet.'
   tags:
     - clusterbook
     - cluster


### PR DESCRIPTION
## What

Single-quote the `description` of `clusterbook-cluster-platform.yaml`.

## Why

The unquoted plain scalar contained `"<key>: true"`. The `: ` (colon-space) inside
a plain YAML scalar is parsed as a mapping key/value separator, producing:

```
yaml: line 7: mapping values are not allowed in this context
```

As a result `claim-machinery-api` skipped this template on load (the other
`clusterbook-cluster-*` and `harvestervm-*` templates loaded fine). Quoting the
string fixes parsing — all four `clusterbook-cluster-*` templates now load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)