### PR TITLE
feat(kind-cluster): add workerCount and ingress-ready options

### DIFF
--- a/kubernetes/kind-cluster/README.md
+++ b/kubernetes/kind-cluster/README.md
@@ -27,6 +27,9 @@ Variables are defined with underscore prefix (private) to prevent them from appe
 | Different mount path | `-D mountBasePath="/data"` |
 | Custom registry mirrors | `-D 'registryMirrors=["https://my-registry.com"]'` |
 | Enable kube-proxy | `-D kubeProxyMode="iptables"` |
+| Change number of workers | `-D workerCount=3` |
+| Enable ingress (ingress-ready + 80/443) | `-D ingressReady=True` |
+| Ingress on non-privileged host ports | `-D ingressReady=True -D ingressHttpHostPort=8080 -D ingressHttpsHostPort=8443` |
 | Use preset config | `kcl run main.k examples/dev-cluster.k` |
 
 ### Basic Configuration
@@ -60,6 +63,22 @@ Variables are defined with underscore prefix (private) to prevent them from appe
 
 **Generated ports**: API server port + range of ports (e.g., 32443-32448)
 
+### Worker Nodes
+
+| Option Name | Default | Description |
+|----------|---------|-------------|
+| `workerCount` | `2` | Number of worker nodes to generate (`0` = control-plane only) |
+
+### Ingress
+
+| Option Name | Default | Description |
+|----------|---------|-------------|
+| `ingressReady` | `False` | Add the `ingress-ready=true` node label (via `kubeadmConfigPatches`) to the control-plane and publish HTTP/HTTPS host ports — required by e.g. ingress-nginx on kind |
+| `ingressHttpHostPort` | `80` | Host port mapped to container port `80` when `ingressReady=True` |
+| `ingressHttpsHostPort` | `443` | Host port mapped to container port `443` when `ingressReady=True` |
+
+> Only one cluster per host can own ports `80`/`443`. To run several clusters, give the extra ones non-privileged host ports, e.g. `-D ingressHttpHostPort=8080 -D ingressHttpsHostPort=8443`.
+
 ### Storage Mounts (Worker Nodes)
 
 | Option Name | Default | Description |
@@ -67,9 +86,9 @@ Variables are defined with underscore prefix (private) to prevent them from appe
 | `mountBasePath` | `"/mnt"` | Base path on the host for mounts |
 | `containerMountPath` | `"/data"` | Path inside the container |
 
-**Generated mount paths**:
+**Generated mount paths** (one per worker, `1..workerCount`):
 - Worker 1: `${mountBasePath}/${clusterName}1` → `${containerMountPath}`
-- Worker 2: `${mountBasePath}/${clusterName}2` → `${containerMountPath}`
+- Worker N: `${mountBasePath}/${clusterName}N` → `${containerMountPath}`
 
 ### Container Registry Mirrors
 

--- a/kubernetes/kind-cluster/examples/README.md
+++ b/kubernetes/kind-cluster/examples/README.md
@@ -9,6 +9,7 @@ This directory contains example configuration files demonstrating various cluste
 | [custom-ports.k](custom-ports.k) | Non-standard port requirements | Custom port list (6443, 8080, 8443, 9090, 3000) |
 | [minimal-cluster.k](minimal-cluster.k) | Testing, CI/CD | Only API port, no custom registry |
 | [dev-cluster.k](dev-cluster.k) | Local development | Latest K8s, standard ports, kube-proxy enabled |
+| [ingress-cluster.k](ingress-cluster.k) | Ingress on kind (ingress-nginx) | `ingress-ready=true` label + 80/443 published, 1 worker |
 
 ## Available Examples
 

--- a/kubernetes/kind-cluster/examples/ingress-cluster.k
+++ b/kubernetes/kind-cluster/examples/ingress-cluster.k
@@ -1,0 +1,16 @@
+# Example: Ingress-ready Cluster Configuration
+# Control-plane labelled `ingress-ready=true` with 80/443 published on the host,
+# suitable for ingress-nginx (or similar) on kind.
+#
+# Usage:
+#   kcl run main.k examples/ingress-cluster.k
+
+_clusterName = "ingress-cluster"
+
+# Single worker is plenty for an ingress demo
+_workerCount = 1
+
+# Add the ingress-ready node label + publish HTTP/HTTPS host ports
+_ingressReady = True
+_ingressHttpHostPort = 80
+_ingressHttpsHostPort = 443

--- a/kubernetes/kind-cluster/main.k
+++ b/kubernetes/kind-cluster/main.k
@@ -23,6 +23,27 @@ _mountBasePath = option("mountBasePath") or "/mnt"
 _clusterName = option("clusterName") or "platform-cluster"
 _containerMountPath = option("containerMountPath") or "/data"
 
+# Worker node count (use != None so workerCount=0 is honoured, not treated as falsy)
+_workerCount = option("workerCount") if option("workerCount") != None else 2
+
+# Ingress: add the `ingress-ready=true` node label (required by e.g. ingress-nginx
+# on kind) and, optionally, publish HTTP/HTTPS host ports on the control-plane node.
+_ingressReady = option("ingressReady") if option("ingressReady") != None else False
+_ingressHttpHostPort = option("ingressHttpHostPort") or 80
+_ingressHttpsHostPort = option("ingressHttpsHostPort") or 443
+
+_ingressReadyPatches = [
+    """kind: InitConfiguration
+nodeRegistration:
+  kubeletExtraArgs:
+    node-labels: "ingress-ready=true"
+"""
+]
+_ingressPortMappings = [
+    {containerPort = 80, hostPort = _ingressHttpHostPort, protocol = "TCP"}
+    {containerPort = 443, hostPort = _ingressHttpsHostPort, protocol = "TCP"}
+] if _ingressReady else []
+
 # Container registry mirror configuration
 _registryMirrors = option("registryMirrors") if option("registryMirrors") != None else [
     "https://registry-1.docker.io"
@@ -45,18 +66,16 @@ _cluster = schema.Cluster {
         {
             role = "control-plane"
             image = _nodeImage
-            extraPortMappings = _extraPortMappings
-        },
+            extraPortMappings = _extraPortMappings + _ingressPortMappings
+            if _ingressReady:
+                kubeadmConfigPatches = _ingressReadyPatches
+        }
+    ] + [
         {
             role = "worker"
             image = _nodeImage
-            extraMounts = [{hostPath = "${_mountBasePath}/${_clusterName}1", containerPath = _containerMountPath}]
-        },
-        {
-            role = "worker"
-            image = _nodeImage
-            extraMounts = [{hostPath = "${_mountBasePath}/${_clusterName}2", containerPath = _containerMountPath}]
-        },
+            extraMounts = [{hostPath = "${_mountBasePath}/${_clusterName}${i + 1}", containerPath = _containerMountPath}]
+        } for i in range(_workerCount)
     ]
     containerdConfigPatches = [
         """[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]

--- a/kubernetes/kind-cluster/schema.k
+++ b/kubernetes/kind-cluster/schema.k
@@ -13,6 +13,7 @@ schema Node:
     image: str
     extraPortMappings?: [PortMapping]
     extraMounts?: [ExtraMount]
+    kubeadmConfigPatches?: [str]
 
 schema Networking:
     apiServerAddress: str


### PR DESCRIPTION
## What

Extends the `kubernetes/kind-cluster` KCL module with two commonly-needed knobs:

- **`workerCount`** (default `2`) — generate an arbitrary number of worker nodes. Uses `!= None` so `workerCount=0` (control-plane only) is honoured instead of being treated as falsy. Mount paths are generated per worker (`${clusterName}${i+1}`).
- **`ingressReady`** (default `False`) — adds the `ingress-ready=true` node label to the control-plane via `kubeadmConfigPatches` (required by e.g. ingress-nginx on kind) and publishes HTTP/HTTPS host ports. Host ports are configurable via `ingressHttpHostPort` (default `80`) and `ingressHttpsHostPort` (default `443`) so multiple clusters can coexist on one host.

## Changes

- `schema.k`: allow `kubeadmConfigPatches?: [str]` on `Node`
- `main.k`: new options + node list rebuilt as `[control-plane] + [workers…]`
- `README.md`: documented the new options
- `examples/ingress-cluster.k`: new example (+ listed in examples README)

## Testing

```
kcl run main.k                                                   # defaults: 2 workers, no ingress
kcl run main.k -D workerCount=3 -D ingressReady=True            # 3 workers + ingress-ready + 80/443
kcl run main.k -D ingressReady=True -D ingressHttpHostPort=8080 -D ingressHttpsHostPort=8443
kcl run main.k -D workerCount=0                                 # control-plane only
kcl run main.k examples/ingress-cluster.k                       # preset
```

All rendered outputs validated as YAML; the `kubeadmConfigPatches` entry renders as a proper `- |` block scalar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)