### PR TITLE
fix(ci): make the version-exists guard actually work

### DIFF
--- a/.github/workflows/kcl-module-ci.yaml
+++ b/.github/workflows/kcl-module-ci.yaml
@@ -234,14 +234,27 @@ jobs:
 
       - name: Check if version exists in registry
         id: check-version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Try to pull the specific version
-          if kcl mod metadata ${{ steps.metadata.outputs.oci_ref }} --tag ${{ steps.metadata.outputs.version }} 2>/dev/null; then
+          # Ask the packages API which tags exist. The previous check ran
+          #   kcl mod metadata <ref> --tag <version>
+          # which fails with "unknown flag: --tag" — 'kcl mod metadata' has no
+          # such flag — so it ALWAYS reported exists=false. That went unnoticed
+          # while CI was the only publisher (the version was always new), and
+          # surfaced the first time a module was pushed from a workstation:
+          # the merge run then tried to republish and 'kcl mod push' exits 1
+          # with "package version 'x.y.z' already exists".
+          NAME="${{ steps.metadata.outputs.name }}"
+          VERSION="${{ steps.metadata.outputs.version }}"
+          TAGS=$(gh api "/orgs/${{ github.repository_owner }}/packages/container/${NAME}/versions" \
+                   --jq '.[].metadata.container.tags[]' 2>/dev/null || true)
+          if echo "${TAGS}" | grep -qx "${VERSION}"; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "⚠️  Version ${{ steps.metadata.outputs.version }} already exists in registry"
+            echo "⚠️  Version ${VERSION} already exists in registry — skipping publish"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "✅ Version ${{ steps.metadata.outputs.version }} does not exist, will publish"
+            echo "✅ Version ${VERSION} does not exist, will publish"
           fi
 
       # 'kcl registry login' cannot be used here: it stores the credential via


### PR DESCRIPTION
The guard ran:

```bash
kcl mod metadata <ref> --tag <version>
```

`kcl mod metadata` has **no `--tag` flag**. It exits non-zero with `unknown flag: --tag`, so the check always reported `exists=false` and the publish step always ran.

```console
$ kcl mod metadata oci://ghcr.io/stuttgart-things/xplane-platform --tag 0.2.0
unknown flag: --tag
```

Invisible while CI was the only publisher — the version was always new, so publishing unconditionally was indistinguishable from skipping correctly.

It surfaced when modules were pushed from a workstation (currently necessary for `xplane-flux-init`, whose ghcr package predates this workflow and doesn't grant it write access — see stuttgart-things/crossplane-configurations#107). The merge run then tries to republish an existing version:

```
⚠️  Version 0.2.1 already exists in registry     ← the echo, from the always-false branch
package version '0.2.1' already exists
##[error]Process completed with exit code 1
```

…failing an otherwise good build, on both `xplane-flux-catalog` and `xplane-platform`.

Replaced with a packages-API query, which is deterministic and needs no registry auth for public packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo