### PR TITLE
fix(ci): authenticate module push via docker config, not kcl registry login

### DIFF
--- a/.github/workflows/kcl-module-ci.yaml
+++ b/.github/workflows/kcl-module-ci.yaml
@@ -244,10 +244,19 @@ jobs:
             echo "✅ Version ${{ steps.metadata.outputs.version }} does not exist, will publish"
           fi
 
+      # 'kcl registry login' cannot be used here: it stores the credential via
+      # the oras credential library, which refuses to write a plaintext store
+      # on the runner and fails with "putting plaintext credentials is
+      # disabled" (reported as a misleading "please check registry, username
+      # and password is valid"). 'kcl mod push' reads ~/.docker/config.json,
+      # so writing that file is enough — no kcl-side login required.
       - name: Login to GitHub Container Registry
         if: steps.check-version.outputs.exists == 'false'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | kcl registry login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push module to OCI registry
         if: steps.check-version.outputs.exists == 'false'


### PR DESCRIPTION
Follow-up to #70. The first real `publish-to-oci` run — the `crossplane/xplane-flux-apps` dispatch ([run](https://github.com/stuttgart-things/kcl/actions/runs/29484995003)) — got as far as login and died there:

```
failed to login 'ghcr.io', please check registry, username and password is valid
failed to store the credentials for ghcr.io: putting plaintext credentials is disabled
```

## Cause

**It is not an auth failure** — the username and token are fine. `kcl registry login` *persists* the credential through the oras credential library, which refuses to write a plaintext credential store on the runner. kcl surfaces that as the misleading first line.

## Fix

`kcl mod push` reads `~/.docker/config.json`, so the kcl-side login is unnecessary. `docker/login-action` writes exactly that file. This mirrors the flow that works locally — `oras login` → `kcl mod push` — where `oras` likewise only writes the docker config; there is no kcl-native credential store involved.

## Why this was never caught

`publish-to-oci` has **never completed successfully**. It ran exactly twice — 2025-10-22 and today's dispatch — and failed both times. Every other run skipped it, because the path filters #70 fixed meant `detect-changed-modules` always returned `[]`. Reviving the trigger is what finally exercised the publish path and exposed this.

## Verification

Partial, and worth stating plainly: I could not exercise the auth path locally. `kcl mod push` checks the registry anonymously and short-circuits on `package version '0.2.0' already exists` **before** authenticating, so no already-published module can test it.

The real proof is a dispatch of `crossplane/xplane-flux-apps` 0.1.0 — a version that is not in the registry — after this merges.

Reminder for that run: `xplane-flux-apps` is a **new** package, so it will land **private**. The REST API cannot flip container visibility; the workflow only prints the link. Until it is set public at
`https://github.com/orgs/stuttgart-things/packages/container/xplane-flux-apps/settings`,
`verify` on crossplane-configurations#97 keeps failing with `403 denied` despite a successful push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
