### PR TITLE
feat: AppRole auth for xplane-vault-auth (no static Vault token)

### DIFF
--- a/crossplane/xplane-vault-auth-base/README.md
+++ b/crossplane/xplane-vault-auth-base/README.md
@@ -56,9 +56,12 @@ items = vault_auth.vaultK8sAuth(config)
 | `boundServiceAccountNamespaces` | `["default"]` |
 | `labels` / `annotations` | — |
 
-## Vault token Secret
+## Vault AppRole Secret
 
-The generated `varFiles` entry references a Secret in the **same namespace** as the Workspace:
+The generated `varFiles` entry references a Secret in the **same namespace** as
+the Workspace. Auth is **AppRole**, not a static token — each tofu apply
+exchanges `role_id`/`secret_id` for a short-lived Vault token, so the
+continuously-reconciling Workspace never wedges on an expired token:
 
 ```yaml
 apiVersion: v1
@@ -69,12 +72,27 @@ metadata:
 type: Opaque
 stringData:
   terraform.tfvars: |
-    vault_token = "hvs..."
+    vault_role_id   = "..."
+    vault_secret_id = "..."
 ```
+
+The AppRole must be bound to a policy that can manage the kubernetes auth mount
+(e.g. `vault-k8sauth-bootstrap`: `sys/auth/*`, `auth/+/config`, `auth/+/role/*`).
+
+## Migration from 0.7.x
+
+0.8.0 is a breaking change:
+
+- Vault provider now authenticates via **AppRole `auth_login`** instead of a
+  static `token`. The tfvars Secret must supply `vault_role_id` +
+  `vault_secret_id` (was `vault_token`). `skip_child_token = true` is set.
+- A `terraform { required_providers }` block now pins vault to `~> 3.25`
+  (v5.x reworked `auth_login`); the kubernetes provider (`~> 2.0`) is added only
+  when a `backendConfig` is rendered.
 
 ## Migration from 0.4.x
 
-0.5.0 is a breaking change:
+0.5.0 was a breaking change:
 
 - Switched dependency from `crossplane-provider-terraform` to `crossplane-provider-opentofu`.
 - Workspace `apiVersion` changed to `opentofu.m.upbound.io/v1beta1`.

--- a/crossplane/xplane-vault-auth-base/kcl.mod
+++ b/crossplane/xplane-vault-auth-base/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth-base"
 edition = "v0.11.0"
-version = "0.7.1"
+version = "0.8.0"
 description = "KCL library for creating Vault Kubernetes authentication backends as Crossplane v2 namespaced OpenTofu Workspaces"
 
 [dependencies]

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -1,7 +1,6 @@
 # Library module — not runnable standalone.
 # Generates Crossplane v2 namespaced OpenTofu Workspaces that configure
 # Vault Kubernetes auth backends (optionally with backend_config).
-
 import v1beta1 as otf
 
 schema K8sAuthBackendConfig:
@@ -10,7 +9,8 @@ schema K8sAuthBackendConfig:
     # via the kubernetes TF provider `data "kubernetes_secret"` from a
     # Secret in the cluster running opentofu-provider.
     secretName: str
-    secretNamespace?: str   # defaults to the Workspace namespace
+    # defaults to the Workspace namespace
+    secretNamespace?: str
     caCertKey?: str = "ca.crt"
     tokenKey?: str = "token"
     disableIssValidation?: bool = True
@@ -27,8 +27,8 @@ schema K8sAuth:
     boundServiceAccountNamespaces?: [str] = ["default"]
     # If set, the generated Workspace also renders vault_kubernetes_auth_backend_config.
     backendConfig?: K8sAuthBackendConfig
-    labels?: {str: str}
-    annotations?: {str: str}
+    labels?: {str:str}
+    annotations?: {str:str}
 
 schema VaultConfig:
     k8sAuths: [K8sAuth]
@@ -210,27 +210,27 @@ _listToJson = lambda items: [str] -> str {
 
 _baseVars = lambda auth: K8sAuth -> [{str:str}] {
     [
-        {key = "auth_name",                         value = auth.name}
-        {key = "cluster_name",                      value = auth.clusterName}
-        {key = "vault_addr",                        value = auth.vaultAddr}
-        {key = "skip_tls_verify",                   value = "true" if auth.skipTlsVerify else "false"}
-        {key = "token_policies",                    value = _listToJson(auth.tokenPolicies)}
-        {key = "token_ttl",                         value = str(auth.tokenTtl)}
-        {key = "bound_service_account_names",       value = _listToJson(auth.boundServiceAccountNames)}
-        {key = "bound_service_account_namespaces",  value = _listToJson(auth.boundServiceAccountNamespaces)}
+        {key = "auth_name", value = auth.name}
+        {key = "cluster_name", value = auth.clusterName}
+        {key = "vault_addr", value = auth.vaultAddr}
+        {key = "skip_tls_verify", value = "true" if auth.skipTlsVerify else "false"}
+        {key = "token_policies", value = _listToJson(auth.tokenPolicies)}
+        {key = "token_ttl", value = str(auth.tokenTtl)}
+        {key = "bound_service_account_names", value = _listToJson(auth.boundServiceAccountNames)}
+        {key = "bound_service_account_namespaces", value = _listToJson(auth.boundServiceAccountNamespaces)}
     ]
 }
 
 _backendConfigVars = lambda auth: K8sAuth, config: VaultConfig -> [{str:str}] {
     bc = auth.backendConfig
     [
-        {key = "kubernetes_host",        value = config.kubernetesHost or ""}
-        {key = "sa_secret_name",         value = bc.secretName}
-        {key = "sa_secret_namespace",    value = bc.secretNamespace or config.namespace}
-        {key = "sa_ca_cert_key",         value = bc.caCertKey}
-        {key = "sa_token_key",           value = bc.tokenKey}
+        {key = "kubernetes_host", value = config.kubernetesHost or ""}
+        {key = "sa_secret_name", value = bc.secretName}
+        {key = "sa_secret_namespace", value = bc.secretNamespace or config.namespace}
+        {key = "sa_ca_cert_key", value = bc.caCertKey}
+        {key = "sa_token_key", value = bc.tokenKey}
         {key = "disable_iss_validation", value = "true" if bc.disableIssValidation else "false"}
-        {key = "disable_local_ca_jwt",   value = "true" if bc.disableLocalCaJwt else "false"}
+        {key = "disable_local_ca_jwt", value = "true" if bc.disableLocalCaJwt else "false"}
     ] if bc else []
 }
 

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -43,11 +43,32 @@ schema VaultConfig:
     # Required if any K8sAuth in k8sAuths has backendConfig set.
     kubernetesHost?: str
 
-# Base HCL: vault provider + auth_backend + auth_backend_role.
+# Base HCL: vault provider (AppRole login) + auth_backend + auth_backend_role.
+#
+# Auth is AppRole, NOT a static token: each tofu apply exchanges
+# role_id/secret_id for a short-lived Vault token carrying only the
+# vault-k8sauth-bootstrap policy. This is why the continuously-reconciling
+# Workspace no longer wedges — a static token expires (768h cap) and 403s every
+# reconcile in both create and delete; an AppRole login mints a fresh token each
+# run. role_id/secret_id arrive via the tfvars varFile (SecretKey), same slot
+# the old static vault_token used.
+#
+# skip_child_token = true: the provider would otherwise mint a child token via
+# auth/token/create, which the least-privilege bootstrap policy need not allow.
+# Pin vault ~> 3.25: v5.x reworked the auth_login block ("Blocks of type
+# auth_login are not expected here").
 _baseHcl = r"""provider "vault" {
-  address         = var.vault_addr
-  skip_tls_verify = var.skip_tls_verify
-  token           = var.vault_token
+  address          = var.vault_addr
+  skip_tls_verify  = var.skip_tls_verify
+  skip_child_token = true
+
+  auth_login {
+    path = "auth/approle/login"
+    parameters = {
+      role_id   = var.vault_role_id
+      secret_id = var.vault_secret_id
+    }
+  }
 }
 
 resource "vault_auth_backend" "kubernetes" {
@@ -81,7 +102,12 @@ variable "skip_tls_verify" {
   default = false
 }
 
-variable "vault_token" {
+variable "vault_role_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "vault_secret_id" {
   type      = string
   sensitive = true
 }
@@ -170,6 +196,14 @@ variable "disable_local_ca_jwt" {
 }
 """
 
+# required_providers: pin vault to ~> 3.25 (v5 reworked auth_login). Add the
+# kubernetes provider only when a backend_config is rendered (it reads the
+# reviewer JWT / CA via data "kubernetes_secret").
+_terraformBlock = lambda hasBackendConfig: bool -> str {
+    _k8s = '\n    kubernetes = {\n      source  = "hashicorp/kubernetes"\n      version = "~> 2.0"\n    }' if hasBackendConfig else ""
+    'terraform {\n  required_providers {\n    vault = {\n      source  = "hashicorp/vault"\n      version = "~> 3.25"\n    }' + _k8s + '\n  }\n}\n\n'
+}
+
 _listToJson = lambda items: [str] -> str {
     '["' + '","'.join(items) + '"]'
 }
@@ -202,7 +236,7 @@ _backendConfigVars = lambda auth: K8sAuth, config: VaultConfig -> [{str:str}] {
 
 # Build one Workspace for a single K8sAuth entry.
 createSingleVaultAuth = lambda auth: K8sAuth, config: VaultConfig -> otf.Workspace {
-    _module = _baseHcl + (_backendConfigHcl if auth.backendConfig else "")
+    _module = _terraformBlock(auth.backendConfig != Undefined) + _baseHcl + (_backendConfigHcl if auth.backendConfig else "")
     _vars = _baseVars(auth) + _backendConfigVars(auth, config)
     otf.Workspace {
         metadata = {

--- a/crossplane/xplane-vault-auth-base/tests/test_main.k
+++ b/crossplane/xplane-vault-auth-base/tests/test_main.k
@@ -1,56 +1,66 @@
 import main as vault_auth
 
-# Test simple authentication backend
-simpleAuth = vault_auth.simpleVaultK8sAuth("test-app", "test-cluster", "https://vault.test.com")
-
-# Test assertions for simple auth (returns list with one workspace)
-assert len(simpleAuth) == 1
-workspace = simpleAuth[0]
-assert workspace.apiVersion == "tf.upbound.io/v1beta1"
-assert workspace.kind == "Workspace"
-assert workspace.metadata.name == "test-cluster-test-app-vault-auth"
-assert workspace.spec.forProvider.source == "Inline"
-assert "vault_auth_backend" in workspace.spec.forProvider.module
-assert "provider \"vault\"" in workspace.spec.forProvider.module
-
-# Test auth with policies
-authWithPolicies = vault_auth.simpleVaultK8sAuthWithPolicies(
-    "cicd-app",
-    "prod-cluster",
-    "https://vault.prod.com",
-    ["read-policy", "write-policy"]
-)
-
-assert len(authWithPolicies) == 1
-policyWorkspace = authWithPolicies[0]
-assert policyWorkspace.metadata.name == "prod-cluster-cicd-app-vault-auth"
-assert "token_policies                   = var.token_policies" in policyWorkspace.spec.forProvider.module
-assert "token_ttl                        = var.token_ttl" in policyWorkspace.spec.forProvider.module
-
-# Validate variables in workspace
-vars = policyWorkspace.spec.forProvider.vars
-tokenPoliciesVar = [v for v in vars if v.key == "token_policies"][0]
-assert tokenPoliciesVar.value == "[read-policy, write-policy]"# Test advanced auth configuration
-advancedAuth = vault_auth.advancedVaultK8sAuth(
-    "advanced-app",
-    "staging",
-    "https://vault.staging.com",
-    ["advanced-policy"],
-    1800
-)
-
-assert len(advancedAuth) == 1
-advancedWorkspace = advancedAuth[0]
-assert advancedWorkspace.metadata.name == "staging-advanced-app-vault-auth"
-
-# Test single workspace creation directly
-directAuth = vault_auth.K8sAuth {
-    name = "direct-app"
-    clusterName = "direct-cluster"
-    vaultAddr = "https://vault.direct.com"
+# --- Config with two auths: one plain, one with backendConfig ---
+_config = vault_auth.VaultConfig {
+    clusterName = "test-cluster"
+    vaultAddr = "https://vault.test.com"
+    skipTlsVerify = True
+    namespace = "default"
+    kubernetesHost = "https://10.0.0.1:6443"
+    k8sAuths = [
+        vault_auth.K8sAuth {
+            name = "certmanager"
+            clusterName = "test-cluster"
+            vaultAddr = "https://vault.test.com"
+            tokenPolicies = ["pki-issue"]
+            boundServiceAccountNames = ["cert-manager"]
+            boundServiceAccountNamespaces = ["cert-manager"]
+        }
+        vault_auth.K8sAuth {
+            name = "cicd"
+            clusterName = "test-cluster"
+            vaultAddr = "https://vault.test.com"
+            tokenPolicies = ["read-secrets"]
+            backendConfig = vault_auth.K8sAuthBackendConfig {
+                secretName = "reviewer-token"
+                secretNamespace = "kube-system"
+            }
+        }
+    ]
 }
-singleAuth = vault_auth.createSingleVaultAuth(directAuth)
-assert len(singleAuth) == 1
-assert singleAuth[0].metadata.name == "direct-cluster-direct-app-vault-auth"
+
+_workspaces = vault_auth.vaultK8sAuth(_config)
+assert len(_workspaces) == 2
+
+_plain = [w for w in _workspaces if w.metadata.name == "test-cluster-certmanager-vault-auth"][0]
+_withCfg = [w for w in _workspaces if w.metadata.name == "test-cluster-cicd-vault-auth"][0]
+
+# --- AppRole login, NOT a static token ---
+_pm = _plain.spec.forProvider.module
+assert "auth_login {" in _pm, "provider must use auth_login (AppRole)"
+assert 'path = "auth/approle/login"' in _pm
+assert "skip_child_token = true" in _pm
+assert "var.vault_role_id" in _pm
+assert "var.vault_secret_id" in _pm
+assert "token           = var.vault_token" not in _pm, "static token block must be gone"
+assert 'variable "vault_role_id"' in _pm
+assert 'variable "vault_secret_id"' in _pm
+
+# --- required_providers pins vault ~> 3.25 ---
+assert "required_providers" in _pm
+assert 'version = "~> 3.25"' in _pm
+# plain auth pulls no kubernetes provider
+assert "hashicorp/kubernetes" not in _pm
+
+# --- credentials still injected via the tfvars SecretKey varFile ---
+_vf = _plain.spec.forProvider.varFiles[0]
+assert _vf.source == "SecretKey"
+assert _vf.secretKeyRef.key == "terraform.tfvars"
+
+# --- backendConfig auth adds the kubernetes provider + backend_config resource ---
+_cm = _withCfg.spec.forProvider.module
+assert "hashicorp/kubernetes" in _cm, "backendConfig must pull the kubernetes provider"
+assert "vault_kubernetes_auth_backend_config" in _cm
+assert "token_reviewer_jwt" in _cm
 
 print("All tests passed! ✓")

--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
-xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.7.1" }
+xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.8.0" }

--- a/crossplane/xplane-vault-auth/kcl.mod.lock
+++ b/crossplane/xplane-vault-auth/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-vault-auth-base]
     name = "xplane-vault-auth-base"
-    full_name = "xplane-vault-auth-base_0.7.1"
-    version = "0.7.1"
-    sum = "+7w9wryxEFzR3+3nYol1B1l7pvvxxkYm7vKtrEmoeWg="
+    full_name = "xplane-vault-auth-base_0.8.0"
+    version = "0.8.0"
+    sum = "b6J3QyDtnx6klXa0BOJxD/aczJPR6PBVf9T1NnkYe6I="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-vault-auth-base"
-    oci_tag = "0.7.1"
+    oci_tag = "0.8.0"

--- a/crossplane/xplane-vault-auth/main.k
+++ b/crossplane/xplane-vault-auth/main.k
@@ -26,22 +26,20 @@ _buildBackendConfig = lambda bc: any -> vault_auth.K8sAuthBackendConfig {
     } if bc else Undefined
 }
 
-_k8sAuths = [
-    vault_auth.K8sAuth {
-        name = auth?.name or "default"
-        clusterName = auth?.clusterName or _clusterName
-        vaultAddr = auth?.vaultAddr or _vaultAddr
-        skipTlsVerify = auth.skipTlsVerify if "skipTlsVerify" in auth else _skipTlsVerify
-        tokenPolicies = auth?.tokenPolicies or ["read-secrets"]
-        tokenTtl = auth?.tokenTtl or 3600
-        boundServiceAccountNames = auth?.boundServiceAccountNames or ["default"]
-        boundServiceAccountNamespaces = auth?.boundServiceAccountNamespaces or ["default"]
-        backendConfig = _buildBackendConfig(auth?.backendConfig)
-    } for auth in (_spec?.k8sAuths or [
-        {"name": "frontend", "tokenPolicies": ["read-secrets"], "tokenTtl": 7200},
-        {"name": "backend", "tokenPolicies": ["read-secrets", "write-logs"], "tokenTtl": 3600},
-    ])
-]
+_k8sAuths = [vault_auth.K8sAuth {
+    name = auth?.name or "default"
+    clusterName = auth?.clusterName or _clusterName
+    vaultAddr = auth?.vaultAddr or _vaultAddr
+    skipTlsVerify = auth.skipTlsVerify if "skipTlsVerify" in auth else _skipTlsVerify
+    tokenPolicies = auth?.tokenPolicies or ["read-secrets"]
+    tokenTtl = auth?.tokenTtl or 3600
+    boundServiceAccountNames = auth?.boundServiceAccountNames or ["default"]
+    boundServiceAccountNamespaces = auth?.boundServiceAccountNamespaces or ["default"]
+    backendConfig = _buildBackendConfig(auth?.backendConfig)
+} for auth in (_spec?.k8sAuths or [
+    {"name": "frontend", "tokenPolicies": ["read-secrets"], "tokenTtl": 7200}
+    {"name": "backend", "tokenPolicies": ["read-secrets", "write-logs"], "tokenTtl": 3600}
+])]
 
 _config = vault_auth.VaultConfig {
     k8sAuths = _k8sAuths


### PR DESCRIPTION
## What

Switches `xplane-vault-auth-base` from a static `token = var.vault_token` to an AppRole `auth_login` block, so the OpenTofu Workspaces that provision Vault Kubernetes auth backends no longer depend on a static token.

## Why

The static token is the exact expiry bomb this line of work is retiring: it expires (Vault caps token TTL at 768h) and then 403s on `auth/token/lookup-self` every reconcile, wedging the continuously-reconciling Workspace in **both create and delete**. An AppRole login mints a fresh short-lived token each apply — no wedge.

## Changes

- **Provider block** to `auth_login { path = "auth/approle/login"; parameters = { role_id, secret_id } }` + `skip_child_token = true`. `vault_token` variable replaced by `vault_role_id` + `vault_secret_id` (same tfvars SecretKey varFile).
- **`terraform { required_providers }`** pinning vault `~> 3.25` (v5 reworked `auth_login`); kubernetes `~> 2.0` only when a `backendConfig` is rendered.
- `xplane-vault-auth-base` **0.7.1 -> 0.8.0**; `xplane-vault-auth` **0.4.1 -> 0.5.0** (dependency bump only, consumer code unchanged).
- Rewrote the stale `test_main.k` to the current API + assert the AppRole change.

## Consumer impact

The tfvars Secret must now supply `vault_role_id` + `vault_secret_id` instead of `vault_token`. Both modules are already published (base 0.8.0, consumer 0.5.0, both public). Validated end-to-end: the tokenless cert-manager to Vault-PKI cert path issues real certs on kind.

Generated with Claude Code