### PR TITLE
feat(flux-catalog): cert-manager approle-issuer opt-in component

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/cert_manager.k
+++ b/crossplane/xplane-flux-catalog/apps/cert_manager.k
@@ -2,10 +2,14 @@ import ..schema as s
 
 # cert-manager — https://github.com/stuttgart-things/flux/tree/main/infra/cert-manager
 #
-# The artifact root pulls a Vault PKI post-release (VAULT_ADDR, VAULT_ROLE_ID,
-# VAULT_SECRET_ID, ...), so the catalog targets the components/ directories
-# instead: ./components/install is a plain cert-manager install with no Vault
-# dependency, which is what other artifacts depend on.
+# The artifact root (base) installs ONLY the cert-manager controller with no
+# Vault dependency (flux#190). ./components/install is the same controller as a
+# standalone component — kept because other artifacts depend on it by name
+# (e.g. trust-manager -> cert-manager:install).
+#
+# The legacy Vault AppRole ClusterIssuer is the OPT-IN approle-issuer component
+# (needs VAULT_* substitutions). New clusters leave it off and use a tokenless
+# Kubernetes-auth ClusterIssuer provisioned out-of-band (VaultK8sAuth).
 #
 # selfsigned is optional and off unless enabled; it needs a domain.
 # (components/extra-certificate exists too — add it when something needs it.)
@@ -25,6 +29,21 @@ certManager: s.App = {
             optional = True
             dependsOn = ["install"]
             requiredSubstitutions = ["CERT_MANAGER_SELFSIGNED_DOMAIN"]
+        }
+        s.Component {
+            name = "approle-issuer"
+            path = "./components/approle-issuer"
+            optional = True
+            dependsOn = ["install"]
+            wrapsHelmRelease = True
+            timeout = "15m"
+            requiredSubstitutions = [
+                "VAULT_ADDR"
+                "VAULT_PKI_PATH"
+                "VAULT_CA_BUNDLE"
+                "VAULT_ROLE_ID"
+                "VAULT_SECRET_ID"
+            ]
         }
     ]
 }

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.2.1"
+version = "0.3.0"


### PR DESCRIPTION
## What

Adds an opt-in **`approle-issuer`** component to the cert-manager entry in `xplane-flux-catalog`, aligning it with the flux overlay restructure in **stuttgart-things/flux#190**.

## Why

flux#190 makes the `infra/cert-manager` **base controller-only** and moves the legacy Vault **AppRole** `ClusterIssuer` into an opt-in `components/approle-issuer`. The catalog previously worked around the AppRole-in-base problem by targeting `./components/install`; now that the base is clean, the catalog exposes the AppRole issuer as a selectable component so:

- **new clusters** install cert-manager controller-only (via `install`) and use a **tokenless Kubernetes-auth `ClusterIssuer`** provisioned out-of-band (VaultK8sAuth);
- **clusters still on the AppRole issuer** enable `approle-issuer` (needs `VAULT_ADDR`/`VAULT_PKI_PATH`/`VAULT_CA_BUNDLE`/`VAULT_ROLE_ID`/`VAULT_SECRET_ID`).

## Changes

- Add `approle-issuer` component (`optional`, `dependsOn: [install]`, `wrapsHelmRelease`, `timeout 15m`, `requiredSubstitutions` for the `VAULT_*` vars).
- Refresh the stale comment (the artifact root no longer pulls the Vault post-release).
- `xplane-flux-catalog` 0.2.1 → 0.3.0.

Catalog tests: **9/9 pass**.

## Follow-up (release ordering)

The `approle-issuer` path exists in the flux artifact only once flux#190 is merged + tagged. `defaultVersion` stays `v1.18.1` (unaffected — `install`/`selfsigned` still resolve there); bump it to the tag that includes the restructure in a later change.

Generated with Claude Code

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ