### PR TITLE
feat(xplane-ip-reservation): function-kcl module for ip-reservation

### DIFF
--- a/crossplane/xplane-ip-reservation/README.md
+++ b/crossplane/xplane-ip-reservation/README.md
@@ -1,0 +1,44 @@
+# xplane-ip-reservation
+
+`function-kcl` module for the [`ip-reservation`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/ip-reservation) Crossplane Configuration. Reserves IP addresses from clusterbook using the `internalNetworkKey` discovered from a `RemoteCluster` (provider-kubeconfig).
+
+Consumed from the Composition as an OCI source:
+
+```yaml
+- step: ip-reservation
+  functionRef:
+    name: function-kcl
+  input:
+    apiVersion: krm.kcl.dev/v1alpha1
+    kind: KCLInput
+    spec:
+      source: oci://ghcr.io/stuttgart-things/xplane-ip-reservation:0.1.0
+```
+
+## What it emits
+
+| # | Kind | Purpose | Condition |
+|---|------|---------|-----------|
+| 1 | `kubernetes.m` Object (Observe) | reads `RemoteCluster.status.internalNetworkKey` | always |
+| 2 | `kubernetes.m` Object (wrapper) | `IPReservation` (provider-clusterbook) | once networkKey is known |
+
+Both Objects use the `in-cluster` (InjectedIdentity) provider config — the
+cluster-scoped `RemoteCluster` / `IPReservation` MRs are wrapped in namespaced
+Objects because the XR is `scope: Namespaced`.
+
+Render and status run in a **single pass**: the module emits both Objects and
+patches the XR status from `ocds`. The IPReservation is withheld until the
+Observe populates the networkKey, so status converges over reconciles.
+
+## Params
+
+| Param | Source | Notes |
+|-------|--------|-------|
+| `params.oxr` | the `XIPReservation` XR | `spec.clusterName` required |
+| `params.ocds` | observed composed resources | supplies networkKey + IPReservation status |
+
+## Local test
+
+```bash
+kcl run main.k -Y test-settings.yaml
+```

--- a/crossplane/xplane-ip-reservation/kcl.mod
+++ b/crossplane/xplane-ip-reservation/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "xplane-ip-reservation"
+edition = "v0.11.2"
+version = "0.1.0"

--- a/crossplane/xplane-ip-reservation/main.k
+++ b/crossplane/xplane-ip-reservation/main.k
@@ -1,0 +1,143 @@
+"""
+xplane-ip-reservation — function-kcl module for the ip-reservation Configuration.
+
+Reserves IP addresses from clusterbook, using the internalNetworkKey discovered
+from a RemoteCluster (provider-kubeconfig):
+
+  1. kubernetes.m Object (Observe) — reads RemoteCluster.status.internalNetworkKey
+  2. kubernetes.m Object (wrapper) — an IPReservation (provider-clusterbook),
+     emitted once the networkKey is known
+
+Render and status run in a single pass: the module emits the Observe Object and
+the IPReservation wrapper AND patches the XR status from `ocds`. On early
+reconciles the networkKey is empty (Observe not yet populated), so the
+IPReservation is withheld and status stays unready until it converges.
+
+Cluster-scoped MRs (RemoteCluster, IPReservation) are wrapped in namespaced
+kubernetes.m Objects because the XR is namespaced (scope: Namespaced). Both
+Objects use the in-cluster (InjectedIdentity) provider config to read/write on
+the management cluster.
+"""
+
+_params = option("params") or {}
+_oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
+
+_spec = _oxr?.spec or {}
+_meta = _oxr?.metadata or {}
+_name = _meta?.name or "ip-reservation"
+
+_clusterName = _spec?.clusterName
+_count = _spec?.count or 1
+_ip = _spec?.ip or ""
+_createDNS = _spec?.createDNS or False
+_cbPcr = _spec?.clusterbookProviderConfigRef or "default"
+# The Object provider config for management-cluster reads/wraps. InjectedIdentity.
+_k8sPcr = _spec?.kubernetesProviderConfigRef or "in-cluster"
+
+_rcKey = "{}-observe-rc".format(_name)
+_ipKey = "{}-ip".format(_name)
+
+# --- Resource 1: Observe the RemoteCluster to read internalNetworkKey ---
+_observeRC = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {
+        name = _rcKey
+        namespace = _meta?.namespace
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = _rcKey
+        }
+    }
+    spec = {
+        managementPolicies = ["Observe"]
+        forProvider = {
+            manifest = {
+                apiVersion = "kubeconfig.stuttgart-things.com/v1alpha1"
+                kind = "RemoteCluster"
+                metadata = {
+                    name = _clusterName
+                }
+            }
+        }
+        providerConfigRef = {
+            name = _k8sPcr
+            kind = "ClusterProviderConfig"
+        }
+    }
+}
+
+# --- Read networkKey from the observed RemoteCluster status ---
+_networkKey = _ocds[_rcKey].Resource?.status?.atProvider?.manifest?.status?.atProvider?.internalNetworkKey or "" if _rcKey in _ocds else ""
+
+# --- Resource 2: IPReservation wrapped in an Object (once networkKey known) ---
+_ipSpec = {
+    networkKey = _networkKey
+    clusterName = _clusterName
+    count = _count
+    createDNS = _createDNS
+    **({ip = _ip} if _ip else {})
+}
+_ipObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {
+        name = _ipKey
+        namespace = _meta?.namespace
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = _ipKey
+        }
+    }
+    spec = {
+        forProvider = {
+            manifest = {
+                apiVersion = "ipreservation.clusterbook.stuttgart-things.com/v1alpha1"
+                kind = "IPReservation"
+                metadata = {
+                    name = _ipKey
+                }
+                spec = {
+                    forProvider = _ipSpec
+                    providerConfigRef = {
+                        name = _cbPcr
+                        kind = "ClusterProviderConfig"
+                    }
+                }
+            }
+        }
+        providerConfigRef = {
+            name = _k8sPcr
+            kind = "ClusterProviderConfig"
+        }
+        readiness = {
+            policy = "DeriveFromObject"
+        }
+    }
+}
+_ipResources = [_ipObj] if _networkKey != "" else []
+
+# --- Status: read IPReservation status back off the wrapping Object via ocds ---
+_isReady = lambda resourceName: str -> bool {
+    _found = resourceName in _ocds
+    _conds = _ocds[resourceName]?.Resource?.status?.conditions or [] if _found else []
+    len([c for c in _conds if c.type == "Ready" and c.status == "True"]) > 0
+}
+
+_ipAt = _ocds[_ipKey].Resource?.status?.atProvider?.manifest?.status?.atProvider or {} if _ipKey in _ocds else {}
+_ipAddresses = _ipAt?.ipAddresses or []
+_resStatus = _ipAt?.status or ""
+_fqdn = _ipAt?.fqdn or ""
+_zone = _ipAt?.zone or ""
+
+_xrStatus = _oxr | {
+    status = {
+        ready = _isReady(_ipKey)
+        networkKey = _networkKey
+        ipAddresses = _ipAddresses
+        reservationStatus = _resStatus
+        fqdn = _fqdn
+        zone = _zone
+    }
+}
+
+items = [_observeRC] + _ipResources + [_xrStatus]

--- a/crossplane/xplane-ip-reservation/test-settings.yaml
+++ b/crossplane/xplane-ip-reservation/test-settings.yaml
@@ -1,0 +1,12 @@
+kcl_options:
+  - key: params
+    value:
+      oxr: {apiVersion: resources.stuttgart-things.com/v1alpha1, kind: XIPReservation, metadata: {name: t, namespace: crossplane-system}, spec: {clusterName: xplane-test}}
+      ocds:
+        t-observe-rc:
+          Resource: {status: {atProvider: {manifest: {status: {atProvider: {internalNetworkKey: "172.18.0"}}}}}}
+        t-ip:
+          Resource:
+            status:
+              conditions: [{type: Ready, status: "True"}]
+              atProvider: {manifest: {status: {atProvider: {ipAddresses: ["172.18.0.42"], status: "ASSIGNED:DNS", fqdn: "*.t.example.com", zone: "example.com"}}}}


### PR DESCRIPTION
## What

New `function-kcl` module for the [`ip-reservation`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/ip-reservation) Crossplane Configuration. Reserves IPs from clusterbook using the `internalNetworkKey` discovered from a `RemoteCluster` (provider-kubeconfig).

Single-pass render + status: emits an Observe Object (reads networkKey), then an `IPReservation` (provider-clusterbook) wrapped in a namespaced `kubernetes.m` Object once the networkKey is known, and patches the XR status (`ipAddresses`, `reservationStatus`, `fqdn`, `zone`) from `ocds`.

## Test plan
- `kcl run main.k -Y test-settings.yaml` — withholding without networkKey, IPReservation emission, full status.
- Consumed by `ip-reservation:v0.1.0`; `crossplane render` + `crossplane xpkg build` green.

Published as `oci://ghcr.io/stuttgart-things/xplane-ip-reservation:0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
