### PR TITLE
feat(platform): auto-provision the vaultIssuer reviewer JWT (hands-off)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.2.1" }

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -284,3 +284,9 @@ test_vault_issuer_is_opt_in = lambda {
         vaultIssuer = {enabled = False}
     }) == False
 }
+
+test_vault_issuer_still_opt_in = lambda {
+    assert l.vaultIssuerEnabled({
+        vaultIssuer = {enabled = True}
+    }) == True
+}

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -232,6 +232,27 @@ _viIssuerName = _viSpec?.issuerName or "vault-pki-k8s"
 _viCaSecret = _viSpec?.caSecretName or "vault-pki-ca"
 _viTargetRef = _shared.kubernetesProviderConfigRef
 
+# --- Reviewer JWT provisioning (auto) ---
+# Vault's k8s-auth mount needs a token_reviewer_jwt from the TARGET (an
+# auth-delegator SA), which the VaultK8sAuth Workspace reads from a secret on
+# the MGMT cluster. autoReviewer provisions the whole chain: an auth-delegator
+# SA + long-lived token Secret on the target, an Observe of that Secret, and a
+# copy of its ca.crt+token into a mgmt Secret. An explicit reviewerSecret skips
+# it. Verified: provider-kubernetes Observe exposes a Secret's data, so the copy
+# needs no external step.
+_viReviewerObserveKey = "{}-reviewer-observe".format(_name)
+_viReviewerMgmtSecret = "{}-reviewer".format(_name)
+_viAutoReviewer = _viSpec.autoReviewer if "autoReviewer" in _viSpec else (not _viSpec?.reviewerSecret)
+
+# Observed reviewer ca.crt + token from the target Secret (empty until observed).
+_viRevData = (_ocds[_viReviewerObserveKey].Resource?.status?.atProvider?.manifest?.data or {}) if _viReviewerObserveKey in _ocds else {}
+_viRevToken = _viRevData?.token or ""
+_viRevCa = _viRevData["ca.crt"] if "ca.crt" in _viRevData else ""
+
+# The reviewer secret the Workspace reads, and whether it is available yet.
+_viEffReviewerSecret = _viReviewerMgmtSecret if _viAutoReviewer else (_viSpec?.reviewerSecret or "")
+_viReviewerAvailable = (_viRevToken != "") if _viAutoReviewer else (_viSpec?.reviewerSecret != None)
+
 _vaultK8sAuthXR = {
     apiVersion = "config.stuttgart-things.com/v1alpha1"
     kind = "VaultK8sAuth"
@@ -251,8 +272,11 @@ _vaultK8sAuthXR = {
             tokenPolicies = _viSpec?.tokenPolicies or ["pki-issue"]
             boundServiceAccountNames = ["cert-manager"]
             boundServiceAccountNamespaces = [_viCmNs]
-            if _viSpec?.reviewerSecret:
-                backendConfig = {secretName = _viSpec.reviewerSecret, secretNamespace = _namespace}
+            # Config the mount only once a reviewer secret exists (auto or
+            # explicit); until then the Workspace just creates the mount+role and
+            # adds the backend_config on a later reconcile.
+            if _viReviewerAvailable:
+                backendConfig = {secretName = _viEffReviewerSecret, secretNamespace = _namespace}
         }]
     }
 }
@@ -325,7 +349,84 @@ _tokenReqBindingObj = {
     }
 }
 
-_vaultIssuerChildren = [_vaultK8sAuthXR, _vaultPkiSecretXR, _issuerObj, _tokenReqRoleObj, _tokenReqBindingObj] if _vaultIssuerEnabled else []
+# --- auto-reviewer Objects (only when autoReviewer) ---
+_viRevSAObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {name = "{}-reviewer-sa".format(_name), namespace = _namespace, annotations = {"krm.kcl.dev/composition-resource-name" = "{}-reviewer-sa".format(_name)}}
+    spec = {
+        forProvider.manifest = {
+            apiVersion = "v1"
+            kind = "ServiceAccount"
+            metadata = {name = "vault-auth-reviewer", namespace = "kube-system"}
+        }
+        providerConfigRef = {name = _viTargetRef, kind = "ClusterProviderConfig"}
+    }
+}
+_viRevCRBObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {name = "{}-reviewer-crb".format(_name), namespace = _namespace, annotations = {"krm.kcl.dev/composition-resource-name" = "{}-reviewer-crb".format(_name)}}
+    spec = {
+        forProvider.manifest = {
+            apiVersion = "rbac.authorization.k8s.io/v1"
+            kind = "ClusterRoleBinding"
+            metadata.name = "vault-auth-reviewer"
+            roleRef = {apiGroup = "rbac.authorization.k8s.io", kind = "ClusterRole", name = "system:auth-delegator"}
+            subjects = [{kind = "ServiceAccount", name = "vault-auth-reviewer", namespace = "kube-system"}]
+        }
+        providerConfigRef = {name = _viTargetRef, kind = "ClusterProviderConfig"}
+    }
+}
+_viRevTokenObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {name = "{}-reviewer-token".format(_name), namespace = _namespace, annotations = {"krm.kcl.dev/composition-resource-name" = "{}-reviewer-token".format(_name)}}
+    spec = {
+        forProvider.manifest = {
+            apiVersion = "v1"
+            kind = "Secret"
+            metadata = {name = "vault-auth-reviewer-token", namespace = "kube-system", annotations = {"kubernetes.io/service-account.name" = "vault-auth-reviewer"}}
+            type = "kubernetes.io/service-account-token"
+        }
+        providerConfigRef = {name = _viTargetRef, kind = "ClusterProviderConfig"}
+    }
+}
+_viRevObserveObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {name = _viReviewerObserveKey, namespace = _namespace, annotations = {"krm.kcl.dev/composition-resource-name" = _viReviewerObserveKey}}
+    spec = {
+        managementPolicies = ["Observe"]
+        forProvider.manifest = {
+            apiVersion = "v1"
+            kind = "Secret"
+            metadata = {name = "vault-auth-reviewer-token", namespace = "kube-system"}
+        }
+        providerConfigRef = {name = _viTargetRef, kind = "ClusterProviderConfig"}
+    }
+}
+
+# Copy the observed ca.crt + token into a mgmt Secret the Workspace reads. Only
+# emitted once the token is observed (base64 values pass straight through).
+_viRevMgmtObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {name = "{}-reviewer-secret".format(_name), namespace = _namespace, annotations = {"krm.kcl.dev/composition-resource-name" = "{}-reviewer-secret".format(_name)}}
+    spec = {
+        forProvider.manifest = {
+            apiVersion = "v1"
+            kind = "Secret"
+            metadata = {name = _viReviewerMgmtSecret, namespace = _namespace}
+            type = "Opaque"
+            data = {"ca.crt" = _viRevCa, token = _viRevToken}
+        }
+        providerConfigRef = {name = "in-cluster", kind = "ClusterProviderConfig"}
+    }
+}
+_viReviewerObjects = ([_viRevSAObj, _viRevCRBObj, _viRevTokenObj, _viRevObserveObj] if _viAutoReviewer else []) + ([_viRevMgmtObj] if (_viAutoReviewer and _viRevToken != "") else [])
+
+_vaultIssuerChildren = ([_vaultK8sAuthXR, _vaultPkiSecretXR, _issuerObj, _tokenReqRoleObj, _tokenReqBindingObj] + _viReviewerObjects) if _vaultIssuerEnabled else []
 
 _children = ([_cniXR] if _cniEnabled else []) + ([_ipReservationXR] if _ipResEnabled else []) + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else []) + ([_ciliumXR] if (_ciliumEnabled and l.gateOpen(_networkReady, _ciliumKey in _ocds)) else []) + _vaultIssuerChildren
 


### PR DESCRIPTION
## What

Closes the one manual step in the `vaultIssuer` cert path — the Vault `token_reviewer_jwt`. `autoReviewer` (default on) provisions the whole reviewer chain instead of requiring a pre-made `reviewerSecret`:

- On the **target**: an `system:auth-delegator` ServiceAccount + ClusterRoleBinding + a long-lived token Secret (provider-kubernetes Objects).
- An **Observe** of that token Secret — provider-kubernetes exposes Secret `data` cross-cluster (verified live) — then a **copy** of its `ca.crt` + `token` into a mgmt Secret the VaultK8sAuth Workspace reads.

## Ordering (handled by gating)

VaultK8sAuth omits `backendConfig` (creates mount+role only) and the mgmt Secret is withheld until the target token is **observed**; on the next reconcile the copy lands and the Workspace configures the mount. An explicit `reviewerSecret` still bypasses auto-provisioning.

## Validation

`xplane-platform` 0.5.0 → 0.6.0. Tests **28/28**; render validated across three scenarios (no-token-yet → reviewer chain only + VaultK8sAuth waits; observed-token → mgmt copy + mount configured; explicit-secret → bypass).

This makes the whole tokenless cert path **hands-off** — no per-cluster reviewer secret prereq.

Generated with Claude Code

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ