### PR TITLE
feat(kcl): cross-artifact dependsOn + optional components (catalog 0.2.1, platform 0.2.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/README.md
+++ b/crossplane/xplane-flux-catalog/README.md
@@ -35,6 +35,30 @@ catalog_test.k    invariants — run with `kcl test`
 KCL has no file globbing, so apps are registered explicitly. Adding one is a
 two-line diff in `main.k` plus the new file.
 
+## Dependencies
+
+`Component.dependsOn` takes two forms:
+
+```kcl
+dependsOn = ["control-plane"]           # a sibling component of this app
+dependsOn = ["cert-manager:install"]    # a component of ANOTHER app
+```
+
+Both resolve to the emitted Kustomization name `{app}-{component}`, which is
+globally unique because app names are. Cross-artifact dependencies are real:
+`trust-manager` cannot reconcile before cert-manager's CRDs exist.
+
+A consumer must **reject** a reference whose target app or component is not
+enabled — `xplane-platform` does, naming what to add. Flux would otherwise leave
+the Kustomization in `DependencyNotReady` indefinitely.
+
+## Optional components
+
+`Component.optional = True` marks an opt-in extra that is **not** deployed unless
+the XR names it. cert-manager's `selfsigned` issuer needs a domain; defaulting it
+to enabled would make installing cert-manager at all require an unrelated
+variable.
+
 ## Adding an app
 
 1. `apps/<name>.k` — declare the artifact, default tag and components. Paths are

--- a/crossplane/xplane-flux-catalog/apps/cert_manager.k
+++ b/crossplane/xplane-flux-catalog/apps/cert_manager.k
@@ -1,0 +1,30 @@
+import ..schema as s
+
+# cert-manager — https://github.com/stuttgart-things/flux/tree/main/infra/cert-manager
+#
+# The artifact root pulls a Vault PKI post-release (VAULT_ADDR, VAULT_ROLE_ID,
+# VAULT_SECRET_ID, ...), so the catalog targets the components/ directories
+# instead: ./components/install is a plain cert-manager install with no Vault
+# dependency, which is what other artifacts depend on.
+#
+# selfsigned is optional and off unless enabled; it needs a domain.
+# (components/extra-certificate exists too — add it when something needs it.)
+certManager: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/infra/cert-manager"
+    defaultVersion = "v1.18.1"
+    components = [
+        s.Component {
+            name = "install"
+            path = "./components/install"
+            wrapsHelmRelease = True
+            timeout = "15m"
+        }
+        s.Component {
+            name = "selfsigned"
+            path = "./components/selfsigned"
+            optional = True
+            dependsOn = ["install"]
+            requiredSubstitutions = ["CERT_MANAGER_SELFSIGNED_DOMAIN"]
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/apps/trust_manager.k
+++ b/crossplane/xplane-flux-catalog/apps/trust_manager.k
@@ -1,0 +1,24 @@
+import ..schema as s
+
+# trust-manager — https://github.com/stuttgart-things/flux/tree/main/infra/trust-manager
+#
+# The first CROSS-ARTIFACT dependency in the catalog: trust-manager's CRDs and
+# webhook require cert-manager, so it cannot reconcile until cert-manager's own
+# Kustomization is Ready. The upstream README states this as
+# `dependsOnNames=cert-manager-install`, which is exactly the name this catalog
+# emits for cert-manager's install component.
+#
+# All of its own variables have manifest defaults, so nothing is required.
+trustManager: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/infra/trust-manager"
+    defaultVersion = "v1.18.1"
+    components = [
+        s.Component {
+            name = "install"
+            path = "./"
+            wrapsHelmRelease = True
+            timeout = "15m"
+            dependsOn = ["cert-manager:install"]
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -11,17 +11,33 @@ test_get_returns_app = lambda {
     assert c.get("dapr").defaultVersion == "v1.18.1"
 }
 
-# Every dependsOn must name a component that exists in the SAME app — a typo
-# here would otherwise surface as a Kustomization stuck in DependencyNotReady
-# on a live cluster, which is a slow and confusing way to find it.
+# Every dependsOn must resolve to a component that actually exists — either a
+# sibling in the same app, or "app:component" in another app. A typo would
+# otherwise surface only as a Kustomization stuck in DependencyNotReady on a
+# live cluster, which is a slow and confusing way to find it.
+_depApp = lambda owner: str, dep: str -> str {
+    dep.split(":")[0] if ":" in dep else owner
+}
+_depComponent = lambda dep: str -> str {
+    dep.split(":")[1] if ":" in dep else dep
+}
+
 test_dependson_targets_exist = lambda {
     assert all _n, app in c.catalog {
         all comp in app.components {
             all dep in comp.dependsOn {
-                dep in [x.name for x in app.components]
+                _depApp(_n, dep) in c.catalog and _depComponent(dep) in [x.name for x in c.catalog[_depApp(_n, dep)].components]
             }
         }
-    }, "a dependsOn entry names a component that does not exist in its app"
+    }, "a dependsOn entry names a component that does not exist"
+}
+
+# The first cross-artifact dependency: trust-manager cannot reconcile before
+# cert-manager's CRDs exist.
+test_cross_artifact_dependson = lambda {
+    tm = c.get("trust-manager").components[0]
+    assert tm.dependsOn == ["cert-manager:install"]
+    assert "install" in [x.name for x in c.get("cert-manager").components]
 }
 
 # Component names must be unique within an app; duplicates would collide on the
@@ -53,4 +69,12 @@ test_headlamp_is_registered = lambda {
 # string and deploys something silently broken.
 test_headlamp_declares_required_substitutions = lambda {
     assert c.get("headlamp").components[0].requiredSubstitutions == ["DOMAIN", "HOSTNAME", "GATEWAY_NAME"]
+}
+
+# Opt-in extras must not default to enabled: cert-manager's selfsigned issuer
+# needs a domain, and requiring it just to install cert-manager would be wrong.
+test_optional_components_are_marked = lambda {
+    cm = {x.name: x for x in c.get("cert-manager").components}
+    assert not cm["install"].optional, "the base install is not optional"
+    assert cm["selfsigned"].optional
 }

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.1.2"
+version = "0.2.1"

--- a/crossplane/xplane-flux-catalog/main.k
+++ b/crossplane/xplane-flux-catalog/main.k
@@ -3,13 +3,17 @@
 # KCL has no file globbing, so every app is registered explicitly: add
 # apps/<name>.k, then one import and one entry here. Keeping it manual is the
 # point — adding an app to the platform is a reviewable two-line diff.
+import .apps.cert_manager as cert_manager
 import .apps.dapr as dapr
 import .apps.headlamp as headlamp
+import .apps.trust_manager as trust_manager
 import schema as s
 
 catalog: {str:s.App} = {
+    "cert-manager" = cert_manager.certManager
     dapr = dapr.dapr
     headlamp = headlamp.headlamp
+    "trust-manager" = trust_manager.trustManager
 }
 
 names = sorted(catalog)

--- a/crossplane/xplane-flux-catalog/schema.k
+++ b/crossplane/xplane-flux-catalog/schema.k
@@ -23,7 +23,19 @@ schema Component:
     so this is './components/control-plane', not './apps/dapr/components/...'"""
 
     dependsOn?: [str] = []
-    """Other component names (within this app) that must be Ready first"""
+    """Components that must be Ready first.
+
+    Two forms:
+      "control-plane"          another component of THIS app
+      "cert-manager:install"   a component of ANOTHER app (cross-artifact)
+
+    Both resolve to the emitted Kustomization name '{app}-{component}', which is
+    globally unique because app names are. Cross-artifact dependencies are real:
+    trust-manager cannot reconcile before cert-manager's CRDs exist.
+
+    A consumer must reject a reference whose target app or component is not
+    enabled — Flux would otherwise leave the Kustomization in DependencyNotReady
+    indefinitely."""
 
     timeout?: str
     """Overrides the FluxApps default. Set 15m on components that wrap a
@@ -36,6 +48,13 @@ schema Component:
     so a missing one is a silently broken deploy. Consumers should reject an app
     whose required vars are neither in `substitute` nor plausibly supplied by a
     `substituteFrom` source."""
+
+    optional?: bool = False
+    """Opt-in extra: NOT deployed unless the XR enables it explicitly.
+
+    Some artifacts ship pieces most clusters do not want — cert-manager's
+    selfsigned issuer, extra certificates. Defaulting those to enabled would make
+    the base app unusable without supplying their variables."""
 
     wrapsHelmRelease?: bool = False
     """Documentation flag: this component installs a HelmRelease. Explains why

--- a/crossplane/xplane-platform/README.md
+++ b/crossplane/xplane-platform/README.md
@@ -64,6 +64,9 @@ where it could not be tested at all.
 | apps enabled while `fluxInit.enabled: false` | rejected — fluxInit creates the sources apps reference |
 | a component depending on a **disabled** sibling | rejected, naming the offenders — it would otherwise sit in `DependencyNotReady` forever |
 | unknown app name | rejected by the catalog |
+| a dependency's app is not enabled | rejected, naming what to add: `trust-manager-install depends on cert-manager:install, but app 'cert-manager' is not enabled — add it to spec.apps`. Deliberately **not** auto-enabled: a toggle that silently installs artifacts you did not list gets confusing with transitive chains, and conflicts with disable-prunes |
+| a dependency's component is disabled | rejected the same way |
+| catalog `optional` components | not deployed unless the XR enables them explicitly |
 | required substitution variable not supplied | rejected — Flux substitutes empty strings rather than failing, so this would deploy silently broken. Satisfied by `substitute` keys, or skipped when the component carries a `substituteFrom` (resolved at build time, not statically checkable) |
 | disabling an app | prunes it — the entry stops being emitted, and flux-apps' Objects use `managementPolicies: ["*"]`, so the Kustomization and its workload are removed |
 

--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.1.2" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.2.1" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.1.2"
-    version = "0.1.2"
-    sum = "OWn3PMC14v+7f0+YgIdjeiaOEz9tLMNVsjUJod3QNQY="
+    full_name = "xplane-flux-catalog_0.2.1"
+    version = "0.2.1"
+    sum = "SqTtGS1jVbiTiFxRVMuYfo5Tct5n9/MMwXDRol0gnTw="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.1.2"
+    oci_tag = "0.2.1"

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -35,6 +35,13 @@ isEnabled = lambda block: {str:} -> bool {
     block.enabled if "enabled" in block else True
 }
 
+compEnabled = lambda comp: any, override: {str:} -> bool {
+    """A component's enablement. Catalog `optional` components are opt-in: they
+    are not deployed unless the XR names them, because they ship variables the
+    base app does not need (cert-manager's selfsigned issuer wants a domain)."""
+    override.enabled if "enabled" in override else not comp.optional
+}
+
 enabledApps = lambda spec: {str:} -> {str:} {
     """spec.apps entries that are enabled. Map, not list, so overrides merge."""
     {k: v for k, v in (spec?.apps or {}) if isEnabled(v or {})}
@@ -42,6 +49,21 @@ enabledApps = lambda spec: {str:} -> {str:} {
 
 fluxInitEnabled = lambda spec: {str:} -> bool {
     isEnabled(spec?.fluxInit or {})
+}
+
+depApp = lambda owner: str, dep: str -> str {
+    """Owning app of a dependsOn reference. "cert-manager:install" is
+    cross-artifact; a bare name is a sibling in the same app."""
+    dep.split(":")[0] if ":" in dep else owner
+}
+
+depComponent = lambda dep: str -> str {
+    dep.split(":")[1] if ":" in dep else dep
+}
+
+depName = lambda owner: str, dep: str -> str {
+    """The emitted Kustomization name — globally unique, since app names are."""
+    depApp(owner, dep) + "-" + depComponent(dep)
 }
 
 appSources = lambda spec: {str:} -> [{str:}] {
@@ -70,7 +92,7 @@ appEntries = lambda spec: {str:} -> [{str:}] {
         path = _c.path
         sourceRef = {kind = "OCIRepository", name = _n}
         if _c.dependsOn:
-            dependsOn = [{name = "{}-{}".format(_n, _d)} for _d in _c.dependsOn]
+            dependsOn = [{name = depName(_n, _d)} for _d in _c.dependsOn]
         if (((_a?.components or {})[_c.name] or {})?.timeout or _c.timeout):
             timeout = ((_a?.components or {})[_c.name] or {})?.timeout or _c.timeout
         if (_a?.substitute or {}) | (((_a?.components or {})[_c.name] or {})?.substitute or {}):
@@ -79,7 +101,7 @@ appEntries = lambda spec: {str:} -> [{str:}] {
             substituteFrom = ((_a?.components or {})[_c.name] or {}).substituteFrom
         if (((_a?.components or {})[_c.name] or {})?.targetNamespace or _a?.targetNamespace):
             targetNamespace = ((_a?.components or {})[_c.name] or {})?.targetNamespace or _a?.targetNamespace
-    } for _c in cat.get(_n).components if isEnabled((_a?.components or {})[_c.name] or {})] for _n, _a in enabledApps(spec)], [])
+    } for _c in cat.get(_n).components if compEnabled(_c, (_a?.components or {})[_c.name] or {})] for _n, _a in enabledApps(spec)], [])
 }
 
 _compOverride = lambda app: {str:}, name: str -> {str:} {
@@ -93,7 +115,7 @@ _appMissing = lambda name: str, app: {str:} -> [str] {
     _supplied = lambda cname: str -> {str:} {
         (app?.substitute or {}) | (_compOverride(app, cname)?.substitute or {})
     }
-    _checked = [c for c in cat.get(name).components if isEnabled(_compOverride(app, c.name)) and not _compOverride(app, c.name)?.substituteFrom]
+    _checked = [c for c in cat.get(name).components if compEnabled(c, _compOverride(app, c.name)) and not _compOverride(app, c.name)?.substituteFrom]
     sum([[name + "-" + c.name + ": " + v for v in c.requiredSubstitutions if v not in _supplied(c.name)] for c in _checked], [])
 }
 
@@ -106,6 +128,32 @@ missingSubstitutions = lambda spec: {str:} -> [str] {
     sum([_appMissing(n, a) for n, a in enabledApps(spec)], [])
 }
 
+_compEnabled = lambda apps: {str:}, appName: str, compName: str -> bool {
+    """Is a (possibly cross-app) component enabled in this XR?"""
+    _match = [c for c in cat.get(appName).components if c.name == compName]
+    len(_match) > 0 and compEnabled(_match[0], ((apps[appName] or {})?.components or {})[compName] or {})
+}
+
+appDepProblems = lambda name: str, app: {str:}, apps: {str:} -> [str] {
+    """Dependencies of one app that cannot be satisfied by this XR.
+
+    Deliberately rejects rather than auto-enabling the missing app: a toggle that
+    silently installs artifacts you did not list gets confusing with transitive
+    chains, and it conflicts with disable-prunes. The message names what to add.
+    """
+    _checked = [c for c in cat.get(name).components if compEnabled(c, _compOverride(app, c.name))]
+    _pairs = sum([[{owner = c.name, dep = d} for d in c.dependsOn] for c in _checked], [])
+    _noApp = [name + "-" + p.owner + " depends on " + p.dep + ", but app '" + depApp(name, p.dep) + "' is not enabled — add it to spec.apps" for p in _pairs if depApp(name, p.dep) not in apps]
+    _offComp = [name + "-" + p.owner + " depends on " + p.dep + ", but component '" + depComponent(p.dep) + "' of app '" + depApp(name, p.dep) + "' is disabled — enable it or drop the dependency" for p in _pairs if depApp(name, p.dep) in apps and not _compEnabled(apps, depApp(name, p.dep), depComponent(p.dep))]
+    _noApp + _offComp
+}
+
+depProblems = lambda spec: {str:} -> [str] {
+    """Every unsatisfiable dependency in this XR, as human-readable messages."""
+    _apps = enabledApps(spec)
+    sum([appDepProblems(_n, _a, _apps) for _n, _a in _apps], [])
+}
+
 validate = lambda spec: {str:} -> bool {
     """Rules that must hold before anything is emitted.
 
@@ -116,14 +164,13 @@ validate = lambda spec: {str:} -> bool {
     _apps = enabledApps(spec)
     assert fluxInitEnabled(spec) or len(_apps) == 0, "apps are enabled but fluxInit is disabled — fluxInit creates the Flux sources every app references; enable fluxInit or disable all apps"
 
-    # A component depending on a disabled sibling would sit in DependencyNotReady
-    # forever; fail at render instead. Flattened rather than nested `all`, which
-    # does not capture the outer loop binding.
-    _badDeps = sum([["{}-{}".format(_n, _c.name) for _c in cat.get(_n).components if isEnabled((_a?.components or {})[_c.name] or {}) and len([_d for _d in _c.dependsOn if not isEnabled((_a?.components or {})[_d] or {})]) > 0] for _n, _a in _apps], [])
-
+    # An unsatisfiable dependency would sit in DependencyNotReady forever; fail at
+    # render instead, naming what to add. Covers cross-artifact references
+    # ("cert-manager:install") as well as siblings.
     # KCL does NOT interpolate ${} inside assert messages — it prints the
-    # placeholder literally. Concatenate so the message names the offenders.
-    assert len(_badDeps) == 0, "these components depend on a disabled component: " + ", ".join(_badDeps)
+    # placeholder literally — so the messages are concatenated.
+    _depProblems = depProblems(spec)
+    assert len(_depProblems) == 0, "unsatisfiable dependencies — " + "; ".join(_depProblems)
     _missing = missingSubstitutions(spec)
     assert len(_missing) == 0, "required substitution variables are not supplied (Flux substitutes empty strings rather than failing, so this would deploy silently broken): " + ", ".join(_missing)
     True

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -157,3 +157,80 @@ test_headlamp_missing_vars_detected = lambda {
         }
     })) == 3
 }
+
+# --- cross-artifact dependsOn -------------------------------------------------
+
+# trust-manager cannot reconcile before cert-manager's CRDs exist; the reference
+# must resolve to cert-manager's emitted Kustomization name, not trust-manager's.
+test_cross_artifact_dependson_resolves = lambda {
+    e = [x for x in l.appEntries({
+        apps = {"trust-manager" = {}, "cert-manager" = {}}
+    }) if x.name == "trust-manager-install"][0]
+    assert e.dependsOn == [{name = "cert-manager-install"}]
+}
+
+# Rejected, not auto-enabled: a toggle that silently installs artifacts you did
+# not list gets confusing with transitive chains.
+test_missing_dependency_app_is_reported = lambda {
+    p = l.depProblems({
+        apps = {
+            "trust-manager" = {}
+        }
+    })
+    assert len(p) == 1
+    assert "add it to spec.apps" in p[0], "the message must name the fix"
+    assert "cert-manager" in p[0]
+}
+
+test_disabled_dependency_component_is_reported = lambda {
+    p = l.depProblems({
+        apps = {"trust-manager" = {}, "cert-manager" = {
+            components = {
+                install = {enabled = False}
+            }
+        }}
+    })
+    assert len([x for x in p if "is disabled" in x]) > 0
+}
+
+test_satisfied_dependency_has_no_problems = lambda {
+    assert len(l.depProblems({
+        apps = {"trust-manager" = {}, "cert-manager" = {}}
+    })) == 0
+}
+
+# --- optional components ------------------------------------------------------
+
+# cert-manager's selfsigned issuer needs a domain; requiring it just to install
+# cert-manager would make the base app unusable.
+test_optional_component_not_emitted_by_default = lambda {
+    names = [e.name for e in l.appEntries({
+        apps = {
+            "cert-manager" = {}
+        }
+    })]
+    assert "cert-manager-install" in names
+    assert "cert-manager-selfsigned" not in names
+}
+
+test_optional_component_emitted_when_enabled = lambda {
+    spec = {
+        apps = {
+            "cert-manager" = {
+                components = {
+                    selfsigned = {enabled = True, substitute = {CERT_MANAGER_SELFSIGNED_DOMAIN = "example.com"}}
+                }
+            }
+        }
+    }
+    assert "cert-manager-selfsigned" in [e.name for e in l.appEntries(spec)]
+}
+
+# An optional component that is off must not have its required vars demanded.
+test_optional_component_vars_not_required_when_off = lambda {
+    assert len(l.missingSubstitutions({
+        apps = {
+            "cert-manager" = {}
+        }
+    })) == 0
+}


### PR DESCRIPTION
Solves the cross-artifact `dependsOn` gap from stuttgart-things/crossplane-configurations#107.

## The problem

`trust-manager` cannot reconcile before cert-manager's CRDs exist — a dependency **across artifacts**. The catalog's `dependsOn` was within-app only: names were rewritten to `{app}-{component}`, so one artifact could not reference another's Kustomization.

## Qualified references

```kcl
dependsOn = ["control-plane"]           # sibling component of this app
dependsOn = ["cert-manager:install"]    # component of ANOTHER app
```

Both resolve to `{app}-{component}`, which is globally unique because app names are. Pleasingly, the upstream trust-manager README already states its dependency as `dependsOnNames=cert-manager-install` — exactly the name this catalog emits.

Chosen over a structured `{app, component}` schema because the app files stay readable and the one existing `dependsOn` keeps working. Worth revisiting only if infra and apps land in **different namespaces**, since Flux's `dependsOn` would then need a `namespace` too.

## Reject, don't auto-enable

```
unsatisfiable dependencies — trust-manager-install depends on cert-manager:install,
but app 'cert-manager' is not enabled — add it to spec.apps
```

Auto-enabling would silently install artifacts the user never listed, which gets confusing with transitive chains and conflicts with disable-prunes. The message names the fix instead.

## First infra entries — which surfaced a second gap

Added `cert-manager` and `trust-manager`. cert-manager's `selfsigned` issuer requires `CERT_MANAGER_SELFSIGNED_DOMAIN`, so with everything defaulting to enabled, **installing cert-manager at all demanded an unrelated variable**. `Component.optional` marks opt-in extras; they are not deployed unless the XR names them.

```
apps: {cert-manager: {}}                    → cert-manager-install
apps: {cert-manager: {components: {selfsigned: {enabled: true, substitute: {...}}}}}
                                            → cert-manager-install, cert-manager-selfsigned
```

## A bug this caught

Implementing `optional`, I updated the enablement predicate in the validation paths but **not** the emission path — so validation skipped `selfsigned` while `appEntries` still emitted it. The suite passed; only inspecting rendered output revealed it. All five call sites now share one predicate.

## Verification

22 tests. Both new behaviours verified to **FAIL** when the feature is disabled (optional ignored → emits everything; cross-app refs owner-prefixed → wrong dependency name), and the rejection messages verified **out-of-process**, since KCL cannot assert that an `assert` fires.

Modules pushed from local (`kcl mod push`) — catalog `0.2.1`, platform `0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo