### PR TITLE
feat(xplane-cluster-catalog): size + distribution catalog

### DIFF
--- a/crossplane/xplane-cluster-catalog/README.md
+++ b/crossplane/xplane-cluster-catalog/README.md
@@ -53,7 +53,7 @@ Every var in the tables is load-bearing, with the incident history in the commen
 
 `kubeconfigStage` is shared across distributions and deliberately **separate** from the distribution playbooks. A completed Tekton `PipelineRun` is immutable, so folding the upload into the distribution run would mean re-running the whole cluster build — including `cilium install` against a live cluster — to redo an upload. A unit test asserts no distribution absorbs it.
 
-> **Assumption:** this per-stage split follows option **A** of crossplane-configurations#168 (normalize both providers onto per-stage runs). If option B is chosen instead, `Distribution` needs a `staging: combined|per-stage` key.
+> **Decided:** this per-stage split is option **A** of crossplane-configurations#168 — normalize both providers onto per-stage runs — chosen 2026-07-27, staggered: the `cluster` Configuration emits per-stage runs for both providers from the start, while `machinery/vspherevm`'s own combined-run path stays as it is for direct users. So `Distribution` needs no `staging` key.
 
 ## API
 

--- a/crossplane/xplane-cluster-catalog/README.md
+++ b/crossplane/xplane-cluster-catalog/README.md
@@ -1,0 +1,77 @@
+# xplane-cluster-catalog
+
+Structural facts about the cluster shapes the stuttgart-things fleet builds: what a t-shirt `size` means, and how each Kubernetes distribution is installed.
+
+Consumed by the `cluster` Configuration in [stuttgart-things/crossplane-configurations](https://github.com/stuttgart-things/crossplane-configurations) (issue #167 / #169), the same way [`xplane-flux-catalog`](../xplane-flux-catalog/) is consumed by `xplane-platform`.
+
+## Why this exists
+
+The knobs a cluster varies on were spread across three unrelated places, and the rules connecting them existed only as **prose comments**. The sharpest example, from `xrs/proxmoxvm/labul/kind1/remotecluster-u26-kind1.yaml`:
+
+> This cluster already runs cilium (installed by `sthings.rke.k3s_cluster`, which must install it — the k3s config disables flannel and kube-proxy). A Platform XR for u26-kind1 must therefore leave `cni.enabled` off, or it would install a second CNI.
+
+and its mirror image in `platform-kind-test1.yaml`, where `cni.enabled: true` is correct *because* the kind cluster is deliberately built without one. Two clusters, opposite settings, and the only thing preventing a mistake was that someone read the comment.
+
+Here it is `cniOwnership`, and `platformCniEnabled(name)` derives the Platform setting from it. A unit test asserts the two are opposites.
+
+## What it holds — and what it does not
+
+**Structural facts only**: core counts, playbook names, var names, required inventory groups, CNI ownership. Environment-specific *values* — IPs, endpoints, Vault roles, credentials, template UUIDs — stay in the per-environment `EnvironmentConfig` or on the XR. Same line `xplane-flux-catalog` draws for apps.
+
+## Sizes
+
+| size | cpu | memory | disk | masters |
+|---|---|---|---|---|
+| `small` | 2 | 4096 | 40 | 1 |
+| `medium` | 4 | 8192 | 64 | 1 |
+| `large` | 8 | 16384 | 100 | 1 |
+| `medium-ha` | 4 | 8192 | 64 | **3** |
+
+Values are a rounding of what the fleet actually runs, not new invention: `small` is the vspherevm XRD default, `large` matches `kind-test1` (sized for a kind cluster plus crossplane, flux and the app catalog on top).
+
+All values are **strings** — both VM XRDs take strings, and emitting ints fails schema validation on the composed resource. A unit test enforces it.
+
+`medium-ha` is present so the shape is reviewable, but no current distribution accepts it: `assertSizeSupported()` rejects `masters > 1` unless the distribution declares `multiNode`. That is gated on crossplane-configurations#170 (static addressing + an aggregate ready gate) and #171 (the API endpoint is a single node IP today, so three masters would be HA in name only).
+
+## Distributions
+
+| | `k3s` | `kind` |
+|---|---|---|
+| playbook | `sthings.rke.k3s_cluster` | `sthings.container.kind` |
+| CNI ownership | `self` — the role installs cilium | `platform` — built deliberately without one |
+| inventory groups | `initial_master_node`, `additional_master_nodes`, `workers` | `all` |
+| multi-node | no | no |
+
+Every var in the tables is load-bearing, with the incident history in the comments. Two worth repeating:
+
+- **k3s `install_cilium: "true"` is mandatory.** The role's `k3s_config` default writes `flannel-backend=none`, `disable-kube-proxy=true` and `disable-network-policy=true` — k3s comes up deliberately without a CNI *and* without kube-proxy. With it false the cluster has no working pod network at all.
+- **k3s's three inventory groups are not cosmetic.** `sthings.rke.deploy_configure_rke` branches on `groups['initial_master_node']` and `groups['additional_master_nodes']`; a flat `all+[...]` inventory fails with an undefined-group error. Empty groups render as header-only INI sections, which ansible registers as existing-but-empty — exactly what the role's `in groups[...]` tests need.
+
+**`rke2` is deliberately absent.** The fleet runs multinode rke2 through ansible (`exec/labul/sthings-infra-rke2`), but no Crossplane path has ever built one, so an entry here would be a guess wearing the same clothes as a verified fact. Add it after a reference run — a unit test currently asserts its absence, so adding it forces updating that test in the same commit.
+
+## The kubeconfig-upload stage
+
+`kubeconfigStage` is shared across distributions and deliberately **separate** from the distribution playbooks. A completed Tekton `PipelineRun` is immutable, so folding the upload into the distribution run would mean re-running the whole cluster build — including `cilium install` against a live cluster — to redo an upload. A unit test asserts no distribution absorbs it.
+
+> **Assumption:** this per-stage split follows option **A** of crossplane-configurations#168 (normalize both providers onto per-stage runs). If option B is chosen instead, `Distribution` needs a `staging: combined|per-stage` key.
+
+## API
+
+```python
+import xplane_cluster_catalog as cat
+
+cat.getSize("medium")                       # -> Size, fails loudly on unknown
+cat.getDistribution("k3s")                  # -> Distribution, ditto
+cat.platformCniEnabled("k3s")               # -> False
+cat.assertSizeSupported("k3s", "medium-ha") # -> fails: no verified multi-node path
+cat.kubeconfigStage                         # -> Stage
+cat.sizeNames, cat.distributionNames        # sorted names, for error messages
+```
+
+## Test
+
+```bash
+kcl test .     # 11 tests, no Crossplane and no cluster required
+```
+
+The tests are the point: these rules — CNI ownership, the mandatory cilium var, the inventory groups, the separate upload stage — are exactly what should fail in CI rather than on a live cluster.

--- a/crossplane/xplane-cluster-catalog/catalog_test.k
+++ b/crossplane/xplane-cluster-catalog/catalog_test.k
@@ -1,0 +1,94 @@
+# Unit tests for the cluster catalog. Run with `kcl test`.
+# These validate the catalog's own invariants — no Crossplane, no cluster.
+import .main as c
+
+test_distributions_registered = lambda {
+    assert "k3s" in c.distributions
+    assert "kind" in c.distributions
+
+    # rke2 is deliberately absent until a reference run exists — if someone adds
+    # it, this test should be updated in the same commit as the reference run,
+    # not before.
+    assert "rke2" not in c.distributions
+}
+
+test_sizes_registered = lambda {
+    assert c.getSize("small").cpu == "2"
+    assert c.getSize("medium").memory == "8192"
+    assert c.getSize("large").disk == "100"
+}
+
+test_unknown_names_fail_loudly = lambda {
+    # Cannot assert on the failure itself in KCL, so assert the precondition the
+    # error message is built from: the known-name lists are non-empty and sorted.
+    assert len(c.distributionNames) > 0
+    assert len(c.sizeNames) > 0
+    assert c.distributionNames == sorted(c.distributionNames)
+}
+
+# --- The rule this catalog exists to make checkable ------------------------
+# "A k3s cluster must NOT get a Platform CNI; a kind cluster must." Until now
+# that lived only as a prose comment in two XR files.
+test_cni_ownership_is_opposite_for_k3s_and_kind = lambda {
+    assert c.getDistribution("k3s").cniOwnership == "self"
+    assert c.getDistribution("kind").cniOwnership == "platform"
+    assert not c.platformCniEnabled("k3s")
+    assert c.platformCniEnabled("kind")
+}
+
+# k3s writes flannel-backend=none + disable-kube-proxy=true, so the role MUST
+# install cilium. A k3s entry without it produces a cluster with no pod network
+# at all — the exact failure that made ansible/exec/labul/k3s-target-k3s useless.
+test_k3s_installs_cilium = lambda {
+    assert c.getDistribution("k3s").vars["install_cilium"] == "true"
+}
+
+# The role branches on groups['initial_master_node'] and
+# groups['additional_master_nodes']; a flat `all` inventory fails with an
+# undefined group.
+test_k3s_declares_the_required_inventory_groups = lambda {
+    _g = c.getDistribution("k3s").inventoryGroups
+    assert "initial_master_node" in _g
+    assert "additional_master_nodes" in _g
+    assert "workers" in _g
+}
+
+# kind must not rebuild on every reconcile (it would move the API port) and must
+# rewrite the kubeconfig address away from 0.0.0.0, which the API server cert is
+# not valid for.
+test_kind_is_reconcile_safe = lambda {
+    _v = c.getDistribution("kind").vars
+    assert _v["rebuild_kind_cluster"] == "false"
+    assert _v["update_kubeconfig_ip"] == "true"
+}
+
+# --- Multi-node gating -----------------------------------------------------
+test_multi_node_sizes_are_rejected_by_single_node_distributions = lambda {
+    # Both current distributions are single-node only, so every size with
+    # masters > 1 must be unbuildable through them. assertSizeSupported would
+    # fail the render; here we assert the data it decides on.
+    assert not c.getDistribution("k3s").multiNode
+    assert not c.getDistribution("kind").multiNode
+    assert c.getSize("medium-ha").masters == 3
+}
+
+test_single_node_sizes_are_supported = lambda {
+    assert c.assertSizeSupported("k3s", "medium")
+    assert c.assertSizeSupported("kind", "large")
+}
+
+# --- Shared stage ----------------------------------------------------------
+# The kubeconfig upload is its own stage precisely so it can be re-run without
+# re-running the cluster build; if it ever migrates into a distribution's
+# playbooks, that is a regression worth failing on.
+test_kubeconfig_upload_is_a_separate_stage = lambda {
+    assert c.kubeconfigStage.playbooks == ["sthings.container.upload_kubeconfig_vault"]
+    # KCL has no for-statement inside a lambda; count via a comprehension.
+    assert len([1 for _, d in c.distributions if "sthings.container.upload_kubeconfig_vault" in d.playbooks]) == 0
+}
+
+# Sizes are consumed as strings by both VM XRDs; an int would fail schema
+# validation on the composed resource.
+test_size_values_are_strings = lambda {
+    assert len([1 for _, s in c.sizes if typeof(s.cpu) != "str" or typeof(s.memory) != "str" or typeof(s.disk) != "str"]) == 0
+}

--- a/crossplane/xplane-cluster-catalog/distributions/k3s.k
+++ b/crossplane/xplane-cluster-catalog/distributions/k3s.k
@@ -1,0 +1,35 @@
+# k3s — single-node today.
+#
+# Every var here is load-bearing; see the header of
+# stuttgart-things/crossplane xrs/ansiblerun/labul/kind1/ansiblerun-k3s-u26-kind1.yaml
+# for the incident history behind them.
+import ..schema as s
+
+k3s: s.Distribution = s.Distribution {
+    playbooks = ["sthings.rke.k3s_cluster"]
+    vars = {
+        install_k3s = "true"
+        k3s_state = "present"
+        cluster_setup = "singlenode"
+        # MANDATORY. The role's k3s_config default writes flannel-backend=none,
+        # disable-kube-proxy=true and disable-network-policy=true — k3s comes up
+        # deliberately without a CNI and without kube-proxy. With this false the
+        # cluster has no working pod network at all.
+        install_cilium = "true"
+        prepare_rancher_ha_nodes = "true"
+        install_helm_diff = "false"
+        # Fetched to the ansible controller, i.e. the Tekton pod's ephemeral
+        # filesystem. On the node it stays at /etc/rancher/k3s/k3s.yaml with the
+        # API server address rewritten to the VM IP.
+        fetched_kubeconfig_path = "/tmp/kubeconfig"
+        ansible_become = "true"
+        ansible_become_method = "sudo"
+    }
+    inventoryGroups = ["initial_master_node", "additional_master_nodes", "workers"]
+    # The role installs cilium itself (see install_cilium above), so a Platform
+    # for a k3s cluster must leave cni.enabled off.
+    cniOwnership = "self"
+    # cluster_setup would have to become "multinode" and the groups populated
+    # from N VM IPs. Not verified in this fleet yet -> #170.
+    multiNode = False
+}

--- a/crossplane/xplane-cluster-catalog/distributions/kind.k
+++ b/crossplane/xplane-cluster-catalog/distributions/kind.k
@@ -1,0 +1,28 @@
+# kind — a Kubernetes-in-Docker cluster on a provisioned VM.
+#
+# Mirrors what nativevspherevm-kind-test1.yaml runs today.
+import ..schema as s
+
+kind: s.Distribution = s.Distribution {
+    playbooks = ["sthings.container.kind"]
+    vars = {
+        install_kind = "true"
+        create_kind_cluster = "true"
+        # false, so re-reconciles are idempotent instead of destroying and
+        # rebuilding the cluster (and moving the API port) on every run.
+        rebuild_kind_cluster = "false"
+        # `kind export kubeconfig` emits 0.0.0.0, which the API server
+        # certificate is not valid for — rewrite it to the VM's external IP.
+        update_kubeconfig_ip = "true"
+        fetch_kubeconfig = "true"
+        ansible_become = "true"
+        ansible_become_method = "sudo"
+    }
+    # The kind role targets the VM directly; no master/worker split (the kind
+    # NODES are containers on that one VM, expressed via count_* vars).
+    inventoryGroups = ["all"]
+    # kind is built deliberately WITHOUT a CNI, so the Platform's Cni component
+    # is required — the mirror image of k3s.
+    cniOwnership = "platform"
+    multiNode = False
+}

--- a/crossplane/xplane-cluster-catalog/kcl.mod
+++ b/crossplane/xplane-cluster-catalog/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "xplane-cluster-catalog"
+edition = "v0.12.3"
+version = "0.1.0"

--- a/crossplane/xplane-cluster-catalog/main.k
+++ b/crossplane/xplane-cluster-catalog/main.k
@@ -43,7 +43,8 @@ getSize = lambda name: str -> s.Size {
 # A SEPARATE stage, not appended to the distribution playbooks: a completed
 # Tekton PipelineRun is immutable, so folding the upload into the distribution
 # run would mean re-running the whole cluster build (including `cilium install`
-# against a live cluster) to redo an upload. cluster_name and the Vault path are
+# against a live cluster) to redo an upload. This is option A of
+# crossplane-configurations#168, decided — not an open assumption. cluster_name and the Vault path are
 # supplied by the consumer, not the catalog — they are per-cluster values.
 kubeconfigStage: s.Stage = s.Stage {
     playbooks = ["sthings.container.upload_kubeconfig_vault"]

--- a/crossplane/xplane-cluster-catalog/main.k
+++ b/crossplane/xplane-cluster-catalog/main.k
@@ -1,0 +1,76 @@
+# The cluster catalog registry.
+#
+# KCL has no file globbing, so every distribution is registered explicitly: add
+# distributions/<name>.k, then one import and one entry here. Keeping it manual
+# is the point — adding a distribution is a reviewable two-line diff.
+#
+# rke2 is DELIBERATELY ABSENT. The fleet runs multinode rke2 clusters through
+# ansible (exec/labul/sthings-infra-rke2), but no Crossplane path has ever built
+# one, so an entry here would be a guess wearing the same clothes as a verified
+# fact. Add it after a reference run, not before.
+import .distributions.k3s as k3s
+import .distributions.kind as kind
+import sizes as sz
+import schema as s
+
+distributions: {str:s.Distribution} = {
+    k3s = k3s.k3s
+    kind = kind.kind
+}
+
+sizes: {str:s.Size} = sz.sizeTable
+
+distributionNames = sorted(distributions)
+sizeNames = sorted(sizes)
+
+_knownDist = ", ".join(distributionNames)
+_knownSize = ", ".join(sizeNames)
+
+# Look up by name, failing loudly. KCL does NOT interpolate ${} inside assert
+# messages — it prints the placeholder literally — so concatenate.
+getDistribution = lambda name: str -> s.Distribution {
+    assert name in distributions, "unknown distribution '" + name + "' — known: " + _knownDist
+    distributions[name]
+}
+
+getSize = lambda name: str -> s.Size {
+    assert name in sizes, "unknown size '" + name + "' — known: " + _knownSize
+    sizes[name]
+}
+
+# The kubeconfig-upload stage, shared by every distribution.
+#
+# A SEPARATE stage, not appended to the distribution playbooks: a completed
+# Tekton PipelineRun is immutable, so folding the upload into the distribution
+# run would mean re-running the whole cluster build (including `cilium install`
+# against a live cluster) to redo an upload. cluster_name and the Vault path are
+# supplied by the consumer, not the catalog — they are per-cluster values.
+kubeconfigStage: s.Stage = s.Stage {
+    playbooks = ["sthings.container.upload_kubeconfig_vault"]
+    vars = {
+        secret_path_kubeconfig = "kubeconfigs"
+        # No-op safety net on k3s (the role already rewrote 127.0.0.1 to the VM
+        # IP) and on kind (update_kubeconfig_ip did it); harmless either way.
+        replace_ip = "true"
+        ansible_become = "true"
+        ansible_become_method = "sudo"
+    }
+    inventoryGroups = ["all"]
+}
+
+# Whether a Platform for a cluster of this distribution should enable its Cni
+# component. Derived, never declared twice: "self" means the distribution's own
+# role installed a CNI, so a second one would break the cluster.
+platformCniEnabled = lambda name: str -> bool {
+    getDistribution(name).cniOwnership == "platform"
+}
+
+# Reject a size the distribution cannot actually build. A consumer calling this
+# gets a readable error instead of silently provisioning one node when three
+# were asked for.
+assertSizeSupported = lambda distribution: str, size: str -> bool {
+    _d = getDistribution(distribution)
+    _s = getSize(size)
+    assert _s.masters == 1 or _d.multiNode, "distribution '" + distribution + "' has no verified multi-node path in this catalog — size '" + size + "' asks for " + str(_s.masters) + " masters (see crossplane-configurations#170)"
+    True
+}

--- a/crossplane/xplane-cluster-catalog/schema.k
+++ b/crossplane/xplane-cluster-catalog/schema.k
@@ -1,0 +1,101 @@
+"""
+Structural definitions for the stuttgart-things cluster catalog.
+
+Deliberately holds STRUCTURAL facts only — how many cores a `medium` has, which
+playbook installs k3s, which inventory groups its role requires, who owns the
+CNI. Environment-specific VALUES (IPs, endpoints, Vault roles, credentials,
+template UUIDs) are not here: they live in the per-environment EnvironmentConfig
+or on the XR. Same line xplane-flux-catalog draws for apps.
+
+The point is that the rules connecting these facts stop being prose. Today
+"a k3s cluster must not get a Platform CNI, a kind cluster must" exists only as
+a comment in two XR files in stuttgart-things/crossplane; here it is a field a
+consumer can check.
+"""
+
+schema Size:
+    """
+    A t-shirt size. cpu/memory/disk are STRINGS because both VM XRDs
+    (NativeProxmoxVM, NativeVsphereVM) take strings — emitting ints would fail
+    schema validation on the composed resource.
+    """
+    cpu: str
+    """vCPU count. -> vm.cpu on both providers."""
+
+    memory: str
+    """MiB. -> vm.memory (Proxmox) / vm.ram (vSphere). The rename is the
+    consumer's job; the catalog states the fact once."""
+
+    disk: str
+    """GiB. -> vm.disk on both providers."""
+
+    masters: int = 1
+    """Control-plane node count. 1 = singlenode. >1 requires static addressing
+    and an aggregate ready gate (crossplane-configurations#170), so a consumer
+    that cannot do those must reject it rather than silently building one node."""
+
+    workers: int = 0
+    """Worker node count."""
+
+    check:
+        int(cpu) > 0, "cpu must be a positive integer string"
+        int(memory) > 0, "memory must be a positive integer string (MiB)"
+        int(disk) > 0, "disk must be a positive integer string (GiB)"
+        masters > 0, "masters must be > 0"
+        workers >= 0, "workers must be >= 0"
+        masters == 1 or masters % 2 == 1, "masters must be odd — an even control-plane count cannot hold etcd quorum"
+
+schema Distribution:
+    """
+    How a Kubernetes distribution is installed on an already-provisioned VM.
+
+    This describes ONE ansible stage: the distribution install. The base-OS stage
+    runs from the VM XR's own `spec.ansible`, and the kubeconfig-upload stage is
+    shared across distributions (see `kubeconfigStage` in main.k) — they are
+    separate Tekton PipelineRuns because a completed run is immutable, so folding
+    them together would make re-doing one mean re-doing all.
+    """
+    playbooks: [str]
+    """Ansible playbooks for the distribution install."""
+
+    vars: {str:str}
+    """varsFile entries as key/value. The consumer renders them into the
+    ansible-run `key+-value` syntax; keeping them a map here means a consumer
+    can override one without re-stating the set."""
+
+    inventoryGroups: [str]
+    """Inventory groups the role REQUIRES to exist, in order. Not cosmetic:
+    sthings.rke.deploy_configure_rke branches on `groups['initial_master_node']`
+    and `groups['additional_master_nodes']`, so a flat `all+[...]` inventory
+    fails with an undefined-group error. Empty groups render as header-only INI
+    sections, which ansible registers as existing-but-empty — which is what the
+    role's `in groups[...]` tests need."""
+
+    cniOwnership: str
+    """Who installs the CNI:
+
+      "self"     — the distribution's own role does it (k3s: its config writes
+                   flannel-backend=none + disable-kube-proxy=true, so the role
+                   MUST install cilium). A Platform for such a cluster must
+                   leave cni.enabled off or it installs a second CNI.
+      "platform" — the cluster comes up deliberately without one (kind), and the
+                   Platform's Cni component is required.
+
+    This is the field that turns the rule into something checkable."""
+
+    multiNode: bool = False
+    """Whether this distribution supports masters > 1 through this catalog. False
+    is not a statement about the upstream distribution — it means the fleet has
+    no verified multi-node path for it here yet."""
+
+    check:
+        len(playbooks) > 0, "a distribution needs at least one playbook"
+        cniOwnership in ["self", "platform"], "cniOwnership must be 'self' or 'platform'"
+        len(inventoryGroups) > 0, "inventoryGroups must name at least one group"
+
+schema Stage:
+    """A shared ansible stage that is not distribution-specific."""
+    playbooks: [str]
+    vars: {str:str}
+    inventoryGroups: [str]
+

--- a/crossplane/xplane-cluster-catalog/sizes.k
+++ b/crossplane/xplane-cluster-catalog/sizes.k
@@ -1,0 +1,36 @@
+# T-shirt sizes.
+#
+# Values are a deliberate rounding of what the fleet actually runs, not new
+# invention: `small` is the vspherevm XRD default (2/4096), `medium` matches
+# nativeproxmoxvm-u26-eva (6/6144/40) rounded to 4/8192, `large` matches
+# nativevspherevm-kind-test1 (8/16384/100), which is sized for a kind cluster
+# plus crossplane + flux + the app catalog on top.
+import schema as s
+
+sizeTable: {str:s.Size} = {
+    small = s.Size {
+        cpu = "2"
+        memory = "4096"
+        disk = "40"
+    }
+    medium = s.Size {
+        cpu = "4"
+        memory = "8192"
+        disk = "64"
+    }
+    large = s.Size {
+        cpu = "8"
+        memory = "16384"
+        disk = "100"
+    }
+    # Three control-plane nodes. Gated on crossplane-configurations#170 (static
+    # addressing + aggregate ready gate) AND #171 (the API endpoint is a single
+    # node IP today, so 3 masters would be HA in name only). Present so the
+    # shape is reviewable; a consumer without those must reject masters > 1.
+    "medium-ha" = s.Size {
+        cpu = "4"
+        memory = "8192"
+        disk = "64"
+        masters = 3
+    }
+}


### PR DESCRIPTION
Implements the catalog half of stuttgart-things/crossplane-configurations#167.

## Why

The knobs a cluster varies on were spread across three unrelated places, and the rules connecting them existed only as **prose comments**. From `xrs/proxmoxvm/labul/kind1/remotecluster-u26-kind1.yaml`:

> This cluster already runs cilium (installed by `sthings.rke.k3s_cluster`, which must install it — the k3s config disables flannel and kube-proxy). A Platform XR for u26-kind1 must therefore leave `cni.enabled` off, or it would install a second CNI.

and its mirror image in `platform-kind-test1.yaml`, where `cni.enabled: true` is correct *because* kind is built without one. Two clusters, opposite settings, and the only thing preventing a mistake was that someone read the comment.

Here it is `cniOwnership`, `platformCniEnabled()` derives the Platform setting from it, and a unit test asserts the two are opposites.

## Contents

- **Sizes** `small` / `medium` / `large` / `medium-ha` — a rounding of what the fleet already runs, not new invention. All values are **strings** (both VM XRDs take strings; ints fail schema validation on the composed resource) — enforced by a test.
- **Distributions** `k3s` and `kind`, with the load-bearing vars and the incident history in the comments.
- **`kubeconfigStage`** — shared, and deliberately separate from the distribution playbooks.

## Deliberate omissions

**`rke2` is absent.** The fleet runs multinode rke2 through ansible (`exec/labul/sthings-infra-rke2`), but no Crossplane path has ever built one — an entry would be a guess wearing the clothes of a verified fact. A test asserts its absence, so adding it forces updating that test alongside the reference run.

**`medium-ha` is present but unbuildable.** `assertSizeSupported()` rejects `masters > 1` because no distribution declares `multiNode`. Gated on crossplane-configurations#170 (static addressing + aggregate ready gate) and #171 (the API endpoint is a single node IP today, so three masters would be HA in name only). The shape is there to be reviewed, not used.

## Two rules worth calling out in review

- **k3s `install_cilium: "true"` is mandatory**, not a preference: the role's `k3s_config` default writes `flannel-backend=none` + `disable-kube-proxy=true`, so without it the cluster has no working pod network at all.
- **k3s's three inventory groups are not cosmetic**: `deploy_configure_rke` branches on `groups['initial_master_node']` / `groups['additional_master_nodes']`, and a flat `all+[...]` inventory fails with an undefined-group error.

Both are asserted by tests.

## Assumption

The per-stage split (baseos / distribution / kubeconfig as separate PipelineRuns) follows **option A** of crossplane-configurations#168, which is recommended but not yet decided. If option B is chosen, `Distribution` needs a `staging: combined|per-stage` key — cheap to add now, annoying later, hence the flag in the README.

## Test

`kcl test .` → 11/11 pass. `kcl fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr
