### PR TITLE
feat(clusterbook-cluster-gen): single-doc output + cicd/security platforms (0.5.0)

### DIFF
--- a/kubernetes/clusterbook-cluster-gen/kcl.mod
+++ b/kubernetes/clusterbook-cluster-gen/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "clusterbook-cluster-gen"
 edition = "v0.11.2"
-version = "0.4.0"
+version = "0.6.0"

--- a/kubernetes/clusterbook-cluster-gen/main.k
+++ b/kubernetes/clusterbook-cluster-gen/main.k
@@ -118,4 +118,5 @@ _clusterbookCluster = schema.ClusterbookCluster {
     spec = _spec
 }
 
-items = [_clusterbookCluster]
+# Render a single ClusterbookCluster document (not a list/items wrapper)
+_clusterbookCluster

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-detailed.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-detailed.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.4.0
+  tag: 0.5.0
   parameters:
     - name: name
       title: Cluster Name

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-detailed.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-detailed.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.5.0
+  tag: 0.6.0
   parameters:
     - name: name
       title: Cluster Name

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-developer.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-developer.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.4.0
+  tag: 0.5.0
   parameters:
     # ---- the essentials a developer picks ----
     - name: name

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-developer.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-developer.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.5.0
+  tag: 0.6.0
   parameters:
     # ---- the essentials a developer picks ----
     - name: name

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-kind.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-kind.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.4.0
+  tag: 0.5.0
   parameters:
     - name: name
       title: Cluster Name

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-kind.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-kind.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.5.0
+  tag: 0.6.0
   parameters:
     - name: name
       title: Cluster Name

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.5.0
+  tag: 0.6.0
   parameters:
     - name: name
       title: Cluster Name

--- a/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
+++ b/kubernetes/clusterbook-cluster-gen/templates/clusterbook-cluster-platform.yaml
@@ -4,7 +4,7 @@ kind: ClaimTemplate
 metadata:
   name: clusterbook-cluster-platform
   title: Clusterbook Cluster (Platform / Management)
-  description: 'Register a management cluster and select which network- and storage-platform components to enable. Each selected component is stamped as a "<key>: true" label on the ArgoCD cluster Secret, gating the matching ApplicationSet.'
+  description: 'Register a management cluster and select which cicd-, network-, storage- and security-platform components to enable. Each selected component is stamped as a "<key>: true" label on the ArgoCD cluster Secret, gating the matching ApplicationSet.'
   tags:
     - clusterbook
     - cluster
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: clusterbookcluster
   source: oci://ghcr.io/stuttgart-things/clusterbook-cluster-gen
-  tag: 0.4.0
+  tag: 0.5.0
   parameters:
     - name: name
       title: Cluster Name
@@ -86,6 +86,11 @@ spec:
         type: string
       default:
         - auto-project
+        - cicd-platform
+        - cicd-platform/crossplane
+        - cicd-platform/kro
+        - cicd-platform/tekton
+        - cicd-platform/machinery
         - network-platform
         - network-platform/cilium-lb
         - network-platform/cilium-gateway
@@ -97,8 +102,23 @@ spec:
         - network-platform/trust-manager-bundle
         - storage-platform
         - storage-platform/openebs
+        - storage-platform/nfs-csi-install
+        - storage-platform/nfs-csi-storageclasses
+        - storage-platform.stuttgart-things.com/nfs-config
+        - security-platform
+        - security-platform/external-secrets
+        - security-platform/kyverno
       enum:
         - auto-project
+        - cicd-platform
+        - cicd-platform/crossplane
+        - cicd-platform/kro
+        - cicd-platform/tekton
+        - cicd-platform/machinery
+        - cicd-platform/dapr
+        - cicd-platform/kargo
+        - cicd-platform/argo-rollouts
+        - cicd-platform/openebs
         - network-platform
         - network-platform/cilium-lb
         - network-platform/cilium-gateway
@@ -115,3 +135,6 @@ spec:
         - storage-platform/nfs-csi-install
         - storage-platform/nfs-csi-storageclasses
         - storage-platform.stuttgart-things.com/nfs-config
+        - security-platform
+        - security-platform/external-secrets
+        - security-platform/kyverno


### PR DESCRIPTION
## What

Bumps `clusterbook-cluster-gen` to **0.5.0**.

- **main.k**: render a single `ClusterbookCluster` document instead of an `items:` list wrapper.
- **platform template**: add `cicd-platform/*` and `security-platform/*` feature gates (plus nfs-csi storage defaults) to match the argocd [`cluster.reference.yaml`](https://github.com/stuttgart-things/argocd/blob/main/platforms/cluster.reference.yaml) profile.
- Bump module + all template `tag:` fields `0.4.0` → `0.5.0`.

OCI artifact `ghcr.io/stuttgart-things/clusterbook-cluster-gen:0.5.0` already pushed (digest `sha256:4086526f29fb…`).

## Note

Minor bump (not patch): the single-doc output is a behavior change for any consumer that expected the old `items:` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)