### PR TITLE
feat(kcl): headlamp + required substitutions (catalog 0.1.2), source Usages (flux-init 0.3.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/dapr.k
+++ b/crossplane/xplane-flux-catalog/apps/dapr.k
@@ -25,6 +25,7 @@ dapr: s.App = {
             name = "template-execution"
             path = "./components/template-execution"
             dependsOn = ["control-plane"]
+            requiredSubstitutions = ["GITHUB_TOKEN", "BACKSTAGE_AUTH_TOKEN", "REDIS_PASSWORD"]
         }
     ]
 }

--- a/crossplane/xplane-flux-catalog/apps/headlamp.k
+++ b/crossplane/xplane-flux-catalog/apps/headlamp.k
@@ -1,0 +1,25 @@
+import ..schema as s
+
+# headlamp — https://github.com/stuttgart-things/flux/tree/main/apps/headlamp
+#
+# Single component: the artifact root kustomization pulls requirements.yaml
+# (Namespace + HelmRepository), release.yaml (HelmRelease) and rbac.yaml, so the
+# path is "./" rather than a components/ subdirectory.
+#
+# DOMAIN, HOSTNAME and GATEWAY_NAME have NO defaults in the manifests and are
+# used to build the HTTPRoute — Flux would substitute them with empty strings and
+# deploy something silently broken, so they are declared required.
+# The Gateway they reference must already exist on the target cluster.
+headlamp: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/apps/headlamp"
+    defaultVersion = "v1.18.1"
+    components = [
+        s.Component {
+            name = "app"
+            path = "./"
+            wrapsHelmRelease = True
+            timeout = "15m"
+            requiredSubstitutions = ["DOMAIN", "HOSTNAME", "GATEWAY_NAME"]
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -41,3 +41,16 @@ test_helmrelease_components_raise_timeout = lambda {
         }
     }, "a component that wraps a HelmRelease must raise its timeout"
 }
+
+test_headlamp_is_registered = lambda {
+    h = c.get("headlamp")
+    assert h.artifact == "oci://ghcr.io/stuttgart-things/flux/apps/headlamp"
+    assert len(h.components) == 1
+    assert h.components[0].path == "./", "single-component apps reconcile the artifact root"
+}
+
+# Vars without a manifest default must be declared, or Flux substitutes an empty
+# string and deploys something silently broken.
+test_headlamp_declares_required_substitutions = lambda {
+    assert c.get("headlamp").components[0].requiredSubstitutions == ["DOMAIN", "HOSTNAME", "GATEWAY_NAME"]
+}

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.1.1"
+version = "0.1.2"

--- a/crossplane/xplane-flux-catalog/main.k
+++ b/crossplane/xplane-flux-catalog/main.k
@@ -4,10 +4,12 @@
 # apps/<name>.k, then one import and one entry here. Keeping it manual is the
 # point — adding an app to the platform is a reviewable two-line diff.
 import .apps.dapr as dapr
+import .apps.headlamp as headlamp
 import schema as s
 
 catalog: {str:s.App} = {
     dapr = dapr.dapr
+    headlamp = headlamp.headlamp
 }
 
 names = sorted(catalog)
@@ -17,6 +19,8 @@ _known = ", ".join(names)
 # Look up an app by name. Fails loudly on an unknown name rather than silently
 # returning an empty app that would render zero Kustomizations.
 get = lambda name: str -> s.App {
-    assert name in catalog, "unknown app '${name}' — known: ${_known}"
+    # KCL does NOT interpolate ${} inside assert messages — it prints the
+    # placeholder literally. Concatenate so the message names the app.
+    assert name in catalog, "unknown app '" + name + "' — known: " + _known
     catalog[name]
 }

--- a/crossplane/xplane-flux-catalog/schema.k
+++ b/crossplane/xplane-flux-catalog/schema.k
@@ -29,6 +29,14 @@ schema Component:
     """Overrides the FluxApps default. Set 15m on components that wrap a
     HelmRelease — chart pull + rollout regularly exceeds the 10m default"""
 
+    requiredSubstitutions?: [str] = []
+    """Substitution variables this component's manifests use WITHOUT a default.
+
+    Flux replaces an undefined variable with an empty string rather than failing,
+    so a missing one is a silently broken deploy. Consumers should reject an app
+    whose required vars are neither in `substitute` nor plausibly supplied by a
+    `substituteFrom` source."""
+
     wrapsHelmRelease?: bool = False
     """Documentation flag: this component installs a HelmRelease. Explains why
     timeout is raised and signals that readiness depends on a chart rollout"""

--- a/crossplane/xplane-flux-init/kcl.mod
+++ b/crossplane/xplane-flux-init/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-init"
 edition = "v0.11.2"
-version = "0.2.0"
+version = "0.3.0"

--- a/crossplane/xplane-flux-init/main.k
+++ b/crossplane/xplane-flux-init/main.k
@@ -6,6 +6,7 @@ Bootstraps Flux on a target cluster via the flux-operator:
   2. kubernetes.m.crossplane.io Object — FluxInstance CR (uses operator)
   3. protection.crossplane.io Usage — FluxInstance deletes before operator
   4. kubernetes.m.crossplane.io Object(s) — one OCIRepository/GitRepository per source
+  5. protection.crossplane.io Usage(s) — each source deletes before the FluxInstance
 
 Render and status are done in a single pass: the module emits the managed
 resources AND patches the XR status from `ocds` (observed composed resources).
@@ -107,6 +108,7 @@ _sops = _spec?.sops or {}
 _sopsEnabled = _sops?.enabled or False
 _sopsSecretName = _sops?.secretName or "sops-age"
 _sopsAgeKey = _sops?.ageKey or ""
+
 # Preferred: copy the age key from an existing Secret (no plaintext in the XR).
 # The referenced Secret must live on the target cluster (read via the same
 # kubernetesProviderConfigRef). data['<key>'] is base64 and is copied verbatim.
@@ -245,48 +247,47 @@ _fluxInstanceUsage = {
 _sourceName = lambda s: {str:} -> str {
     "{}-source-{}".format(_name, s.name)
 }
-_sourceObjects = [
-    {
-        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
-        kind = "Object"
-        metadata = {
-            name = _sourceName(s)
-            namespace = _ns
-            annotations = {
-                "krm.kcl.dev/composition-resource-name" = _sourceName(s)
-                "crossplane.io/uses" = _instanceName
-            }
-        }
-        spec = {
-            providerConfigRef = {
-                name = _k8sPcr
-                kind = "ClusterProviderConfig"
-            }
-            forProvider = {
-                manifest = {
-                    apiVersion = "source.toolkit.fluxcd.io/v1"
-                    kind = s?.kind or "OCIRepository"
-                    metadata = {
-                        name = s.name
-                        namespace = _ns
-                    }
-                    spec = {
-                        interval = _reconcileEvery
-                        url = s.url
-                        ref = {
-                            tag = s?.ref or "latest"
-                        }
-                        **({secretRef = {name = s.pullSecret}} if s?.pullSecret else {})
-                    }
-                }
-            }
-            readiness = {
-                policy = "DeriveFromObject"
-            }
+_sourceObjects = [{
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {
+        name = _sourceName(s)
+        namespace = _ns
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = _sourceName(s)
+            "crossplane.io/uses" = _instanceName
         }
     }
-    for s in _sources
-]
+    spec = {
+        providerConfigRef = {
+            name = _k8sPcr
+            kind = "ClusterProviderConfig"
+        }
+        forProvider = {
+            manifest = {
+                apiVersion = "source.toolkit.fluxcd.io/v1"
+                kind = s?.kind or "OCIRepository"
+                metadata = {
+                    name = s.name
+                    namespace = _ns
+                }
+                spec = {
+                    interval = _reconcileEvery
+                    url = s.url
+                    ref = {
+                        tag = s?.ref or "latest"
+                    }
+                    **({
+                        secretRef = {name = s.pullSecret}
+                    } if s?.pullSecret else {})
+                }
+            }
+        }
+        readiness = {
+            policy = "DeriveFromObject"
+        }
+    }
+} for s in _sources]
 
 # --- Optional: age decryption Secret in the flux namespace ---
 # Only emitted when sops.enabled and sops.ageKey are set. Omit ageKey to manage
@@ -366,6 +367,43 @@ _xrStatus = _oxr | {
 }
 
 # Flux resources are held until the observe gate opens (no-op without clusterName).
-_fluxResources = ([_helmRelease, _fluxInstance, _fluxInstanceUsage] + _sopsResources + _sourceObjects) if _observeReady else []
+# --- Usages: each source must be deleted BEFORE the FluxInstance ---
+# Without these, deleting a FluxInit removes the composed resources in parallel.
+# If the FluxInstance goes first it takes Flux's CRDs with it, and
+# provider-kubernetes can then no longer observe an OCIRepository to finalise its
+# Object — which hangs on finalizer.managedresource.crossplane.io with
+#   observe failed: cannot get object: no matches for kind "OCIRepository"
+# and has to be unstuck by hand. Chaining source -> instance -> operator makes
+# teardown deterministic. (The crossplane.io/uses annotation on the source
+# Objects is decorative; a Usage is what actually orders deletion.)
+_sourceUsages = [{
+    apiVersion = "protection.crossplane.io/v1beta1"
+    kind = "Usage"
+    metadata = {
+        name = "{}-uses-flux-instance".format(_sourceName(s))
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = "{}-uses-flux-instance".format(_sourceName(s))
+        }
+    }
+    spec = {
+        replayDeletion = True
+        of = {
+            apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+            kind = "Object"
+            resourceRef = {
+                name = _instanceName
+            }
+        }
+        by = {
+            apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+            kind = "Object"
+            resourceRef = {
+                name = _sourceName(s)
+            }
+        }
+    }
+} for s in _sources]
+
+_fluxResources = ([_helmRelease, _fluxInstance, _fluxInstanceUsage] + _sopsResources + _sourceObjects + _sourceUsages) if _observeReady else []
 
 items = _observeResources + _fluxResources + [_xrStatus]


### PR DESCRIPTION
Two modules, both driven by things found running this on kind1.

## xplane-flux-catalog 0.1.2

**`get()` printed its own placeholders.** KCL does not interpolate `${}` inside `assert` messages, so a typo'd app name reported literally:

```
unknown app '${name}' — known: ${_known}
```

Now: `unknown app 'halplamp' — known: dapr, headlamp`. (Docstrings *do* interpolate — a `${VAR}` inside one broke the build while fixing this. The two behave oppositely.)

**headlamp added.** Single component, so `path` is the artifact root `"./"` rather than a `components/` subdirectory — the first entry to exercise that shape. Wraps a HelmRelease, so it carries the 15m timeout the invariant requires.

**`Component.requiredSubstitutions` added.** headlamp's `DOMAIN`, `HOSTNAME` and `GATEWAY_NAME` have **no default** in the manifests, and Flux substitutes an undefined variable with an **empty string rather than failing** — so without this, enabling headlamp deploys something silently broken. Declared for dapr's `template-execution` too (`GITHUB_TOKEN` / `BACKSTAGE_AUTH_TOKEN` / `REDIS_PASSWORD`, normally supplied via `substituteFrom`).

Enforcement lands in `xplane-platform` once this is published — this PR only declares the facts.

## xplane-flux-init 0.3.0

**A `Usage` per source, so each source deletes before the FluxInstance.**

Found migrating kind1 to the platform umbrella: deleting a `FluxInit` removes composed resources in parallel, and when the FluxInstance went first it took Flux's CRDs with it. provider-kubernetes could then no longer observe an `OCIRepository` to finalise its Object:

```
observe failed: cannot get object: no matches for kind "OCIRepository" in version "source.toolkit.fluxcd.io/v1"
```

The Object hung on `finalizer.managedresource.crossplane.io` and had to be unstuck by hand. The `crossplane.io/uses` annotation already on the source Objects is **decorative** — a `Usage` is what actually orders deletion.

Teardown is now `source → instance → operator`:

```
Usage t-flux-instance-uses-operator     of=Release/t-flux-operator   by=Object/t-flux-instance
Usage t-source-dapr-uses-flux-instance  of=Object/t-flux-instance    by=Object/t-source-dapr
```

## Follow-ups

- `xplane-platform` 0.1.1: bump the catalog pin and enforce `requiredSubstitutions`.
- `flux-init` Configuration: bump its module pin to 0.3.0 (this is a behaviour change to teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo