### PR TITLE
feat(crossplane): add xplane-flux-apps function-kcl module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository contains KCL modules, tests, and documentation for Crossplane, K
 | Module                  | Path                                             | Description                                      |
 |-------------------------|--------------------------------------------------|--------------------------------------------------|
 | xplane-cilium           | crossplane/xplane-cilium/                        | Cilium CNI, L2 announcements, advanced networking|
+| xplane-flux-apps        | crossplane/xplane-flux-apps/                     | Generic Flux app Kustomizations on a target cluster|
 | xplane-helm-release     | crossplane/xplane-helm-release/                  | Helm chart deployment via Crossplane              |
 | xplane-vault-auth       | crossplane/xplane-vault-auth/                    | Vault Kubernetes authentication via Terraform     |
 | xplane-vault-config     | crossplane/xplane-vault-config/                  | Vault, CSI, ESO, RBAC, ServiceAccount tokens      |

--- a/crossplane/xplane-flux-apps/README.md
+++ b/crossplane/xplane-flux-apps/README.md
@@ -1,0 +1,50 @@
+# xplane-flux-apps
+
+`function-kcl` module for the [`flux-apps`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/flux-apps)
+Crossplane Configuration.
+
+Generic app deployment for Flux. Given a namespaced `FluxApps` XR that carries a
+list of apps, this module emits **one `kubernetes.m.crossplane.io/v1alpha1`
+Object per app**, each wrapping a `kustomize.toolkit.fluxcd.io/v1` Kustomization
+applied to a target cluster via a Kubernetes `ClusterProviderConfig`.
+
+It is the data-driven generalization of the
+[`flux-app-kustomizations`](../../flux/flux-app-kustomizations) module: the
+hardcoded `tekton` / `crossplane` Kustomizations there become entries in
+`spec.apps` here, so new apps are added as data, not code.
+
+Each Kustomization references an **existing** Flux source
+(`GitRepository` / `OCIRepository` / `Bucket`) — the source is a precondition on
+the target cluster, typically bootstrapped by the
+[`flux-init`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/flux-init)
+Configuration.
+
+## Inputs (`option("params")`)
+
+| Field | Meaning |
+|---|---|
+| `oxr` | The observed `FluxApps` XR (spec + metadata). |
+| `ocds` | Observed composed resources — read to compute `status`. |
+| `ctx["apiextensions.crossplane.io/environment"]` | Defaults from the `flux-apps-defaults` EnvironmentConfig. |
+
+Value resolution is **spec > EnvironmentConfig > hardcoded fallback** for the
+shared fields (`namespace`, `interval`, `retryInterval`, `timeout`,
+`sourceRef`); per-app fields under `spec.apps[]` always win.
+
+## Outputs
+
+- One `Object` (namespaced provider-kubernetes) per `spec.apps` entry, wrapping
+  a Flux `Kustomization` named after the app.
+- The XR with `status` patched (`ready`, `appsReady`, `appCount`, `readyCount`).
+
+## Render locally
+
+```bash
+kcl run -Y test-settings.yaml
+```
+
+## Push
+
+```bash
+kcl mod push oci://ghcr.io/stuttgart-things/xplane-flux-apps
+```

--- a/crossplane/xplane-flux-apps/kcl.mod
+++ b/crossplane/xplane-flux-apps/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "xplane-flux-apps"
+edition = "v0.11.2"
+version = "0.1.0"

--- a/crossplane/xplane-flux-apps/main.k
+++ b/crossplane/xplane-flux-apps/main.k
@@ -1,0 +1,150 @@
+"""
+xplane-flux-apps — function-kcl module for the flux-apps Crossplane Configuration.
+
+Generic app deployment for Flux: given a namespaced `FluxApps` XR that lists
+apps, this module emits one `kubernetes.m.crossplane.io/v1alpha1` Object per
+app, each wrapping a `kustomize.toolkit.fluxcd.io/v1` Kustomization applied to a
+target cluster. It is the data-driven generalization of the
+`flux-app-kustomizations` KCL module: the hardcoded tekton/crossplane
+Kustomizations there become entries in `spec.apps` here.
+
+Each Kustomization references an existing Flux source (GitRepository /
+OCIRepository / Bucket) — the source itself is a precondition on the target
+cluster (typically bootstrapped by the `flux-init` Configuration).
+
+Render and status are done in a single pass: the module emits the managed
+resources AND patches the XR status from `ocds` (observed composed resources).
+On the first reconcile `ocds` is empty, so `status.ready` starts False and
+converges as the composed Kustomizations become Ready.
+
+Defaults resolve spec > `flux-apps-defaults` EnvironmentConfig > hardcoded
+fallback (surfaced by the composition's function-environment-configs step under
+`params.ctx["apiextensions.crossplane.io/environment"]`).
+"""
+
+_params = option("params") or {}
+_oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
+_env = (_params?.ctx or {})["apiextensions.crossplane.io/environment"] or {}
+
+_spec = _oxr?.spec or {}
+_meta = _oxr?.metadata or {}
+_name = _meta?.name or "flux-apps"
+
+# --- Provider config ref (required by the XRD) ---
+_k8sPcr = _spec?.kubernetesProviderConfigRef
+
+# --- Resolve shared defaults: spec > EnvironmentConfig > hardcoded fallback ---
+_ns = _spec?.namespace or _env?.namespace or "flux-system"
+_interval = _spec?.interval or _env?.interval or "1h"
+_retryInterval = _spec?.retryInterval or _env?.retryInterval or "1m"
+_timeout = _spec?.timeout or _env?.timeout or "5m"
+_prune = _spec.prune if "prune" in _spec else True
+_wait = _spec.wait if "wait" in _spec else True
+
+# Default source referenced by every app (per-app spec.apps[].sourceRef wins).
+_sourceRef = _spec?.sourceRef or _env?.sourceRef or {}
+_srcKind = _sourceRef?.kind or "GitRepository"
+_srcName = _sourceRef?.name or "flux-apps"
+_srcNs = _sourceRef?.namespace or ""
+
+# Common metadata applied to all apps unless overridden per-app.
+_commonMeta = _spec?.commonMetadata or {}
+
+_apps = _spec?.apps or []
+
+# --- ocds key / composition-resource-name for an app ---
+_appResName = lambda app: {str:} -> str {
+    "{}-app-{}".format(_name, app.name)
+}
+
+# --- Build one provider-kubernetes Object wrapping a Flux Kustomization ---
+_appObject = lambda app: {str:} -> {str:} {
+    _resName = _appResName(app)
+    _src = app?.sourceRef or {}
+    _sourceRefOut = {
+        kind = _src?.kind or _srcKind
+        name = _src?.name or _srcName
+        **({namespace = _src.namespace} if _src?.namespace else ({namespace = _srcNs} if _srcNs else {}))
+    }
+    _sub = app?.substitute or {}
+    _subFrom = app?.substituteFrom or []
+    _postBuild = {
+        **({substitute = _sub} if _sub else {})
+        **({substituteFrom = _subFrom} if _subFrom else {})
+    }
+    _appCommon = app?.commonMetadata or _commonMeta
+    {
+        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+        kind = "Object"
+        metadata = {
+            name = _resName
+            namespace = _ns
+            annotations = {
+                "krm.kcl.dev/composition-resource-name" = _resName
+            }
+        }
+        spec = {
+            providerConfigRef = {
+                name = _k8sPcr
+                kind = "ClusterProviderConfig"
+            }
+            forProvider = {
+                manifest = {
+                    apiVersion = "kustomize.toolkit.fluxcd.io/v1"
+                    kind = "Kustomization"
+                    metadata = {
+                        name = app.name
+                        namespace = _ns
+                    }
+                    spec = {
+                        interval = app?.interval or _interval
+                        retryInterval = app?.retryInterval or _retryInterval
+                        timeout = app?.timeout or _timeout
+                        sourceRef = _sourceRefOut
+                        path = app.path
+                        prune = app.prune if "prune" in app else _prune
+                        wait = app.wait if "wait" in app else _wait
+                        **({force = app.force} if "force" in app else {})
+                        **({targetNamespace = app.targetNamespace} if app?.targetNamespace else {})
+                        **({dependsOn = app.dependsOn} if app?.dependsOn else {})
+                        **({components = app.components} if app?.components else {})
+                        **({commonMetadata = _appCommon} if _appCommon else {})
+                        **({healthChecks = app.healthChecks} if app?.healthChecks else {})
+                        **({healthCheckExprs = app.healthCheckExprs} if app?.healthCheckExprs else {})
+                        **({patches = app.patches} if app?.patches else {})
+                        **({images = app.images} if app?.images else {})
+                        **({decryption = app.decryption} if app?.decryption else {})
+                        **({postBuild = _postBuild} if _postBuild else {})
+                    }
+                }
+            }
+            readiness = {
+                policy = "DeriveFromObject"
+            }
+        }
+    }
+}
+
+_appObjects = [_appObject(a) for a in _apps]
+
+# --- Status: read Ready condition off each composed resource via ocds ---
+_isReady = lambda resourceName: str -> bool {
+    _found = resourceName in _ocds
+    _conds = _ocds[resourceName]?.Resource?.status?.conditions or [] if _found else []
+    len([c for c in _conds if c.type == "Ready" and c.status == "True"]) > 0
+}
+
+_readyApps = [a.name for a in _apps if _isReady(_appResName(a))]
+_appsReady = len(_readyApps) == len(_apps) if _apps else True
+
+_xrStatus = _oxr | {
+    status = {
+        appsReady = _appsReady
+        ready = _appsReady
+        appCount = len(_apps)
+        readyCount = len(_readyApps)
+    }
+}
+
+items = _appObjects + [_xrStatus]

--- a/crossplane/xplane-flux-apps/test-settings.yaml
+++ b/crossplane/xplane-flux-apps/test-settings.yaml
@@ -1,0 +1,38 @@
+kcl_options:
+  - key: params
+    value:
+      oxr:
+        apiVersion: config.stuttgart-things.com/v1alpha1
+        kind: FluxApps
+        metadata:
+          name: test-flux-apps
+          namespace: crossplane-system
+        spec:
+          kubernetesProviderConfigRef: xplane-test-kubernetes
+          namespace: flux-system
+          sourceRef:
+            kind: GitRepository
+            name: flux-apps
+          apps:
+            - name: tekton
+              path: ./cicd/tekton
+              substitute:
+                TEKTON_NAMESPACE: tekton-pipelines
+                TEKTON_VERSION: "0.76.1"
+            - name: crossplane
+              path: ./apps/crossplane
+              dependsOn:
+                - name: tekton
+              substitute:
+                CROSSPLANE_VERSION: "1.20.0"
+                CROSSPLANE_NAMESPACE: crossplane-system
+      ocds: {}
+      ctx:
+        "apiextensions.crossplane.io/environment":
+          namespace: flux-system
+          interval: "1h"
+          retryInterval: "1m"
+          timeout: "5m"
+          sourceRef:
+            kind: GitRepository
+            name: flux-apps


### PR DESCRIPTION
## Summary

New `function-kcl` module `crossplane/xplane-flux-apps` — the generic, data-driven counterpart to `flux/flux-app-kustomizations`. It backs the new [`flux-apps`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/flux-apps) Crossplane Configuration (companion PR in `crossplane-configurations`).

Given a namespaced `FluxApps` XR that lists apps, the module emits **one `kubernetes.m.crossplane.io/v1alpha1` Object per `spec.apps` entry**, each wrapping a `kustomize.toolkit.fluxcd.io/v1` Kustomization applied to a target cluster, and patches the XR `status` from `ocds` in a single pass — the same pattern as `xplane-flux-init`.

Where `flux-app-kustomizations` hardcodes the `tekton` and `crossplane` Kustomizations, those become entries in `spec.apps` here. Each Kustomization references an **existing** Flux source (`GitRepository`/`OCIRepository`/`Bucket`) — a precondition on the target cluster, typically bootstrapped by `flux-init`.

## Contents

- `crossplane/xplane-flux-apps/kcl.mod` — package `xplane-flux-apps` v0.1.0 (dep-less)
- `crossplane/xplane-flux-apps/main.k` — render + status
- `crossplane/xplane-flux-apps/test-settings.yaml` — `kcl run -Y` params
- `crossplane/xplane-flux-apps/README.md`
- `README.md` — adds the module to the Crossplane Modules table

## Features

- Shared defaults resolve `spec > flux-apps-defaults EnvironmentConfig > hardcoded fallback` (`namespace`, `interval`, `retryInterval`, `timeout`, `sourceRef`)
- Per-app overrides: `sourceRef`, `targetNamespace`, `interval`/`retryInterval`/`timeout`, `prune`/`wait`/`force`, `dependsOn`, `components`, `postBuild.substitute`/`substituteFrom`, `commonMetadata`, `healthChecks`/`healthCheckExprs`, `patches`, `images`, SOPS `decryption`
- Status: `ready`, `appsReady`, `appCount`, `readyCount` (converge as composed Kustomizations become Ready)

## Validation

Rendered locally with the KCL CLI — minimal case, all optional fields, boolean-default handling, and the `ocds` ready path (`ready`/`appCount`/`readyCount` correct). `kcl fmt` clean.

## Follow-up

After merge the module must be pushed to `oci://ghcr.io/stuttgart-things/xplane-flux-apps:0.1.0` — the `flux-apps` Composition references that OCI tag at render time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHtCyP74EmqovSr7L4Cj6K

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHtCyP74EmqovSr7L4Cj6K)_