### PR TITLE
fix(xplane-flux-catalog): type components explicitly (0.1.1)

### DIFF
--- a/crossplane/xplane-flux-catalog/README.md
+++ b/crossplane/xplane-flux-catalog/README.md
@@ -76,3 +76,19 @@ app.components       # [control-plane, template-execution]
 `substituteFrom`. Deliver it with sops-secrets-operator **before** that component
 reconciles — `substituteFrom` resolves at build time, so a Secret applied by the
 same Kustomization is too late.
+
+## Consuming from another module
+
+Add it as a `kcl.mod` dependency (the pattern `xplane-platform` uses):
+
+```toml
+[dependencies]
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.1.1" }
+```
+
+**Use `0.1.1` or later.** In 0.1.0 the components in `apps/*.k` were plain dict
+literals; KCL coerces those inside the module (so `kcl test` passed) but NOT when
+the module is imported as a package, where any consumer hit
+`expect [xplane_flux_catalog.Component], got list`. App files must instantiate
+`s.Component { ... }` explicitly. In-module tests cannot catch this — only an
+actual cross-package import can, so verify new app files against a consumer.

--- a/crossplane/xplane-flux-catalog/apps/dapr.k
+++ b/crossplane/xplane-flux-catalog/apps/dapr.k
@@ -15,13 +15,13 @@ dapr: s.App = {
     artifact = "oci://ghcr.io/stuttgart-things/flux/apps/dapr"
     defaultVersion = "v1.18.1"
     components = [
-        {
+        s.Component {
             name = "control-plane"
             path = "./components/control-plane"
             wrapsHelmRelease = True
             timeout = "15m"
         }
-        {
+        s.Component {
             name = "template-execution"
             path = "./components/template-execution"
             dependsOn = ["control-plane"]

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.1.0"
+version = "0.1.1"


### PR DESCRIPTION
**0.1.0 is unusable by any consumer.** Found on the first real consumption attempt — a Composition pulling the module through `function-kcl`:

```
expect [xplane_flux_catalog.Component], got list
```

The components in `apps/dapr.k` were plain dict literals. KCL coerces those to `Component` *inside* the module — so `kcl run` and `kcl test` both passed — but not when the module is imported as a package. App files must instantiate `s.Component { ... }` explicitly.

## Why the tests missed it

They instantiate within the same package, where coercion applies. **No in-module test can catch this class of bug**; only a cross-package import reproduces it.

So the fix was verified with a separate consumer module using a path dependency, not by re-running the (already green) suite:

```
out:
  artifact: oci://ghcr.io/stuttgart-things/flux/apps/dapr
  version: v1.18.1
  components: [control-plane, template-execution]
```

The README now documents the trap so new app files get checked the same way.

## Note

The green CI on #73 was accurate about formatting, structure and the module's own invariants — it just never imported the module the way a consumer does. Worth remembering when adding apps: `kcl test` passing is necessary, not sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo