### PR TITLE
fix(xr-namespace): free-text target cluster + string annotations param

### DIFF
--- a/crossplane/xr-namespace/README.md
+++ b/crossplane/xr-namespace/README.md
@@ -26,6 +26,9 @@ kcl run oci://ghcr.io/stuttgart-things/xr-namespace --tag 0.1.0 \
   -D annotations='field.cattle.io/projectId=c-cxgxd:p-sfgv4'
 ```
 
-The `annotations` parameter accepts either a native key/value map (when driven
-through the claims CLI / `params`) or a comma-separated `key=value` string for
-`-D` CLI use, e.g. `field.cattle.io/projectId=c-cxgxd:p-sfgv4,owner=team-x`.
+The `annotations` parameter is a comma-separated `key=value` string, e.g.
+`field.cattle.io/projectId=c-cxgxd:p-sfgv4,owner=team-x`. It is a string (not an
+object) on purpose: the claim-machinery API renders OCI modules via `kcl -D
+key=value` and cannot round-trip object params, so a string is parsed in
+`main.k` instead. `providerConfig` is free text (no fixed enum) so profiles can
+target a ProviderConfig that isn't in the common list.

--- a/crossplane/xr-namespace/templates/namespace-annotated.yaml
+++ b/crossplane/xr-namespace/templates/namespace-annotated.yaml
@@ -38,15 +38,19 @@ spec:
       title: Target cluster
       type: string
       default: harvester
-      enum:
-        - in-cluster
-        - harvester
+      description: >
+        Name of the Kubernetes (Cluster)ProviderConfig to target. Common values:
+        in-cluster, harvester. Free text - enter any ProviderConfig that exists
+        on crossplane-mgmt (useful when the profile targets a recently created
+        cluster not in the default list).
 
     - name: annotations
       title: Namespace Annotations
-      type: object
-      default: {}
+      type: string
+      default: ""
       description: >
-        Arbitrary annotations applied to the Namespace, as a key/value map the
-        user defines. Example for the Harvester "Default" Rancher project so the
-        UI lists the VMs: {"field.cattle.io/projectId": "c-cxgxd:p-sfgv4"}.
+        Annotations applied to the Namespace as a comma-separated list of
+        key=value pairs (the API cannot round-trip object params to KCL, so a
+        string is used). Example for the Harvester "Default" Rancher project so
+        the UI lists the VMs: field.cattle.io/projectId=c-cxgxd:p-sfgv4
+        Multiple: field.cattle.io/projectId=c-cxgxd:p-sfgv4,owner=team-x

--- a/crossplane/xr-namespace/templates/namespace-minimal.yaml
+++ b/crossplane/xr-namespace/templates/namespace-minimal.yaml
@@ -38,6 +38,8 @@ spec:
       title: Target cluster
       type: string
       default: in-cluster
-      enum:
-        - in-cluster
-        - harvester
+      description: >
+        Name of the Kubernetes (Cluster)ProviderConfig to target. Common values:
+        in-cluster, harvester. Free text - enter any ProviderConfig that exists
+        on crossplane-mgmt (useful when the profile targets a recently created
+        cluster not in the default list).


### PR DESCRIPTION
## Problem

Testing the `xr-namespace-annotated` template through the claim-machinery API produced a ManagedNamespace **with no annotations**, despite passing `field.cattle.io/projectId`.

Root cause: the API renders OCI modules via `kcl -D key=value` (`internal/render/kcl.go` → `formatKCLFlag`). A `type: object` param is a Go map, which hits the `default` case `fmt.Sprintf("%s=%v", ...)` and cannot be parsed back into a KCL map — so the annotation silently vanished.

Also: `providerConfig` used a fixed `enum`, which renders as a dropdown and blocks targeting a ProviderConfig not in the list (e.g. a freshly created cluster).

## Fix

- **`annotations`**: `type: object` → `type: string`, a comma-separated `key=value` list. `main.k` already parses this (and still accepts a native map if ever passed). Reproduces the `vms` case: `field.cattle.io/projectId=c-cxgxd:p-sfgv4`.
- **`providerConfig`**: drop the `enum` → free text, with common values (`in-cluster`, `harvester`) noted in the description.

Template-only change — the published OCI module `0.1.0` is unchanged, so no re-push needed.

## Test

```bash
kcl run crossplane/xr-namespace -D templateName=annotated -D name=vms \
  -D providerConfig=harvester -D annotations='field.cattle.io/projectId=c-cxgxd:p-sfgv4,owner=team-x'
# -> renders annotations.field.cattle.io/projectId + owner
kcl run crossplane/xr-namespace -D templateName=minimal -D name=demo-ns -D providerConfig=my-fresh-cluster
# -> providerConfigRef: my-fresh-cluster
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)