### PR TITLE
feat(platform): cilium (LB/Gateway) + ip-reservation platform components

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.2.1" }

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -61,6 +61,23 @@ cniEnabled = lambda spec: {str:} -> bool {
     (spec?.cni or {})?.enabled or False
 }
 
+ciliumEnabled = lambda spec: {str:} -> bool {
+    """Opt-IN. The cilium Configuration adds Cilium LoadBalancer + Gateway on top
+    of the CNI (a superset of `cni`). Off by default — only clusters that want an
+    advertised LB VIP / Gateway enable it. In the platform it defaults to
+    install.enabled=false (the CNI is `cni`'s job or already on the cluster); it
+    only layers the LB/Gateway services, so it is gated on the network being up."""
+    (spec?.cilium or {})?.enabled or False
+}
+
+ipReservationEnabled = lambda spec: {str:} -> bool {
+    """Opt-IN. Composes an XIPReservation (ip-reservation Configuration) that
+    reserves a clusterbook IP for this cluster. Off by default. When both this and
+    cilium (dynamic LB) are enabled, cilium's reservationRef auto-wires to this
+    child so the reserved IP becomes the LB pool block."""
+    (spec?.ipReservation or {})?.enabled or False
+}
+
 gateOpen = lambda ready: bool, exists: bool -> bool {
     """Should a gated child be emitted?
 

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -260,3 +260,11 @@ test_gate_is_one_way = lambda {
     # — not emitting it is what makes Crossplane delete it.
     assert l.gateOpen(False, True) == True
 }
+
+test_cilium_and_ipreservation_are_opt_in = lambda {
+    assert l.ciliumEnabled({}) == False
+    assert l.ipReservationEnabled({}) == False
+    assert l.ciliumEnabled({cilium = {enabled = True}}) == True
+    assert l.ipReservationEnabled({ipReservation = {enabled = True}}) == True
+    assert l.ciliumEnabled({cilium = {enabled = False}}) == False
+}

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -264,7 +264,13 @@ test_gate_is_one_way = lambda {
 test_cilium_and_ipreservation_are_opt_in = lambda {
     assert l.ciliumEnabled({}) == False
     assert l.ipReservationEnabled({}) == False
-    assert l.ciliumEnabled({cilium = {enabled = True}}) == True
-    assert l.ipReservationEnabled({ipReservation = {enabled = True}}) == True
-    assert l.ciliumEnabled({cilium = {enabled = False}}) == False
+    assert l.ciliumEnabled({
+        cilium = {enabled = True}
+    }) == True
+    assert l.ipReservationEnabled({
+        ipReservation = {enabled = True}
+    }) == True
+    assert l.ciliumEnabled({
+        cilium = {enabled = False}
+    }) == False
 }

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -36,10 +36,14 @@ _fluxEnabled = l.fluxInitEnabled(_spec)
 _apps = l.enabledApps(_spec)
 _appsEnabled = len(_apps) > 0
 _cniEnabled = l.cniEnabled(_spec)
+_ciliumEnabled = l.ciliumEnabled(_spec)
+_ipResEnabled = l.ipReservationEnabled(_spec)
 
 _cniKey = "{}-cni".format(_name)
 _fluxKey = "{}-flux-init".format(_name)
 _appsKey = "{}-flux-apps".format(_name)
+_ciliumKey = "{}-cilium".format(_name)
+_ipResKey = "{}-ip-reservation".format(_name)
 
 # --- Read child status back (needed by the CNI gate below, so defined early) ---
 _readStatus = lambda key: str -> {str:} {
@@ -144,18 +148,85 @@ _fluxAppsXR = {
     }
 }
 
-_children = ([_cniXR] if _cniEnabled else []) + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else [])
+# --- Child 3: XIPReservation ---
+# Reserves a clusterbook IP on the MANAGEMENT cluster (independent of the target
+# CNI, so not network-gated). When cilium's dynamic LB is also enabled its
+# reservationRef auto-wires to this child.
+_ipResSpec = _spec?.ipReservation or {}
+_ipReservationXR = {
+    apiVersion = "resources.stuttgart-things.com/v1alpha1"
+    kind = "XIPReservation"
+    metadata = {
+        name = _ipResKey
+        namespace = _namespace
+        annotations = {"krm.kcl.dev/composition-resource-name" = _ipResKey}
+    }
+    spec = {
+        if _shared?.clusterName:
+            clusterName = _shared.clusterName
+        if _ipResSpec?.count:
+            count = _ipResSpec.count
+        if _ipResSpec?.ip:
+            ip = _ipResSpec.ip
+        if "createDNS" in _ipResSpec:
+            createDNS = _ipResSpec.createDNS
+        if _ipResSpec?.clusterbookProviderConfigRef:
+            clusterbookProviderConfigRef = _ipResSpec.clusterbookProviderConfigRef
+        # the XIPReservation observes the RemoteCluster in-cluster on the mgmt cluster
+        kubernetesProviderConfigRef = _shared.observeProviderConfigRef
+    }
+}
+
+# --- Child 4: Cilium (LoadBalancer + Gateway) ---
+# Superset services on top of the CNI: LB pool + L2 announcement + Gateway.
+# Defaults install.enabled=false (the CNI is `cni`'s job / already present) — it
+# only layers the services, so it is gated on the network being up. When dynamic
+# LB is requested and no reservationRef is set, auto-wire it to the ipReservation
+# child so the reserved IP becomes the pool block.
+_ciliumSpec = _spec?.cilium or {}
+_ciliumInstall = _ciliumSpec?.install or {enabled = False}
+_ciliumLB = _ciliumSpec?.loadBalancer or {}
+_wantAutoRef = _ipResEnabled and (_ciliumLB?.ipMode or "static") == "dynamic" and not _ciliumLB?.reservationRef
+_ciliumLBOut = _ciliumLB | ({reservationRef = _ipResKey} if _wantAutoRef else {})
+_ciliumXR = {
+    apiVersion = "config.stuttgart-things.com/v1alpha1"
+    kind = "Cilium"
+    metadata = {
+        name = _ciliumKey
+        namespace = _namespace
+        annotations = {"krm.kcl.dev/composition-resource-name" = _ciliumKey}
+    }
+    spec = {
+        if _shared?.clusterName:
+            clusterName = _shared.clusterName
+        if _shared.helmProviderConfigRef:
+            helmProviderConfigRef = _shared.helmProviderConfigRef
+        if _shared.kubernetesProviderConfigRef:
+            kubernetesProviderConfigRef = _shared.kubernetesProviderConfigRef
+        install = _ciliumInstall
+        if _ciliumLBOut:
+            loadBalancer = _ciliumLBOut
+        if _ciliumSpec?.gateway:
+            gateway = _ciliumSpec.gateway
+    }
+}
+
+_children = ([_cniXR] if _cniEnabled else []) + ([_ipReservationXR] if _ipResEnabled else []) + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else []) + ([_ciliumXR] if (_ciliumEnabled and l.gateOpen(_networkReady, _ciliumKey in _ocds)) else [])
 
 _fluxStatus = _readStatus(_fluxKey)
 _fluxReady = _isReady(_fluxStatus)
 _appsStatus = _readStatus(_appsKey)
 _appsReady = _isReady(_appsStatus)
+_ciliumStatus = _readStatus(_ciliumKey)
+_ciliumReady = _isReady(_ciliumStatus)
+_ipResStatus = _readStatus(_ipResKey)
+_ipResReady = _isReady(_ipResStatus)
 
 # clusterType is discovered by the FluxInit child from the RemoteCluster; lifting
 # it into shared status keeps later components from re-observing it.
 _clusterType = _fluxStatus?.clusterType or ""
 
-_enabledReady = ([_cniReady] if _cniEnabled else []) + ([_fluxReady] if _fluxEnabled else []) + ([_appsReady] if _appsEnabled else [])
+_enabledReady = ([_cniReady] if _cniEnabled else []) + ([_ipResReady] if _ipResEnabled else []) + ([_fluxReady] if _fluxEnabled else []) + ([_appsReady] if _appsEnabled else []) + ([_ciliumReady] if _ciliumEnabled else [])
 _readyComponents = len([r for r in _enabledReady if r])
 
 _xrStatus = _oxr | {
@@ -181,6 +252,19 @@ _xrStatus = _oxr | {
                 ready = _appsReady
                 appCount = _appsStatus?.appCount or 0
                 readyCount = _appsStatus?.readyCount or 0
+            }
+            ipReservation = {
+                enabled = _ipResEnabled
+                ready = _ipResReady
+                ipAddresses = _ipResStatus?.ipAddresses or []
+                networkKey = _ipResStatus?.networkKey or ""
+            }
+            cilium = {
+                enabled = _ciliumEnabled
+                ready = _ciliumReady
+                loadBalancerReady = _ciliumStatus?.loadBalancerReady or False
+                gatewayReady = _ciliumStatus?.gatewayReady or False
+                networkKey = _ciliumStatus?.networkKey or ""
             }
         }
         componentCount = len(_enabledReady)


### PR DESCRIPTION
## What

Adds two opt-in children to the `xplane-platform` module so a single `Platform` XR can also do the **network half** of the cluster bootstrap:

- **`XIPReservation`** (ip-reservation Configuration) — reserves a clusterbook IP on the management cluster; not network-gated.
- **`Cilium`** (cilium Configuration) — LoadBalancer + Gateway services. Defaults `install.enabled: false` (it layers on the CNI from `cni` or the cluster), gated on the network being up.

## Auto-wiring

When `cilium.loadBalancer.ipMode: dynamic` is set with no explicit `reservationRef` **and** `ipReservation` is enabled, the Cilium child's `reservationRef` auto-wires to the ipReservation child — so the reserved IP flows into the Cilium LB pool block and becomes an advertised Gateway VIP. Proven live on u26-kind1 (reserved `10.31.102.16` → Gateway VIP → HTTPS with a Vault-signed cert).

## Additive & non-breaking

Both default **off** — existing Platforms (including the live u26-kind1 one) render identically. cni-vs-cilium is resolved additively: `cni` owns the CNI install/gate, `cilium` layers the LB/Gateway services. Full consolidation (fold CNI-install into `cilium`) is a deliberate future call.

- Status gains `components.{ipReservation,cilium}`; both fold into `readyComponents`.
- `xplane-platform` 0.3.0 → 0.4.0. Tests: **26/26**.

Pairs with the `bootstrap/cilium` + `bootstrap/ip-reservation` Configurations (crossplane-configurations#155 and prior).

Generated with Claude Code

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ