### PR TITLE
feat(kcl): xplane-cni 0.1.0, platform composes + gates on it (0.3.0)

### DIFF
--- a/crossplane/xplane-cni/README.md
+++ b/crossplane/xplane-cni/README.md
@@ -1,0 +1,64 @@
+# xplane-cni
+
+`function-kcl` module behind the [`cni`](https://github.com/stuttgart-things/crossplane-configurations/tree/main/bootstrap/cni)
+Crossplane Configuration. Installs a CNI on a target cluster and reports when it
+is up.
+
+```
+Cni XR
+ ├─ kubernetes.m.crossplane.io Object   RemoteCluster (Observe) — gate
+ └─ helm.m.crossplane.io Release        the CNI chart (cilium today)
+```
+
+## Why this is its own component
+
+A cluster with no CNI has NotReady nodes, so nothing schedules. A Helm install
+aimed at such a cluster does not fail fast — it times out and retries. So every
+other platform component has to wait for `status.ready` here rather than race
+it; `xplane-platform` gates its FluxInit/FluxApps children on exactly that.
+
+## Spec
+
+| field | default | notes |
+|---|---|---|
+| `clusterName` | — | derives `{clusterName}-helm` and the API server address |
+| `helmProviderConfigRef` | `{clusterName}-helm` | explicit wins |
+| `observeProviderConfigRef` | `in-cluster` | management cluster, for the gate |
+| `provider` | `cilium` | only supported value today |
+| `namespace` | `kube-system` | |
+| `chart.version` / `chart.repository` | `1.19.6` / `https://helm.cilium.io/` | |
+| `cilium.kubeProxyReplacement` | `true` | |
+| `cilium.k8sServiceHost` | `{clusterName}-control-plane` | |
+| `cilium.k8sServicePort` | `6443` | |
+| `cilium.ipamMode` | `kubernetes` | |
+| `cilium.operatorReplicas` | `1` | |
+| `values` | `{}` | raw Helm values, merged last — wins over everything above |
+
+### The API server address is not a detail
+
+kind runs **without kube-proxy**. Nothing programs the `10.96.0.1` service VIP
+until cilium is up, and cilium cannot come up if it needs that VIP to reach the
+API server. `k8sServiceHost` breaks the circular dependency by naming the
+control-plane container directly — `{clusterName}-control-plane` is exactly what
+kind creates, which is why `clusterName` alone is enough.
+
+`validate()` rejects `kubeProxyReplacement` with no resolvable address rather
+than letting the cluster deadlock silently. With `kubeProxyReplacement: false`
+the host/port are omitted entirely — a real kube-proxy makes normal discovery
+work, and pinning a host would then be wrong, not merely redundant.
+
+## Layout
+
+- `logic.k` — all decisions, no `option("params")`, unit-tested
+- `logic_test.k` — `kcl test .`
+- `main.k` — marshals params in and `items` out
+
+`kcl test .` compiles `main.k` too, so `validate()` is vacuously true on an
+empty spec (no XR to check).
+
+## Local render
+
+```bash
+kcl test .
+kcl run -Y test-settings.yaml
+```

--- a/crossplane/xplane-cni/kcl.mod
+++ b/crossplane/xplane-cni/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "xplane-cni"
+edition = "v0.12.3"
+version = "0.1.0"

--- a/crossplane/xplane-cni/logic.k
+++ b/crossplane/xplane-cni/logic.k
@@ -1,0 +1,96 @@
+"""
+Pure logic for the cni Configuration — no option("params"), so every rule here
+is unit-testable with `kcl test`. main.k is the thin render entry point.
+
+The interesting part is values resolution, not resource emission: a CNI on a
+kind-style cluster needs a handful of settings that are *cluster-shape facts*
+(is there a kube-proxy? where is the API server?) rather than free-form Helm
+values, and getting them wrong deadlocks the cluster silently. Those get named
+fields with defaults derived from clusterName; everything else is passthrough.
+"""
+
+_CHART_DEFAULTS = {
+    cilium = {
+        name = "cilium"
+        repository = "https://helm.cilium.io/"
+        version = "1.19.6"
+    }
+}
+
+chart = lambda spec: {str:} -> {str:} {
+    """Chart coordinates for the selected provider, with spec overrides."""
+    _p = provider(spec)
+    _d = _CHART_DEFAULTS[_p]
+    _c = spec?.chart or {}
+    {
+        name = _d.name
+        repository = _c?.repository or _d.repository
+        version = _c?.version or _d.version
+    }
+}
+
+provider = lambda spec: {str:} -> str {
+    _p = spec?.provider or "cilium"
+    assert _p in _CHART_DEFAULTS, "unsupported CNI provider '" + _p + "' — supported: " + ", ".join(sorted(_CHART_DEFAULTS))
+    _p
+}
+
+apiServerHost = lambda spec: {str:} -> str {
+    """Where cilium reaches the API server when it replaces kube-proxy.
+
+    A kind cluster has NO kube-proxy, so nothing programs the 10.96.0.1 service
+    VIP until cilium is up — and cilium cannot come up if it needs that VIP to
+    talk to the API server. Pointing at the control-plane container by name
+    breaks the circular dependency. `{clusterName}-control-plane` is exactly the
+    container kind creates, which is why clusterName is enough on its own.
+    """
+    _c = spec?.cilium or {}
+    _c?.k8sServiceHost or ("{}-control-plane".format(spec.clusterName) if spec?.clusterName else "")
+}
+
+kubeProxyReplacement = lambda spec: {str:} -> bool {
+    """`or True` would swallow an explicit false, so test for the key."""
+    _c = spec?.cilium or {}
+    _c.kubeProxyReplacement if "kubeProxyReplacement" in _c else True
+}
+
+values = lambda spec: {str:} -> {str:} {
+    """Helm values for the release: computed defaults, then spec.values on top.
+
+    spec.values wins on conflict — it is the escape hatch for anything this
+    module does not model, including overriding what it computed.
+    """
+    _c = spec?.cilium or {}
+    _kpr = kubeProxyReplacement(spec)
+    _host = apiServerHost(spec)
+
+    # Only meaningful with kubeProxyReplacement on, and an empty host would make
+    # cilium fail to start rather than fall back — so omit both unless resolved.
+    _api = {
+        k8sServiceHost = _host
+        k8sServicePort = _c?.k8sServicePort or 6443
+    } if (_kpr and _host) else {}
+
+    {
+        kubeProxyReplacement = _kpr
+        ipam = {mode = _c?.ipamMode or "kubernetes"}
+        operator = {replicas = _c?.operatorReplicas or 1}
+    } | _api | (spec?.values or {})
+}
+
+validate = lambda spec: {str:} -> bool {
+    """Rules that must hold before anything is emitted.
+
+    Vacuously true on an empty spec: that is the module being evaluated with no
+    XR at all (unit tests, bare `kcl run`), not a misconfigured one.
+    """
+    _empty = not spec
+    _ = provider(spec)
+
+    # kubeProxyReplacement with no reachable API server address is the deadlock
+    # this module exists to prevent: cilium waits on a service VIP that only
+    # cilium can program. Fail at render, naming the fix.
+    _resolved = apiServerHost(spec) or (spec?.values or {})?.k8sServiceHost or ""
+    assert _empty or not kubeProxyReplacement(spec) or _resolved, "kubeProxyReplacement is on but no API server address could be resolved — set spec.clusterName (derives {clusterName}-control-plane) or spec.cilium.k8sServiceHost; without it cilium waits on a service VIP that only cilium can program"
+    True
+}

--- a/crossplane/xplane-cni/logic_test.k
+++ b/crossplane/xplane-cni/logic_test.k
@@ -13,7 +13,9 @@ test_chart_defaults = lambda {
 }
 
 test_chart_overrides = lambda {
-    _c = l.chart({chart = {version = "1.20.0", repository = "oci://example.test/charts"}})
+    _c = l.chart({
+        chart = {version = "1.20.0", repository = "oci://example.test/charts"}
+    })
     assert _c.version == "1.20.0"
     assert _c.repository == "oci://example.test/charts"
     # name is not overridable — it identifies the provider
@@ -34,7 +36,9 @@ test_kube_proxy_replacement_defaults_on = lambda {
 
 test_explicit_false_is_not_swallowed = lambda {
     # The `or True` trap: an explicit false must survive.
-    assert l.kubeProxyReplacement({cilium = {kubeProxyReplacement = False}}) == False
+    assert l.kubeProxyReplacement({
+        cilium = {kubeProxyReplacement = False}
+    }) == False
 }
 
 test_values_wire_the_api_server = lambda {

--- a/crossplane/xplane-cni/logic_test.k
+++ b/crossplane/xplane-cni/logic_test.k
@@ -1,0 +1,76 @@
+import .logic as l
+
+test_provider_defaults_to_cilium = lambda {
+    assert l.provider({}) == "cilium"
+    assert l.provider({provider = "cilium"}) == "cilium"
+}
+
+test_chart_defaults = lambda {
+    _c = l.chart({})
+    assert _c.name == "cilium"
+    assert _c.repository == "https://helm.cilium.io/"
+    assert _c.version == "1.19.6"
+}
+
+test_chart_overrides = lambda {
+    _c = l.chart({chart = {version = "1.20.0", repository = "oci://example.test/charts"}})
+    assert _c.version == "1.20.0"
+    assert _c.repository == "oci://example.test/charts"
+    # name is not overridable — it identifies the provider
+    assert _c.name == "cilium"
+}
+
+test_api_host_derives_from_cluster_name = lambda {
+    assert l.apiServerHost({clusterName = "kind-test1"}) == "kind-test1-control-plane"
+}
+
+test_api_host_explicit_wins = lambda {
+    assert l.apiServerHost({clusterName = "kind-test1", cilium = {k8sServiceHost = "10.31.103.22"}}) == "10.31.103.22"
+}
+
+test_kube_proxy_replacement_defaults_on = lambda {
+    assert l.kubeProxyReplacement({}) == True
+}
+
+test_explicit_false_is_not_swallowed = lambda {
+    # The `or True` trap: an explicit false must survive.
+    assert l.kubeProxyReplacement({cilium = {kubeProxyReplacement = False}}) == False
+}
+
+test_values_wire_the_api_server = lambda {
+    _v = l.values({clusterName = "kind-test1"})
+    assert _v.kubeProxyReplacement == True
+    assert _v.k8sServiceHost == "kind-test1-control-plane"
+    assert _v.k8sServicePort == 6443
+    assert _v.ipam.mode == "kubernetes"
+    assert _v.operator.replicas == 1
+}
+
+test_api_server_omitted_without_kube_proxy_replacement = lambda {
+    # With a real kube-proxy present, cilium discovers the API server the normal
+    # way; pinning a host would be wrong, not merely redundant.
+    _v = l.values({clusterName = "kind-test1", cilium = {kubeProxyReplacement = False}})
+    assert "k8sServiceHost" not in _v
+    assert "k8sServicePort" not in _v
+}
+
+test_raw_values_win = lambda {
+    _v = l.values({clusterName = "kind-test1", values = {operator = {replicas = 2}, hubble = {enabled = True}}})
+    assert _v.operator.replicas == 2
+    assert _v.hubble.enabled == True
+    # untouched computed values survive the merge
+    assert _v.k8sServiceHost == "kind-test1-control-plane"
+}
+
+test_validate_accepts_cluster_name = lambda {
+    assert l.validate({clusterName = "kind-test1"}) == True
+}
+
+test_validate_accepts_explicit_host = lambda {
+    assert l.validate({helmProviderConfigRef = "x-helm", cilium = {k8sServiceHost = "1.2.3.4"}}) == True
+}
+
+test_validate_accepts_kube_proxy_cluster = lambda {
+    # No clusterName and no host, but kube-proxy is present — nothing to resolve.
+    assert l.validate({helmProviderConfigRef = "x-helm", cilium = {kubeProxyReplacement = False}}) == True
+}

--- a/crossplane/xplane-cni/main.k
+++ b/crossplane/xplane-cni/main.k
@@ -1,0 +1,137 @@
+"""
+xplane-cni — function-kcl module for the cni Crossplane Configuration.
+
+Installs a CNI on a target cluster:
+  1. kubernetes.m.crossplane.io Object — RemoteCluster observe (gate, optional)
+  2. helm.m.crossplane.io Release      — the CNI chart (cilium today)
+
+Render and status happen in a single pass: the module emits the managed
+resources AND patches the XR status from `ocds` (observed composed resources).
+On the first reconcile `ocds` is empty, so status.ready starts False and
+converges as the Release becomes Ready.
+
+This is the component every other platform component waits on. A cluster with
+no CNI has NotReady nodes, so nothing schedules — a Helm install aimed at it
+does not fail fast, it times out and retries. Consumers should gate on
+status.ready rather than racing it.
+
+All decision logic lives in logic.k so it is unit-testable without Crossplane;
+this file only marshals option("params") in and `items` out.
+"""
+
+import .logic as l
+
+_params = option("params") or {}
+_oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
+
+_spec = _oxr?.spec or {}
+_meta = _oxr?.metadata or {}
+_name = _meta?.name or "cni"
+
+_valid = l.validate(_spec)
+
+# --- Provider config refs: explicit spec wins, else derived from clusterName ---
+# Same derivation as flux-init: {clusterName}-helm / {clusterName}-kubernetes are
+# the names provider-kubeconfig's RemoteCluster creates for the target cluster.
+_clusterName = _spec?.clusterName or ""
+_helmPcr = _spec?.helmProviderConfigRef or ("{}-helm".format(_clusterName) if _clusterName else "")
+_k8sPcr = _spec?.kubernetesProviderConfigRef or ("{}-kubernetes".format(_clusterName) if _clusterName else "")
+_observePcr = _spec?.observeProviderConfigRef or "in-cluster"
+
+_ns = _spec?.namespace or "kube-system"
+_chart = l.chart(_spec)
+
+# --- Resource 1: observe the RemoteCluster (only when clusterName is set) ---
+# Holds the install until the RemoteCluster resolves, so the derived provider
+# config exists before we install through it. Without clusterName there is
+# nothing to observe and the gate is always open.
+_rcKey = "{}-observe-rc".format(_name)
+_observeResources = []
+_clusterType = ""
+if _clusterName:
+    _observeRC = {
+        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+        kind = "Object"
+        metadata = {
+            name = _rcKey
+            namespace = _meta?.namespace
+            annotations = {
+                "krm.kcl.dev/composition-resource-name" = _rcKey
+            }
+        }
+        spec = {
+            managementPolicies = ["Observe"]
+            forProvider = {
+                manifest = {
+                    apiVersion = "kubeconfig.stuttgart-things.com/v1alpha1"
+                    kind = "RemoteCluster"
+                    metadata = {
+                        name = _clusterName
+                    }
+                }
+            }
+            providerConfigRef = {
+                name = _observePcr
+                kind = "ClusterProviderConfig"
+            }
+        }
+    }
+    _observeResources = [_observeRC]
+    _clusterType = _ocds[_rcKey].Resource?.status?.atProvider?.manifest?.status?.atProvider?.clusterType or "" if _rcKey in _ocds else ""
+
+_observeReady = bool(_clusterType) if _clusterName else True
+
+# --- Resource 2: the CNI Helm Release ---
+# external-name is the provider name, not the XR name: the chart owns
+# cluster-wide DaemonSets and CRDs, so two releases of it under different names
+# would fight. Pinning the release name makes a rename of the XR an adoption
+# rather than a second install.
+_releaseName = "{}-{}".format(_name, l.provider(_spec))
+_release = {
+    apiVersion = "helm.m.crossplane.io/v1beta1"
+    kind = "Release"
+    metadata = {
+        name = _releaseName
+        namespace = _ns
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = _releaseName
+            "crossplane.io/external-name" = l.provider(_spec)
+        }
+    }
+    spec = {
+        providerConfigRef = {
+            name = _helmPcr
+            kind = "ClusterProviderConfig"
+        }
+        forProvider = {
+            chart = _chart
+            namespace = _ns
+            values = l.values(_spec)
+        }
+        rollbackLimit = 3
+    }
+}
+
+_cniResources = [_release] if _observeReady else []
+
+# --- Status: read Ready condition off each composed resource via ocds ---
+_isReady = lambda resourceName: str -> bool {
+    _found = resourceName in _ocds
+    _conds = _ocds[resourceName]?.Resource?.status?.conditions or [] if _found else []
+    len([c for c in _conds if c.type == "Ready" and c.status == "True"]) > 0
+}
+
+_releaseReady = _isReady(_releaseName)
+
+_xrStatus = _oxr | {
+    status = {
+        provider = l.provider(_spec)
+        version = _chart.version
+        releaseReady = _releaseReady
+        ready = _releaseReady and _observeReady
+        clusterType = _clusterType
+    }
+}
+
+items = _observeResources + _cniResources + [_xrStatus]

--- a/crossplane/xplane-cni/test-settings.yaml
+++ b/crossplane/xplane-cni/test-settings.yaml
@@ -1,0 +1,20 @@
+kcl_options:
+  - key: params
+    value:
+      oxr:
+        apiVersion: config.stuttgart-things.com/v1alpha1
+        kind: Cni
+        metadata:
+          name: test-cni
+          namespace: crossplane-system
+        spec:
+          clusterName: kind-test1
+          provider: cilium
+          namespace: kube-system
+          chart:
+            version: "1.19.6"
+          cilium:
+            kubeProxyReplacement: true
+            operatorReplicas: 1
+      ocds: {}
+      ctx: {}

--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.2.1" }

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -51,6 +51,29 @@ fluxInitEnabled = lambda spec: {str:} -> bool {
     isEnabled(spec?.fluxInit or {})
 }
 
+cniEnabled = lambda spec: {str:} -> bool {
+    """Opt-IN, unlike every other component.
+
+    Most clusters already have a CNI and installing a second one breaks them, so
+    the default has to be off — the inverse of fluxInit. Only clusters built
+    deliberately blank (this fleet's ansible-provisioned kind clusters) enable it.
+    """
+    (spec?.cni or {})?.enabled or False
+}
+
+gateOpen = lambda ready: bool, exists: bool -> bool {
+    """Should a gated child be emitted?
+
+    `ready` is the gate (e.g. the CNI is up). `exists` says the child is already
+    in ocds, and makes the gate ONE-WAY on purpose: not emitting a child that
+    exists means Crossplane deletes it, so a gate that could re-close would tear
+    Flux down the moment the CNI Release blipped not-Ready during a chart
+    upgrade. The gate is about install ordering, not about continuously
+    enforcing a dependency.
+    """
+    ready or exists
+}
+
 depApp = lambda owner: str, dep: str -> str {
     """Owning app of a dependsOn reference. "cert-manager:install" is
     cross-artifact; a bare name is a sibling in the same app."""

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -239,9 +239,15 @@ test_cni_is_opt_in = lambda {
     # Inverse default from every other component: most clusters already have a
     # CNI and a second one breaks them.
     assert l.cniEnabled({}) == False
-    assert l.cniEnabled({cni = {}}) == False
-    assert l.cniEnabled({cni = {enabled = True}}) == True
-    assert l.cniEnabled({cni = {enabled = False}}) == False
+    assert l.cniEnabled({
+        cni = {}
+    }) == False
+    assert l.cniEnabled({
+        cni = {enabled = True}
+    }) == True
+    assert l.cniEnabled({
+        cni = {enabled = False}
+    }) == False
 }
 
 test_gate_holds_children_until_ready = lambda {

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -234,3 +234,23 @@ test_optional_component_vars_not_required_when_off = lambda {
         }
     })) == 0
 }
+
+test_cni_is_opt_in = lambda {
+    # Inverse default from every other component: most clusters already have a
+    # CNI and a second one breaks them.
+    assert l.cniEnabled({}) == False
+    assert l.cniEnabled({cni = {}}) == False
+    assert l.cniEnabled({cni = {enabled = True}}) == True
+    assert l.cniEnabled({cni = {enabled = False}}) == False
+}
+
+test_gate_holds_children_until_ready = lambda {
+    assert l.gateOpen(False, False) == False
+    assert l.gateOpen(True, False) == True
+}
+
+test_gate_is_one_way = lambda {
+    # A CNI blipping not-Ready mid chart-upgrade must NOT drop an existing child
+    # — not emitting it is what makes Crossplane delete it.
+    assert l.gateOpen(False, True) == True
+}

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -2,6 +2,9 @@
 xplane-platform — function-kcl module for the platform Crossplane Configuration.
 
 Composes one child XR per enabled component of a cluster's platform:
+  0. Cni       (cni Configuration)        — cluster networking; opt-in, and the
+     other children are gated on it, because a cluster with no CNI has NotReady
+     nodes and a Helm install aimed at it times out rather than failing fast
   1. FluxInit  (flux-init Configuration)  — Flux itself, plus one OCIRepository
      source per enabled app
   2. FluxApps  (flux-apps Configuration)  — one Kustomization per enabled
@@ -32,9 +35,61 @@ _shared = l.resolveShared(_spec)
 _fluxEnabled = l.fluxInitEnabled(_spec)
 _apps = l.enabledApps(_spec)
 _appsEnabled = len(_apps) > 0
+_cniEnabled = l.cniEnabled(_spec)
 
+_cniKey = "{}-cni".format(_name)
 _fluxKey = "{}-flux-init".format(_name)
 _appsKey = "{}-flux-apps".format(_name)
+
+# --- Read child status back (needed by the CNI gate below, so defined early) ---
+_readStatus = lambda key: str -> {str:} {
+    (_ocds[key].Resource?.status or {}) if key in _ocds else {}
+}
+_isReady = lambda st: {str:} -> bool {
+    len([c for c in (st?.conditions or []) if c.type == "Ready" and c.status == "True"]) > 0
+}
+
+# --- Child 0: Cni ---
+# Not just another component: until it is Ready the target cluster's nodes are
+# NotReady, so nothing schedules — and a Helm install aimed at such a cluster
+# does not fail fast, it times out and retries. So the other children are held
+# until this one reports ready.
+_cniSpec = _spec?.cni or {}
+_cniStatus = _readStatus(_cniKey)
+_cniReady = _isReady(_cniStatus)
+
+_cniXR = {
+    apiVersion = "config.stuttgart-things.com/v1alpha1"
+    kind = "Cni"
+    metadata = {
+        name = _cniKey
+        namespace = _namespace
+        annotations = {"krm.kcl.dev/composition-resource-name" = _cniKey}
+    }
+    spec = {
+        if _shared?.clusterName:
+            clusterName = _shared.clusterName
+        if _shared.helmProviderConfigRef:
+            helmProviderConfigRef = _shared.helmProviderConfigRef
+        observeProviderConfigRef = _shared.observeProviderConfigRef
+        if _cniSpec?.provider:
+            provider = _cniSpec.provider
+        # NOT _shared.namespace: that is the Flux namespace. A CNI belongs in
+        # kube-system, which the cni Configuration defaults to on its own.
+        if _cniSpec?.namespace:
+            namespace = _cniSpec.namespace
+        if _cniSpec?.chart:
+            chart = _cniSpec.chart
+        if _cniSpec?.cilium:
+            cilium = _cniSpec.cilium
+        if _cniSpec?.values:
+            values = _cniSpec.values
+    }
+}
+
+# One-way gate: once a child exists, keep emitting it even if the CNI blips
+# not-Ready during a chart upgrade — otherwise Crossplane would delete it.
+_networkReady = _cniReady if _cniEnabled else True
 
 # --- Child 1: FluxInit ---
 # Sources are the union of what the XR declared and what enabling an app
@@ -89,15 +144,9 @@ _fluxAppsXR = {
     }
 }
 
-_children = ([_fluxInitXR] if _fluxEnabled else []) + ([_fluxAppsXR] if _appsEnabled else [])
-
-# --- Read child status back ---
-_readStatus = lambda key: str -> {str:} {
-    (_ocds[key].Resource?.status or {}) if key in _ocds else {}
-}
-_isReady = lambda st: {str:} -> bool {
-    len([c for c in (st?.conditions or []) if c.type == "Ready" and c.status == "True"]) > 0
-}
+_children = ([_cniXR] if _cniEnabled else []) \
+    + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) \
+    + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else [])
 
 _fluxStatus = _readStatus(_fluxKey)
 _fluxReady = _isReady(_fluxStatus)
@@ -108,13 +157,19 @@ _appsReady = _isReady(_appsStatus)
 # it into shared status keeps later components from re-observing it.
 _clusterType = _fluxStatus?.clusterType or ""
 
-_enabledReady = ([_fluxReady] if _fluxEnabled else []) + ([_appsReady] if _appsEnabled else [])
+_enabledReady = ([_cniReady] if _cniEnabled else []) + ([_fluxReady] if _fluxEnabled else []) + ([_appsReady] if _appsEnabled else [])
 _readyComponents = len([r for r in _enabledReady if r])
 
 _xrStatus = _oxr | {
     status = {
         shared = _shared | ({clusterType = _clusterType} if _clusterType else {})
         components = {
+            cni = {
+                enabled = _cniEnabled
+                ready = _cniReady
+                provider = _cniStatus?.provider or ""
+                version = _cniStatus?.version or ""
+            }
             fluxInit = {
                 enabled = _fluxEnabled
                 ready = _fluxReady

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -144,9 +144,7 @@ _fluxAppsXR = {
     }
 }
 
-_children = ([_cniXR] if _cniEnabled else []) \
-    + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) \
-    + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else [])
+_children = ([_cniXR] if _cniEnabled else []) + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else [])
 
 _fluxStatus = _readStatus(_fluxKey)
 _fluxReady = _isReady(_fluxStatus)


### PR DESCRIPTION
## What

New **`xplane-cni`** module (0.1.0) — installs a CNI on a target cluster as a `helm.m.crossplane.io` Release, gated on the target's `RemoteCluster` resolving. Cilium today; the provider is an enum so more can follow.

**`xplane-platform` 0.3.0** composes a `Cni` child and holds `FluxInit`/`FluxApps` until it reports ready.

Backs the companion PR in `crossplane-configurations` (`bootstrap/cni` v0.1.0, `platform` v0.3.0).

## Why the CNI settings aren't just Helm values

`kubeProxyReplacement` and `k8sServiceHost` are named fields with defaults derived from `clusterName`, because they're cluster-shape facts and getting them wrong deadlocks the cluster silently.

This fleet's kind clusters run **without kube-proxy**, so cilium has to replace it — and then cannot reach the API server through the `10.96.0.1` service VIP, because nothing programs that VIP until cilium itself is up. It presents as cilium pods stuck on `dial tcp 10.96.0.1:443: network is unreachable`.

`k8sServiceHost` breaks the circle, defaulting to `{clusterName}-control-plane` — exactly the container kind creates. `validate()` rejects `kubeProxyReplacement` with no resolvable address rather than shipping the deadlock. With `kubeProxyReplacement: false` the host/port are omitted entirely: a real kube-proxy makes normal discovery work, and pinning a host would then be wrong, not merely redundant.

## Three design calls worth review

**1. `cni` is opt-IN** — the inverse of every other component. Most clusters already have a CNI and installing a second one breaks them, so the default has to be off.

**2. The ordering is a render gate, not a `Usage`.** A `protection.crossplane.io` Usage orders *deletion* only — it blocks removal of the `of` while the `by` exists — and has no effect on creation. Creation ordering has to be a gate.

**3. The gate is one-way**, and this is the subtle one. Not emitting an existing child is how Crossplane deletes it. A gate that could re-close would tear Flux down the moment the CNI Release blipped `Ready=False` during a chart upgrade. So `gateOpen(ready, exists) = ready or exists`: it's about install ordering, not continuous dependency enforcement.

## Verification

- `xplane-cni`: **13/13** `kcl test` pass
- `xplane-platform`: **25/25** pass (3 new: opt-in default, gate holds, gate is one-way)
- Render-checked all three gate states — closed (only `Cni` emitted), open (`FluxInit` appears), and a CNI blip with `FluxInit` already in `ocds` (survives)
- The rendered Release matches byte-for-byte the one currently running on kind-test1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo
