### PR TITLE
chore(xr-namespace): bump to 0.1.1

### DIFF
--- a/crossplane/xr-namespace/README.md
+++ b/crossplane/xr-namespace/README.md
@@ -13,7 +13,7 @@ which declaratively creates/adopts a `Namespace` on a target cluster via the
 
 ```bash
 # minimal - just a name and a target cluster
-kcl run oci://ghcr.io/stuttgart-things/xr-namespace --tag 0.1.0 \
+kcl run oci://ghcr.io/stuttgart-things/xr-namespace --tag 0.1.1 \
   -D templateName=minimal -D name=team-alpha -D providerConfig=in-cluster
 ```
 
@@ -21,7 +21,7 @@ kcl run oci://ghcr.io/stuttgart-things/xr-namespace --tag 0.1.0 \
 # annotated - generic annotations as a comma-separated key=value string.
 # Reproduces the Harvester `vms` case (assign the namespace to the Rancher
 # "Default" project so the UI lists the VMs running in it):
-kcl run oci://ghcr.io/stuttgart-things/xr-namespace --tag 0.1.0 \
+kcl run oci://ghcr.io/stuttgart-things/xr-namespace --tag 0.1.1 \
   -D templateName=annotated -D name=vms -D providerConfig=harvester \
   -D annotations='field.cattle.io/projectId=c-cxgxd:p-sfgv4'
 ```

--- a/crossplane/xr-namespace/kcl.mod
+++ b/crossplane/xr-namespace/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xr-namespace"
 edition = "v0.11.2"
-version = "0.1.0"
+version = "0.1.1"
 
 [profile]
 entries = [

--- a/crossplane/xr-namespace/templates/namespace-annotated.yaml
+++ b/crossplane/xr-namespace/templates/namespace-annotated.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: xr-namespace
   source: oci://ghcr.io/stuttgart-things/xr-namespace
-  tag: 0.1.0
+  tag: 0.1.1
   parameters:
     # Template selector
     - name: templateName

--- a/crossplane/xr-namespace/templates/namespace-minimal.yaml
+++ b/crossplane/xr-namespace/templates/namespace-minimal.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: xr-namespace
   source: oci://ghcr.io/stuttgart-things/xr-namespace
-  tag: 0.1.0
+  tag: 0.1.1
   parameters:
     # Template selector
     - name: templateName


### PR DESCRIPTION
Republishes `xr-namespace` as `0.1.1` so the OCI artifact carries the updated templates from #57 (string `annotations` param + free-text `providerConfig`).

`main.k` and the schema are unchanged — `template spec.tag` and README `--tag` examples bumped `0.1.0` → `0.1.1` to match the new artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)