### PR TITLE
feat(crossplane): add xplane-platform module (0.1.0)

### DIFF
--- a/crossplane/xplane-platform/README.md
+++ b/crossplane/xplane-platform/README.md
@@ -1,0 +1,89 @@
+# xplane-platform
+
+`function-kcl` module for the
+[`platform`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/platform)
+Crossplane Configuration — the umbrella that assembles a cluster's platform from
+the bootstrap building blocks.
+
+## What it emits
+
+| Child XR | Configuration | When |
+|---|---|---|
+| `FluxInit` | [flux-init](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/flux-init) | `spec.fluxInit.enabled` (default true) |
+| `FluxApps` | [flux-apps](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/flux-apps) | any enabled entry in `spec.apps` |
+
+Plus the XR status: the resolved `shared` contract and per-component readiness.
+
+## Why it exists
+
+stuttgart-things/flux publishes **one OCI artifact per app**, so a Flux source
+name and an app are the same fact. Deploying one by hand means adding an
+`OCIRepository` to a `FluxInit` **and** referencing it by name in a `FluxApps` —
+two objects, one hand-maintained string, nothing validating it until a
+Kustomization stalls.
+
+Here, one toggle produces both:
+
+```yaml
+spec:
+  clusterName: kind1
+  apps:
+    dapr: {}
+```
+
+→ an `OCIRepository` named `dapr` on the FluxInit child, **and** a
+`dapr-control-plane` + `dapr-template-execution` Kustomization pair on the
+FluxApps child, each with `sourceRef: {kind: OCIRepository, name: dapr}` and
+`dependsOn` rewritten to the emitted names.
+
+App definitions come from
+[`xplane-flux-catalog`](../xplane-flux-catalog/) — structural facts only.
+
+## Layout
+
+```
+logic.k        pure functions — every rule, no option("params")
+main.k         render entry point: params in, items out
+logic_test.k   unit tests (`kcl test`)
+```
+
+The split is the point: platform's logic used to be inline in the Composition,
+where it could not be tested at all.
+
+## Rules
+
+| Rule | Enforced |
+|---|---|
+| apps enabled while `fluxInit.enabled: false` | rejected — fluxInit creates the sources apps reference |
+| a component depending on a **disabled** sibling | rejected, naming the offenders — it would otherwise sit in `DependencyNotReady` forever |
+| unknown app name | rejected by the catalog |
+| disabling an app | prunes it — the entry stops being emitted, and flux-apps' Objects use `managementPolicies: ["*"]`, so the Kustomization and its workload are removed |
+
+## Overrides
+
+```yaml
+apps:
+  dapr:
+    version: v1.17.0                    # else catalog defaultVersion
+    substitute: {DAPR_NAMESPACE: dapr-system}   # applied to all components
+    components:
+      control-plane: {enabled: false}
+      template-execution:
+        substitute: {FLUX_SOURCE_API_VERSION: v1}   # merged, wins
+        substituteFrom:
+          - kind: Secret
+            name: dapr-backstage-template-execution-vars
+```
+
+`substituteFrom` is **component-scoped on purpose**. It resolves at *build* time
+and a missing Secret fails the build, so an app-level one would break components
+that do not need it.
+
+## Gotchas found building this
+
+- KCL does **not** interpolate `${}` inside `assert` messages — it prints the
+  placeholder. Concatenate.
+- A nested `all` comprehension does not capture the outer loop binding; flatten
+  with a list comprehension instead.
+- Schema instances must be explicit (`s.Component { ... }`) or a cross-package
+  import fails even though in-module tests pass.

--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,0 +1,7 @@
+[package]
+name = "xplane-platform"
+edition = "v0.12.3"
+version = "0.1.0"
+
+[dependencies]
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.1.1" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,0 +1,9 @@
+[dependencies]
+  [dependencies.xplane-flux-catalog]
+    name = "xplane-flux-catalog"
+    full_name = "xplane-flux-catalog_0.1.1"
+    version = "0.1.1"
+    sum = "5OaQbM9OekmMCRYEl114Ew5eew106PMbCau57nP0eL8="
+    reg = "ghcr.io"
+    repo = "stuttgart-things/xplane-flux-catalog"
+    oci_tag = "0.1.1"

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -1,0 +1,104 @@
+"""
+Pure logic for the platform Configuration — no option("params"), so every rule
+here is unit-testable with `kcl test`. main.k is the thin render entry point.
+
+The reason this module exists: stuttgart-things/flux publishes ONE OCI ARTIFACT
+PER APP, so a Flux source name and an app are the same fact. Enabling an app
+therefore has to produce BOTH an OCIRepository source (on the FluxInit child)
+and a Kustomization entry (on the FluxApps child). Keeping those two in sync by
+hand is the error this module removes.
+"""
+
+import xplane_flux_catalog as cat
+
+resolveShared = lambda spec: {str:} -> {str:} {
+    """The shared cluster contract, resolved once and handed to every component.
+
+    clusterName derives {clusterName}-helm / {clusterName}-kubernetes — the names
+    provider-kubeconfig's RemoteCluster creates. Explicit refs always win.
+    Unresolved fields are OMITTED, never emitted as "", so a consumer can test
+    `if shared.clusterType` and trust it.
+    """
+    _cn = spec?.clusterName or ""
+    {
+        if _cn:
+            clusterName = _cn
+        helmProviderConfigRef = spec?.helmProviderConfigRef or ("{}-helm".format(_cn) if _cn else "")
+        kubernetesProviderConfigRef = spec?.kubernetesProviderConfigRef or ("{}-kubernetes".format(_cn) if _cn else "")
+        observeProviderConfigRef = spec?.observeProviderConfigRef or "in-cluster"
+        namespace = spec?.namespace or "flux-system"
+    }
+}
+
+isEnabled = lambda block: {str:} -> bool {
+    """`or True` would swallow an explicit false, so test for the key."""
+    block.enabled if "enabled" in block else True
+}
+
+enabledApps = lambda spec: {str:} -> {str:} {
+    """spec.apps entries that are enabled. Map, not list, so overrides merge."""
+    {k: v for k, v in (spec?.apps or {}) if isEnabled(v or {})}
+}
+
+fluxInitEnabled = lambda spec: {str:} -> bool {
+    isEnabled(spec?.fluxInit or {})
+}
+
+appSources = lambda spec: {str:} -> [{str:}] {
+    """OCIRepository sources for the FluxInit child — one per enabled app.
+
+    The source is named after the app, which is what lets appEntries() reference
+    it without the user restating the name.
+    """
+    [{
+        name = _n
+        kind = "OCIRepository"
+        url = cat.get(_n).artifact
+        ref = (_a?.version or cat.get(_n).defaultVersion)
+    } for _n, _a in enabledApps(spec)]
+}
+
+appEntries = lambda spec: {str:} -> [{str:}] {
+    """FluxApps `apps[]` entries — one per enabled component of each enabled app.
+
+    An app is not necessarily one Kustomization (dapr ships control-plane +
+    template-execution), so components are expanded here and dependsOn is
+    rewritten to the emitted '{app}-{component}' names.
+    """
+    sum([[{
+        name = "{}-{}".format(_n, _c.name)
+        path = _c.path
+        sourceRef = {kind = "OCIRepository", name = _n}
+        if _c.dependsOn:
+            dependsOn = [{name = "{}-{}".format(_n, _d)} for _d in _c.dependsOn]
+        if (((_a?.components or {})[_c.name] or {})?.timeout or _c.timeout):
+            timeout = ((_a?.components or {})[_c.name] or {})?.timeout or _c.timeout
+        if (_a?.substitute or {}) | (((_a?.components or {})[_c.name] or {})?.substitute or {}):
+            substitute = (_a?.substitute or {}) | (((_a?.components or {})[_c.name] or {})?.substitute or {})
+        if ((_a?.components or {})[_c.name] or {})?.substituteFrom:
+            substituteFrom = ((_a?.components or {})[_c.name] or {}).substituteFrom
+        if (((_a?.components or {})[_c.name] or {})?.targetNamespace or _a?.targetNamespace):
+            targetNamespace = ((_a?.components or {})[_c.name] or {})?.targetNamespace or _a?.targetNamespace
+    } for _c in cat.get(_n).components if isEnabled((_a?.components or {})[_c.name] or {})] for _n, _a in enabledApps(spec)], [])
+}
+
+validate = lambda spec: {str:} -> bool {
+    """Rules that must hold before anything is emitted.
+
+    The fluxInit rule is also a CEL rule on the XRD (which fails at apply time,
+    a much better signal); it is repeated here so the module is safe for any
+    caller, not only that XRD.
+    """
+    _apps = enabledApps(spec)
+    assert fluxInitEnabled(spec) or len(_apps) == 0, "apps are enabled but fluxInit is disabled — fluxInit creates the Flux sources every app references; enable fluxInit or disable all apps"
+
+    # A component depending on a disabled sibling would sit in DependencyNotReady
+    # forever; fail at render instead. Flattened rather than nested `all`, which
+    # does not capture the outer loop binding.
+    _badDeps = sum([["{}-{}".format(_n, _c.name) for _c in cat.get(_n).components if isEnabled((_a?.components or {})[_c.name] or {}) and len([_d for _d in _c.dependsOn if not isEnabled((_a?.components or {})[_d] or {})]) > 0] for _n, _a in _apps], [])
+
+    # KCL does NOT interpolate ${} inside assert messages — it prints the
+    # placeholder literally. Concatenate so the message names the offenders.
+    assert len(_badDeps) == 0, "these components depend on a disabled component: " + ", ".join(_badDeps)
+    True
+}

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -1,0 +1,115 @@
+# Unit tests for the platform logic. `kcl test`.
+# These are the rules that would otherwise only be observable on a live cluster.
+import .logic as l
+
+_dapr = {
+    apps = {
+        dapr = {}
+    }
+}
+
+test_shared_derives_refs_from_clustername = lambda {
+    s = l.resolveShared({clusterName = "kind1"})
+    assert s.helmProviderConfigRef == "kind1-helm"
+    assert s.kubernetesProviderConfigRef == "kind1-kubernetes"
+    assert s.namespace == "flux-system"
+}
+
+# Unresolved fields must be absent, not "" — a consumer testing
+# `if shared.clusterName` must not get a value that was never resolved.
+test_shared_omits_unresolved_clustername = lambda {
+    s = l.resolveShared({helmProviderConfigRef = "h", kubernetesProviderConfigRef = "k"})
+    assert "clusterName" not in s
+}
+
+test_explicit_refs_win = lambda {
+    s = l.resolveShared({clusterName = "kind1", helmProviderConfigRef = "custom"})
+    assert s.helmProviderConfigRef == "custom"
+}
+
+# The point of the whole module: one toggle produces the source AND the app.
+test_enabled_app_yields_source_and_entries = lambda {
+    src = l.appSources(_dapr)
+    assert len(src) == 1
+    assert src[0].name == "dapr"
+    assert src[0].url == "oci://ghcr.io/stuttgart-things/flux/apps/dapr"
+    assert src[0].ref == "v1.18.1"
+    e = l.appEntries(_dapr)
+    assert len(e) == 2
+    assert e[0].sourceRef.name == "dapr", "app entry must reference the source the same toggle created"
+}
+
+test_disabled_app_yields_nothing = lambda {
+    spec = {
+        apps = {
+            dapr = {enabled = False}
+        }
+    }
+    assert len(l.appSources(spec)) == 0
+    assert len(l.appEntries(spec)) == 0
+}
+
+test_version_override = lambda {
+    assert l.appSources({
+        apps = {
+            dapr = {version = "v1.17.0"}
+        }
+    })[0].ref == "v1.17.0"
+}
+
+# dependsOn must be rewritten to the emitted names, or Flux looks for a
+# Kustomization called 'control-plane' that does not exist.
+test_dependson_is_rewritten_to_emitted_names = lambda {
+    e = [x for x in l.appEntries(_dapr) if x.name == "dapr-template-execution"][0]
+    assert e.dependsOn == [{name = "dapr-control-plane"}]
+}
+
+test_helmrelease_timeout_carried_from_catalog = lambda {
+    e = [x for x in l.appEntries(_dapr) if x.name == "dapr-control-plane"][0]
+    assert e.timeout == "15m"
+}
+
+test_substitute_merges_app_and_component = lambda {
+    spec = {
+        apps = {
+            dapr = {
+                substitute = {DAPR_NAMESPACE = "dapr-system"}
+                components = {
+                    "template-execution" = {
+                        substitute = {FLUX_SOURCE_API_VERSION = "v1"}
+                    }
+                }
+            }
+        }
+    }
+    e = [x for x in l.appEntries(spec) if x.name == "dapr-template-execution"][0]
+    assert e.substitute.DAPR_NAMESPACE == "dapr-system"
+    assert e.substitute.FLUX_SOURCE_API_VERSION == "v1"
+}
+
+# substituteFrom is component-scoped on purpose: it resolves at BUILD time and a
+# missing Secret fails the build, so applying an app-level one to every
+# component would break components that do not need it.
+test_substitutefrom_is_component_scoped = lambda {
+    spec = {
+        apps = {
+            dapr = {
+                components = {
+                    "template-execution" = {
+                        substituteFrom = [{kind = "Secret", name = "dapr-vars"}]
+                    }
+                }
+            }
+        }
+    }
+    entries = {x.name: x for x in l.appEntries(spec)}
+    assert "substituteFrom" in entries["dapr-template-execution"]
+    assert "substituteFrom" not in entries["dapr-control-plane"]
+}
+
+test_apps_without_fluxinit_is_rejected = lambda {
+    assert l.validate(_dapr)
+    assert l.validate({
+        fluxInit = {enabled = False}
+    })
+}

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -1,0 +1,141 @@
+"""
+xplane-platform — function-kcl module for the platform Crossplane Configuration.
+
+Composes one child XR per enabled component of a cluster's platform:
+  1. FluxInit  (flux-init Configuration)  — Flux itself, plus one OCIRepository
+     source per enabled app
+  2. FluxApps  (flux-apps Configuration)  — one Kustomization per enabled
+     component of each enabled app
+
+Render and status happen in a single pass: the module emits the child XRs AND
+patches the XR status from `ocds`. On the first reconcile `ocds` is empty, so
+status.ready starts False and converges as the children become Ready.
+
+All decision logic lives in logic.k so it is unit-testable without Crossplane;
+this file only marshals option("params") in and `items` out.
+"""
+
+import .logic as l
+
+_params = option("params") or {}
+_oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
+
+_spec = _oxr?.spec or {}
+_meta = _oxr?.metadata or {}
+_name = _meta?.name or "platform"
+_namespace = _meta?.namespace or "default"
+
+_valid = l.validate(_spec)
+_shared = l.resolveShared(_spec)
+
+_fluxEnabled = l.fluxInitEnabled(_spec)
+_apps = l.enabledApps(_spec)
+_appsEnabled = len(_apps) > 0
+
+_fluxKey = "{}-flux-init".format(_name)
+_appsKey = "{}-flux-apps".format(_name)
+
+# --- Child 1: FluxInit ---
+# Sources are the union of what the XR declared and what enabling an app
+# implies. The app-derived ones are what make `apps: {dapr: {}}` sufficient.
+_fluxSpec = _spec?.fluxInit or {}
+_declaredSources = ((_fluxSpec?.instance or {})?.sources or [])
+_allSources = _declaredSources + l.appSources(_spec)
+
+_fluxInitXR = {
+    apiVersion = "config.stuttgart-things.com/v1alpha1"
+    kind = "FluxInit"
+    metadata = {
+        name = _fluxKey
+        namespace = _namespace
+        annotations = {"krm.kcl.dev/composition-resource-name" = _fluxKey}
+    }
+    spec = {
+        if _shared?.clusterName:
+            clusterName = _shared.clusterName
+        if _shared.helmProviderConfigRef:
+            helmProviderConfigRef = _shared.helmProviderConfigRef
+        if _shared.kubernetesProviderConfigRef:
+            kubernetesProviderConfigRef = _shared.kubernetesProviderConfigRef
+        observeProviderConfigRef = _shared.observeProviderConfigRef
+        namespace = _shared.namespace
+        if _fluxSpec?.operatorChart:
+            operatorChart = _fluxSpec.operatorChart
+        if (_fluxSpec?.instance or _allSources):
+            instance = (_fluxSpec?.instance or {}) | ({sources = _allSources} if _allSources else {})
+        if _fluxSpec?.kustomize:
+            kustomize = _fluxSpec.kustomize
+        if _fluxSpec?.sops:
+            sops = _fluxSpec.sops
+    }
+}
+
+# --- Child 2: FluxApps ---
+# Only the kubernetes ref is projected: flux-apps takes no clusterName and no
+# helm ref, so the shared contract is applied per component, not forwarded whole.
+_fluxAppsXR = {
+    apiVersion = "config.stuttgart-things.com/v1alpha1"
+    kind = "FluxApps"
+    metadata = {
+        name = _appsKey
+        namespace = _namespace
+        annotations = {"krm.kcl.dev/composition-resource-name" = _appsKey}
+    }
+    spec = {
+        kubernetesProviderConfigRef = _shared.kubernetesProviderConfigRef
+        namespace = _shared.namespace
+        apps = l.appEntries(_spec)
+    }
+}
+
+_children = ([_fluxInitXR] if _fluxEnabled else []) + ([_fluxAppsXR] if _appsEnabled else [])
+
+# --- Read child status back ---
+_readStatus = lambda key: str -> {str:} {
+    (_ocds[key].Resource?.status or {}) if key in _ocds else {}
+}
+_isReady = lambda st: {str:} -> bool {
+    len([c for c in (st?.conditions or []) if c.type == "Ready" and c.status == "True"]) > 0
+}
+
+_fluxStatus = _readStatus(_fluxKey)
+_fluxReady = _isReady(_fluxStatus)
+_appsStatus = _readStatus(_appsKey)
+_appsReady = _isReady(_appsStatus)
+
+# clusterType is discovered by the FluxInit child from the RemoteCluster; lifting
+# it into shared status keeps later components from re-observing it.
+_clusterType = _fluxStatus?.clusterType or ""
+
+_enabledReady = ([_fluxReady] if _fluxEnabled else []) + ([_appsReady] if _appsEnabled else [])
+_readyComponents = len([r for r in _enabledReady if r])
+
+_xrStatus = _oxr | {
+    status = {
+        shared = _shared | ({clusterType = _clusterType} if _clusterType else {})
+        components = {
+            fluxInit = {
+                enabled = _fluxEnabled
+                ready = _fluxReady
+                operatorReady = _fluxStatus?.operatorReady or False
+                instanceReady = _fluxStatus?.instanceReady or False
+                sourcesReady = _fluxStatus?.sourcesReady or False
+                sourceCount = _fluxStatus?.sourceCount or 0
+            }
+            fluxApps = {
+                enabled = _appsEnabled
+                ready = _appsReady
+                appCount = _appsStatus?.appCount or 0
+                readyCount = _appsStatus?.readyCount or 0
+            }
+        }
+        componentCount = len(_enabledReady)
+        readyComponents = _readyComponents
+        # Vacuously true with nothing enabled — matches what function-auto-ready
+        # reports on the Ready condition when there is nothing to wait for.
+        ready = _readyComponents == len(_enabledReady)
+    }
+}
+
+items = _children + [_xrStatus]


### PR DESCRIPTION
`function-kcl` module for the [`platform`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/platform) Configuration — moves its logic out of the inline Composition and adds the apps catalog.

## One toggle, both halves

stuttgart-things/flux publishes **one OCI artifact per app**, so a Flux source name and an app are the same fact. Deploying dapr to kind1 by hand meant patching a `FluxInit` to add an `OCIRepository` *and* creating a `FluxApps` referencing it by name — two objects joined by a string nothing validates until a Kustomization stalls.

`apps: {dapr: {}}` now yields both:

```yaml
FluxInit:  instance.sources: [{name: dapr, kind: OCIRepository, url: oci://…/flux/apps/dapr, ref: v1.18.1}]
FluxApps:  apps: [{name: dapr-control-plane, sourceRef: {kind: OCIRepository, name: dapr}, timeout: 15m, …},
                  {name: dapr-template-execution, dependsOn: [{name: dapr-control-plane}], …}]
```

`dependsOn` is rewritten to the emitted `{app}-{component}` names, and `timeout: 15m` for chart-installing components comes from the catalog.

## Why a module and not inline KCL

Testability. Platform's logic was inline in the Composition, where **it could not be tested at all**. `logic.k` holds every rule as pure functions with no `option("params")`; `main.k` only marshals params in and `items` out. 11 unit tests cover rules that would otherwise only be observable on a live cluster.

(An inline-source + `dependencies` variant does work — verified — but leaves the logic untestable and makes platform the only Configuration not following the flux-init/flux-apps pattern.)

## Rules

| Rule | Behaviour |
|---|---|
| apps enabled while `fluxInit.enabled: false` | rejected — fluxInit creates the sources apps reference |
| component depends on a **disabled** sibling | rejected, naming the offenders — otherwise `DependencyNotReady` forever |
| unknown app name | rejected by the catalog |
| disabling an app | prunes it (verified on kind1: entry removed → Object → Kustomization → workload all GC'd) |

Each rejection was verified **out-of-process** — KCL has no try/catch, so an in-process test cannot assert that an assert fires. A test that merely calls `validate()` on valid input proves nothing.

## KCL traps hit (documented in the README)

- `${}` is **not** interpolated inside `assert` messages — it prints the placeholder literally. Concatenate.
- A nested `all` comprehension does not capture the outer loop binding.
- Schema instances must be explicit — the cause of the `xplane-flux-catalog` 0.1.0 breakage.

## Next

Not yet consumed: the `platform` Configuration still needs `spec.apps` on its XRD, the CEL rule for apps-with-fluxInit-disabled, and its Composition repointed at `oci://…/xplane-platform:0.1.0`. Publishing first is a prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo