### PR TITLE
feat(xr-rancher-cluster): add harvester-bootstrap template (0.2.0)

### DIFF
--- a/crossplane/xr-rancher-cluster/README.md
+++ b/crossplane/xr-rancher-cluster/README.md
@@ -22,24 +22,33 @@ Precedence is **explicit XR value > EnvironmentConfig > KCL default**.
 |---|---|---|
 | `minimal`   | `name`, `environmentConfig` | Only the XRD-required `name`; everything else from the EnvironmentConfig. |
 | `harvester` | + `cpuCount`, `memorySize`, `diskSize`, `quantity`, `argocdRegister` | Harvester preset (`infrastructure=harvester`); per-node sizing + Argo CD toggle. |
+| `harvester-bootstrap` | + `reservationEnabled`, `reservationNetworkKey`, `vaultServer`, `vaultPkiPath`, `vaultTokenSecret`, `wildcardIssuerName` | Like `harvester`, but Argo CD registration is **ON by default** and the cluster ships bootstrap-ready: IP/DNS reservation + the full platform-profile label set (storage/security/network) + vault-pki annotations baked in. Mirrors the showcase `k3s-xp`. |
 | `detailed`  | every spec field | Generic cluster with explicit distro, version, namespaces, bootstrap and full Argo CD registration. |
 
 ```bash
 # minimal - distro/version/placement all from the EnvironmentConfig
-kcl run oci://ghcr.io/stuttgart-things/xr-rancher-cluster --tag 0.1.0 \
+kcl run oci://ghcr.io/stuttgart-things/xr-rancher-cluster --tag 0.2.0 \
   -D templateName=minimal -D name=k3s-min -D environmentConfig=default
 ```
 
 ```bash
 # harvester - a 1-node Harvester k3s cluster, registered in Argo CD
-kcl run oci://ghcr.io/stuttgart-things/xr-rancher-cluster --tag 0.1.0 \
+kcl run oci://ghcr.io/stuttgart-things/xr-rancher-cluster --tag 0.2.0 \
   -D templateName=harvester -D name=k3s-xp \
   -D cpuCount=6 -D memorySize=6 -D quantity=1 -D argocdRegister=true
 ```
 
 ```bash
+# harvester-bootstrap - a bootstrap-ready Harvester k3s cluster: registered in
+# Argo CD with IP/DNS reservation + storage/security/network platform profiles
+kcl run oci://ghcr.io/stuttgart-things/xr-rancher-cluster --tag 0.2.0 \
+  -D templateName=harvester-bootstrap -D name=k3s-xp \
+  -D cpuCount=6 -D memorySize=6 -D quantity=1 -D reservationNetworkKey=192.168.10
+```
+
+```bash
 # detailed - a generic rke2 cluster with an Argo CD VIP endpoint
-kcl run oci://ghcr.io/stuttgart-things/xr-rancher-cluster --tag 0.1.0 \
+kcl run oci://ghcr.io/stuttgart-things/xr-rancher-cluster --tag 0.2.0 \
   -D templateName=detailed -D name=rke2-prod -D providerConfigRef=in-cluster \
   -D distro=rke2 -D kubernetesVersion=v1.31.5+rke2r1 -D rancherNamespace=fleet-default \
   -D bootstrapNamespace=platform-system -D argocdRegister=true -D argocdNamespace=argocd \

--- a/crossplane/xr-rancher-cluster/kcl.mod
+++ b/crossplane/xr-rancher-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xr-rancher-cluster"
 edition = "v0.11.2"
-version = "0.1.0"
+version = "0.2.0"
 
 [profile]
 entries = [

--- a/crossplane/xr-rancher-cluster/main.k
+++ b/crossplane/xr-rancher-cluster/main.k
@@ -15,6 +15,9 @@ minimal   : Just the XRD-required `name` (+ environmentConfig). distro, version,
 harvester : Harvester preset (infrastructure=harvester). Exposes per-node sizing
             (cpu/memory/disk/quantity) and the Argo CD toggle; infra identity
             (image/network/credential) comes from the EnvironmentConfig.
+harvester-bootstrap : Like harvester, but Argo CD registration is ON by default and
+            the cluster ships bootstrap-ready: IP/DNS reservation + the full
+            platform-profile label set + vault-pki annotations baked in.
 detailed  : Generic (custom-node) cluster with explicit distro, kubernetesVersion,
             namespaces, bootstrap namespace and full Argo CD registration.
 """
@@ -69,6 +72,23 @@ _argocdNamespace = _spec?.argocd?.namespace or option("argocdNamespace") or _par
 _argocdProviderConfigRef = _spec?.argocd?.providerConfigRef or option("argocdProviderConfigRef") or _params?.argocdProviderConfigRef or ""
 _argocdServer = _spec?.argocd?.server or option("argocdServer") or _params?.argocdServer or ""
 
+# Bootstrap template - Argo CD registration defaults ON, with IP/DNS reservation
+# and the platform-profile label set + vault-pki annotations baked in.
+_registerBootstrap = _asBool(_registerRaw, True)
+
+# IP/DNS reservation. Resolve enabled without `or` so an explicit `false` is kept.
+_reservationEnabledOpt = option("reservationEnabled")
+_reservationEnabledRaw = _reservationEnabledOpt if _reservationEnabledOpt != Undefined else (_params?.reservationEnabled if _params?.reservationEnabled != Undefined else _spec?.argocd?.reservation?.enabled)
+_reservationEnabled = _asBool(_reservationEnabledRaw, True)
+_reservationNetworkKey = _spec?.argocd?.reservation?.networkKey or option("reservationNetworkKey") or _params?.reservationNetworkKey or ""
+_reservationProviderConfigRef = _spec?.argocd?.reservation?.providerConfigRef or option("reservationProviderConfigRef") or _params?.reservationProviderConfigRef or ""
+
+# vault-pki ClusterIssuer parameters (stamped as annotations on the cluster Secret).
+_vaultServer = _spec?.argocd?.annotations?["clusterbook.stuttgart-things.com/vault-server"] or option("vaultServer") or _params?.vaultServer or "https://vault.infra.sthings.lab"
+_vaultPkiPath = _spec?.argocd?.annotations?["clusterbook.stuttgart-things.com/vault-pki-path"] or option("vaultPkiPath") or _params?.vaultPkiPath or "pki/sign/sthings-lab"
+_vaultTokenSecret = _spec?.argocd?.annotations?["clusterbook.stuttgart-things.com/vault-token-secret"] or option("vaultTokenSecret") or _params?.vaultTokenSecret or "cert-manager-vault-token"  # pragma: allowlist secret
+_wildcardIssuerName = _spec?.argocd?.annotations?["clusterbook.stuttgart-things.com/wildcard-issuer-name"] or option("wildcardIssuerName") or _params?.wildcardIssuerName or "vault-pki"
+
 # Minimal Template - only the XRD-required `name` plus the EnvironmentConfig
 # selector. Everything else resolves from the EnvironmentConfig.
 if _templateName == "minimal":
@@ -116,6 +136,85 @@ if _templateName == "harvester":
                     namespace = _argocdNamespace
                 if _argocdProviderConfigRef:
                     providerConfigRef = _argocdProviderConfigRef
+            }
+        }
+    }
+
+# Harvester Bootstrap Template - same Harvester preset as `harvester`, but Argo CD
+# registration is ON by default and the cluster ships with the full platform-profile
+# label set + IP/DNS reservation + vault-pki annotations baked in. Mirrors the
+# crossplane-mgmt showcase XR (k3s-xp): cluster-bootstrap-ready straight away.
+if _templateName == "harvester-bootstrap":
+    rc.RancherCluster {
+        metadata = v1.ObjectMeta {
+            name = _name
+            namespace = _claimNamespace
+        }
+
+        spec = rc.ResourcesStuttgartThingsComV1alpha1RancherClusterSpec {
+            name = _name
+            environmentConfig = _environmentConfig
+            infrastructure = "harvester"
+            if _distro:
+                distro = _distro
+            if _kubernetesVersion:
+                kubernetesVersion = _kubernetesVersion
+            harvester = rc.ResourcesStuttgartThingsComV1alpha1RancherClusterSpecHarvester {
+                cpuCount = _cpuCount
+                memorySize = _memorySize
+                diskSize = _diskSize
+                quantity = _quantity
+                if _sshUser:
+                    sshUser = _sshUser
+            }
+            argocd = rc.ResourcesStuttgartThingsComV1alpha1RancherClusterSpecArgocd {
+                register = _registerBootstrap
+                if _argocdNamespace:
+                    namespace = _argocdNamespace
+                if _argocdProviderConfigRef:
+                    providerConfigRef = _argocdProviderConfigRef
+                if _argocdServer:
+                    server = _argocdServer
+                # IP/DNS reservation via clusterbook-operator. REQUIRED for
+                # network-platform: every network-platform AppSet selector needs the
+                # allocation-ip anchor, only stamped when an IP is reserved.
+                reservation = rc.ResourcesStuttgartThingsComV1alpha1RancherClusterSpecArgocdReservation {
+                    enabled = _reservationEnabled
+                    createDNS = _reservationEnabled
+                    if _reservationNetworkKey:
+                        networkKey = _reservationNetworkKey
+                    if _reservationProviderConfigRef:
+                        providerConfigRef = _reservationProviderConfigRef
+                }
+                # Platform profile toggles -> copied onto the ClusterbookCluster /
+                # Argo CD cluster Secret; the platforms/<profile> AppSets select on
+                # them. storage-platform (openebs) + security-platform
+                # (external-secrets + kyverno) + network-platform (cert-manager chain
+                # + trust-manager + vault-pki ClusterIssuer). Cilium components stay
+                # OFF (k3s default flannel, not Cilium CNI).
+                labels = {
+                    "storage-platform" = "true"
+                    "storage-platform/openebs" = "true"
+                    "security-platform" = "true"
+                    "security-platform/external-secrets" = "true"
+                    "security-platform/kyverno" = "true"
+                    "network-platform" = "true"
+                    "network-platform/cert-manager-install" = "true"
+                    "network-platform/cert-manager-selfsigned" = "true"
+                    "network-platform/cert-manager-cluster-ca" = "true"
+                    "network-platform/cert-manager-vault-pki" = "true"
+                    "network-platform/trust-manager-install" = "true"
+                    "network-platform/trust-manager-bundle" = "true"
+                }
+                # Component parameters. The vault-pki ClusterIssuer reads these; the
+                # token Secret is provisioned into cert-manager by the
+                # vault-pki-secrets Configuration.
+                annotations = {
+                    "clusterbook.stuttgart-things.com/vault-server" = _vaultServer
+                    "clusterbook.stuttgart-things.com/vault-pki-path" = _vaultPkiPath
+                    "clusterbook.stuttgart-things.com/vault-token-secret" = _vaultTokenSecret
+                    "clusterbook.stuttgart-things.com/wildcard-issuer-name" = _wildcardIssuerName
+                }
             }
         }
     }

--- a/crossplane/xr-rancher-cluster/templates/ranchercluster-detailed.yaml
+++ b/crossplane/xr-rancher-cluster/templates/ranchercluster-detailed.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: xr-rancher-cluster
   source: oci://ghcr.io/stuttgart-things/xr-rancher-cluster
-  tag: 0.1.0
+  tag: 0.2.0
   parameters:
     # Template selector
     - name: templateName

--- a/crossplane/xr-rancher-cluster/templates/ranchercluster-harvester-bootstrap.yaml
+++ b/crossplane/xr-rancher-cluster/templates/ranchercluster-harvester-bootstrap.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: ClaimTemplate
+metadata:
+  name: xr-rancher-cluster-harvester-bootstrap
+  title: Rancher Cluster (Harvester, bootstrap-ready)
+  description: Provision a Harvester-backed Rancher cluster that is bootstrap-ready out of the box. Same Harvester preset as the harvester template, but Argo CD registration is ON by default, an IP/DNS reservation is requested, and the full platform-profile label set (storage/security/network) plus vault-pki annotations are baked in. Mirrors the crossplane-mgmt showcase cluster (k3s-xp).
+  tags:
+    - rancher
+    - cluster
+    - harvester
+    - bootstrap
+    - argocd
+    - crossplane
+spec:
+  type: xr-rancher-cluster
+  source: oci://ghcr.io/stuttgart-things/xr-rancher-cluster
+  tag: 0.2.0
+  parameters:
+    # Template selector
+    - name: templateName
+      title: Template
+      type: string
+      default: harvester-bootstrap
+      hidden: true
+
+    - name: name
+      title: Cluster Name
+      type: string
+      required: true
+      default: k3s-xp
+      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+      description: "Name of the Rancher cluster"
+
+    - name: claimNamespace
+      title: Claim Namespace
+      type: string
+      required: true
+      default: default
+      pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+
+    - name: environmentConfig
+      title: EnvironmentConfig
+      type: string
+      default: default
+      description: "Selects the EnvironmentConfig carrying the Harvester infra identity and the Argo CD target"
+
+    - name: cpuCount
+      title: vCPUs per Node
+      type: string
+      default: "6"
+      pattern: "^[0-9]+$"
+
+    - name: memorySize
+      title: Memory per Node (GiB)
+      type: string
+      default: "6"
+      pattern: "^[0-9]+$"
+
+    - name: diskSize
+      title: Root Disk per Node (GiB)
+      type: string
+      default: "40"
+      pattern: "^[0-9]+$"
+
+    - name: quantity
+      title: Node Count
+      type: string
+      default: "1"
+      pattern: "^[0-9]+$"
+      description: "Number of nodes in the machine pool"
+
+    - name: argocdRegister
+      title: Register in Argo CD
+      type: boolean
+      default: true
+      description: "Register the new cluster in Argo CD via clusterbook-operator (server endpoint auto-discovered). ON by default for bootstrap clusters"
+
+    - name: reservationEnabled
+      title: Reserve IP / DNS
+      type: boolean
+      default: true
+      description: "Reserve an IP + create the DNS record via clusterbook-operator. REQUIRED for network-platform AppSets (they need the allocation-ip anchor)"
+
+    - name: reservationNetworkKey
+      title: Reservation Network Key
+      type: string
+      default: ""
+      description: "Network prefix to reserve the IP from (e.g. '192.168.10'). Leave empty to inherit the EnvironmentConfig value"
+
+    - name: reservationProviderConfigRef
+      title: Reservation ProviderConfig
+      type: string
+      default: ""
+      description: "ClusterbookProviderConfig backing the reservation. Leave empty to inherit (default)"
+
+    - name: vaultServer
+      title: Vault Server
+      type: string
+      default: "https://vault.infra.sthings.lab"
+      description: "Vault server URL for the vault-pki ClusterIssuer"
+
+    - name: vaultPkiPath
+      title: Vault PKI Sign Path
+      type: string
+      default: "pki/sign/sthings-lab"
+      description: "Vault PKI sign path for the vault-pki ClusterIssuer"
+
+    - name: vaultTokenSecret
+      title: Vault Token Secret
+      type: string
+      default: "cert-manager-vault-token"
+      description: "Name of the token Secret provisioned into cert-manager by the vault-pki-secrets Configuration"
+
+    - name: wildcardIssuerName
+      title: Wildcard Issuer Name
+      type: string
+      default: "vault-pki"
+      description: "ClusterIssuer name used for the wildcard / gateway-tls certificate"

--- a/crossplane/xr-rancher-cluster/templates/ranchercluster-harvester.yaml
+++ b/crossplane/xr-rancher-cluster/templates/ranchercluster-harvester.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: xr-rancher-cluster
   source: oci://ghcr.io/stuttgart-things/xr-rancher-cluster
-  tag: 0.1.0
+  tag: 0.2.0
   parameters:
     # Template selector
     - name: templateName

--- a/crossplane/xr-rancher-cluster/templates/ranchercluster-minimal.yaml
+++ b/crossplane/xr-rancher-cluster/templates/ranchercluster-minimal.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   type: xr-rancher-cluster
   source: oci://ghcr.io/stuttgart-things/xr-rancher-cluster
-  tag: 0.1.0
+  tag: 0.2.0
   parameters:
     # Template selector
     - name: templateName


### PR DESCRIPTION
## Summary
Adds a new `harvester-bootstrap` ClaimTemplate to the `xr-rancher-cluster` module — a bootstrap-ready Harvester preset that mirrors the crossplane-mgmt showcase XR (`k3s-xp`).

Versus the existing `harvester` template, the bootstrap variant ships ready out of the box:
- **Argo CD registration ON by default** (`argocdRegister: true`)
- **IP/DNS reservation enabled** (`reservationEnabled: true`) → produces the `allocation-ip` anchor the network-platform AppSets require
- **Full platform-profile label set baked in**: storage-platform (openebs), security-platform (external-secrets + kyverno), network-platform (cert-manager chain + trust-manager + vault-pki)
- **vault-pki annotations baked in** (server / pki-path / token-secret / wildcard-issuer), exposed as overridable params

The `'false'` sibling toggles still come from the EnvironmentConfig `defaultLabels`, matching the showcase XR's assumption — the template is intentionally not standalone.

## Changes
- `main.k`: new `harvester-bootstrap` template block + param reads (reservation, vault-pki); docstring updated
- `templates/ranchercluster-harvester-bootstrap.yaml`: new ClaimTemplate
- Bump module to **0.2.0**; update `tag:` references in all ClaimTemplates + README examples
- README: document the new template (table + usage example)

The existing `harvester`/`minimal`/`detailed` templates are unchanged in behavior.

Module published to `ghcr.io/stuttgart-things/xr-rancher-cluster:0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)