### PR TITLE
feat(xplane-platform): enforce requiredSubstitutions, catalog 0.1.2 (0.1.1)

### DIFF
--- a/crossplane/xplane-platform/README.md
+++ b/crossplane/xplane-platform/README.md
@@ -28,7 +28,14 @@ Here, one toggle produces both:
 spec:
   clusterName: kind1
   apps:
-    dapr: {}
+    dapr:
+      components:
+        template-execution:
+          # requires GITHUB_TOKEN / BACKSTAGE_AUTH_TOKEN / REDIS_PASSWORD —
+          # either point at a Secret as here, or set enabled: false
+          substituteFrom:
+            - kind: Secret
+              name: dapr-backstage-template-execution-vars
 ```
 
 → an `OCIRepository` named `dapr` on the FluxInit child, **and** a
@@ -57,6 +64,7 @@ where it could not be tested at all.
 | apps enabled while `fluxInit.enabled: false` | rejected — fluxInit creates the sources apps reference |
 | a component depending on a **disabled** sibling | rejected, naming the offenders — it would otherwise sit in `DependencyNotReady` forever |
 | unknown app name | rejected by the catalog |
+| required substitution variable not supplied | rejected — Flux substitutes empty strings rather than failing, so this would deploy silently broken. Satisfied by `substitute` keys, or skipped when the component carries a `substituteFrom` (resolved at build time, not statically checkable) |
 | disabling an app | prunes it — the entry stops being emitted, and flux-apps' Objects use `managementPolicies: ["*"]`, so the Kustomization and its workload are removed |
 
 ## Overrides

--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.1.1" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.1.2" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.1.1"
-    version = "0.1.1"
-    sum = "5OaQbM9OekmMCRYEl114Ew5eew106PMbCau57nP0eL8="
+    full_name = "xplane-flux-catalog_0.1.2"
+    version = "0.1.2"
+    sum = "OWn3PMC14v+7f0+YgIdjeiaOEz9tLMNVsjUJod3QNQY="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.1.1"
+    oci_tag = "0.1.2"

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -82,6 +82,30 @@ appEntries = lambda spec: {str:} -> [{str:}] {
     } for _c in cat.get(_n).components if isEnabled((_a?.components or {})[_c.name] or {})] for _n, _a in enabledApps(spec)], [])
 }
 
+_compOverride = lambda app: {str:}, name: str -> {str:} {
+    (app?.components or {})[name] or {}
+}
+
+_appMissing = lambda name: str, app: {str:} -> [str] {
+    """Required vars of one app that nothing supplies. A component carrying
+    substituteFrom is skipped — its values come from a ConfigMap/Secret resolved
+    at build time, which cannot be checked statically."""
+    _supplied = lambda cname: str -> {str:} {
+        (app?.substitute or {}) | (_compOverride(app, cname)?.substitute or {})
+    }
+    _checked = [c for c in cat.get(name).components if isEnabled(_compOverride(app, c.name)) and not _compOverride(app, c.name)?.substituteFrom]
+    sum([[name + "-" + c.name + ": " + v for v in c.requiredSubstitutions if v not in _supplied(c.name)] for c in _checked], [])
+}
+
+missingSubstitutions = lambda spec: {str:} -> [str] {
+    """Required substitution variables that nothing supplies.
+
+    Flux replaces an undefined variable with an empty string instead of failing,
+    so a missing one is a silently broken deploy — that is what this catches.
+    """
+    sum([_appMissing(n, a) for n, a in enabledApps(spec)], [])
+}
+
 validate = lambda spec: {str:} -> bool {
     """Rules that must hold before anything is emitted.
 
@@ -100,5 +124,7 @@ validate = lambda spec: {str:} -> bool {
     # KCL does NOT interpolate ${} inside assert messages — it prints the
     # placeholder literally. Concatenate so the message names the offenders.
     assert len(_badDeps) == 0, "these components depend on a disabled component: " + ", ".join(_badDeps)
+    _missing = missingSubstitutions(spec)
+    assert len(_missing) == 0, "required substitution variables are not supplied (Flux substitutes empty strings rather than failing, so this would deploy silently broken): " + ", ".join(_missing)
     True
 }

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -2,9 +2,17 @@
 # These are the rules that would otherwise only be observable on a live cluster.
 import .logic as l
 
+# template-execution requires GITHUB_TOKEN / BACKSTAGE_AUTH_TOKEN / REDIS_PASSWORD,
+# so a bare {dapr = {}} is now correctly rejected — supply them via substituteFrom.
 _dapr = {
     apps = {
-        dapr = {}
+        dapr = {
+            components = {
+                "template-execution" = {
+                    substituteFrom = [{kind = "Secret", name = "dapr-vars"}]
+                }
+            }
+        }
     }
 }
 
@@ -112,4 +120,40 @@ test_apps_without_fluxinit_is_rejected = lambda {
     assert l.validate({
         fluxInit = {enabled = False}
     })
+}
+
+# A component whose required vars are neither in substitute nor covered by a
+# substituteFrom must be rejected — Flux would substitute empty strings and
+# deploy something broken without ever failing.
+test_missing_required_substitutions_detected = lambda {
+    m = l.missingSubstitutions({
+        apps = {
+            dapr = {}
+        }
+    })
+    assert len(m) == 3, "dapr template-execution has 3 required vars"
+    assert "dapr-template-execution: GITHUB_TOKEN" in m
+}
+
+test_substitutefrom_satisfies_required = lambda {
+    assert len(l.missingSubstitutions(_dapr)) == 0
+}
+
+test_explicit_substitute_satisfies_required = lambda {
+    spec = {
+        apps = {
+            headlamp = {
+                substitute = {DOMAIN = "d", HOSTNAME = "h", GATEWAY_NAME = "g"}
+            }
+        }
+    }
+    assert len(l.missingSubstitutions(spec)) == 0
+}
+
+test_headlamp_missing_vars_detected = lambda {
+    assert len(l.missingSubstitutions({
+        apps = {
+            headlamp = {}
+        }
+    })) == 3
 }


### PR DESCRIPTION
Flux replaces an undefined substitution variable with an **empty string instead of failing**, so an app whose required vars are unsupplied deploys *silently broken* — a green Kustomization pointing at an HTTPRoute with an empty host, or a Deployment with an empty tag.

`xplane-flux-catalog` 0.1.2 declares which vars have no manifest default (#76). This enforces them:

```
required substitution variables are not supplied (Flux substitutes empty strings
rather than failing, so this would deploy silently broken):
headlamp-app: DOMAIN, headlamp-app: HOSTNAME, headlamp-app: GATEWAY_NAME
```

A component carrying `substituteFrom` is **skipped** — its values come from a ConfigMap/Secret resolved at build time, which cannot be checked statically.

## It found a real bug immediately

`apps: {dapr: {}}` — the one-toggle example in the module README, and my own test fixture — **was invalid all along**. dapr's `template-execution` needs `GITHUB_TOKEN` / `BACKSTAGE_AUTH_TOKEN` / `REDIS_PASSWORD`, so that snippet would have deployed a broken component. Both are corrected to either supply a `substituteFrom` or disable the component.

The kind1 deployment happened to be fine because it disables `template-execution` explicitly — the documented example was the wrong one.

## Verification

15 unit tests. The rejection itself is verified **out-of-process**: KCL has no try/catch, so an in-process test cannot assert that an `assert` fires — a test calling `validate()` on valid input proves nothing.

Also bumps the catalog pin to 0.1.2, which brings headlamp and the fixed `get()` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo