### PR TITLE
feat(xplane-cluster): composition logic for the ClusterStack XR

### DIFF
--- a/crossplane/xplane-cluster-catalog/README.md
+++ b/crossplane/xplane-cluster-catalog/README.md
@@ -53,7 +53,7 @@ Every var in the tables is load-bearing, with the incident history in the commen
 
 `kubeconfigStage` is shared across distributions and deliberately **separate** from the distribution playbooks. A completed Tekton `PipelineRun` is immutable, so folding the upload into the distribution run would mean re-running the whole cluster build — including `cilium install` against a live cluster — to redo an upload. A unit test asserts no distribution absorbs it.
 
-> **Assumption:** this per-stage split follows option **A** of crossplane-configurations#168 (normalize both providers onto per-stage runs). If option B is chosen instead, `Distribution` needs a `staging: combined|per-stage` key.
+> **Decided:** this per-stage split is option **A** of crossplane-configurations#168 — normalize both providers onto per-stage runs — chosen 2026-07-27, staggered: the `cluster` Configuration emits per-stage runs for both providers from the start, while `machinery/vspherevm`'s own combined-run path stays as it is for direct users. So `Distribution` needs no `staging` key.
 
 ## API
 

--- a/crossplane/xplane-cluster-catalog/README.md
+++ b/crossplane/xplane-cluster-catalog/README.md
@@ -1,0 +1,77 @@
+# xplane-cluster-catalog
+
+Structural facts about the cluster shapes the stuttgart-things fleet builds: what a t-shirt `size` means, and how each Kubernetes distribution is installed.
+
+Consumed by the `cluster` Configuration in [stuttgart-things/crossplane-configurations](https://github.com/stuttgart-things/crossplane-configurations) (issue #167 / #169), the same way [`xplane-flux-catalog`](../xplane-flux-catalog/) is consumed by `xplane-platform`.
+
+## Why this exists
+
+The knobs a cluster varies on were spread across three unrelated places, and the rules connecting them existed only as **prose comments**. The sharpest example, from `xrs/proxmoxvm/labul/kind1/remotecluster-u26-kind1.yaml`:
+
+> This cluster already runs cilium (installed by `sthings.rke.k3s_cluster`, which must install it — the k3s config disables flannel and kube-proxy). A Platform XR for u26-kind1 must therefore leave `cni.enabled` off, or it would install a second CNI.
+
+and its mirror image in `platform-kind-test1.yaml`, where `cni.enabled: true` is correct *because* the kind cluster is deliberately built without one. Two clusters, opposite settings, and the only thing preventing a mistake was that someone read the comment.
+
+Here it is `cniOwnership`, and `platformCniEnabled(name)` derives the Platform setting from it. A unit test asserts the two are opposites.
+
+## What it holds — and what it does not
+
+**Structural facts only**: core counts, playbook names, var names, required inventory groups, CNI ownership. Environment-specific *values* — IPs, endpoints, Vault roles, credentials, template UUIDs — stay in the per-environment `EnvironmentConfig` or on the XR. Same line `xplane-flux-catalog` draws for apps.
+
+## Sizes
+
+| size | cpu | memory | disk | masters |
+|---|---|---|---|---|
+| `small` | 2 | 4096 | 40 | 1 |
+| `medium` | 4 | 8192 | 64 | 1 |
+| `large` | 8 | 16384 | 100 | 1 |
+| `medium-ha` | 4 | 8192 | 64 | **3** |
+
+Values are a rounding of what the fleet actually runs, not new invention: `small` is the vspherevm XRD default, `large` matches `kind-test1` (sized for a kind cluster plus crossplane, flux and the app catalog on top).
+
+All values are **strings** — both VM XRDs take strings, and emitting ints fails schema validation on the composed resource. A unit test enforces it.
+
+`medium-ha` is present so the shape is reviewable, but no current distribution accepts it: `assertSizeSupported()` rejects `masters > 1` unless the distribution declares `multiNode`. That is gated on crossplane-configurations#170 (static addressing + an aggregate ready gate) and #171 (the API endpoint is a single node IP today, so three masters would be HA in name only).
+
+## Distributions
+
+| | `k3s` | `kind` |
+|---|---|---|
+| playbook | `sthings.rke.k3s_cluster` | `sthings.container.kind` |
+| CNI ownership | `self` — the role installs cilium | `platform` — built deliberately without one |
+| inventory groups | `initial_master_node`, `additional_master_nodes`, `workers` | `all` |
+| multi-node | no | no |
+
+Every var in the tables is load-bearing, with the incident history in the comments. Two worth repeating:
+
+- **k3s `install_cilium: "true"` is mandatory.** The role's `k3s_config` default writes `flannel-backend=none`, `disable-kube-proxy=true` and `disable-network-policy=true` — k3s comes up deliberately without a CNI *and* without kube-proxy. With it false the cluster has no working pod network at all.
+- **k3s's three inventory groups are not cosmetic.** `sthings.rke.deploy_configure_rke` branches on `groups['initial_master_node']` and `groups['additional_master_nodes']`; a flat `all+[...]` inventory fails with an undefined-group error. Empty groups render as header-only INI sections, which ansible registers as existing-but-empty — exactly what the role's `in groups[...]` tests need.
+
+**`rke2` is deliberately absent.** The fleet runs multinode rke2 through ansible (`exec/labul/sthings-infra-rke2`), but no Crossplane path has ever built one, so an entry here would be a guess wearing the same clothes as a verified fact. Add it after a reference run — a unit test currently asserts its absence, so adding it forces updating that test in the same commit.
+
+## The kubeconfig-upload stage
+
+`kubeconfigStage` is shared across distributions and deliberately **separate** from the distribution playbooks. A completed Tekton `PipelineRun` is immutable, so folding the upload into the distribution run would mean re-running the whole cluster build — including `cilium install` against a live cluster — to redo an upload. A unit test asserts no distribution absorbs it.
+
+> **Assumption:** this per-stage split follows option **A** of crossplane-configurations#168 (normalize both providers onto per-stage runs). If option B is chosen instead, `Distribution` needs a `staging: combined|per-stage` key.
+
+## API
+
+```python
+import xplane_cluster_catalog as cat
+
+cat.getSize("medium")                       # -> Size, fails loudly on unknown
+cat.getDistribution("k3s")                  # -> Distribution, ditto
+cat.platformCniEnabled("k3s")               # -> False
+cat.assertSizeSupported("k3s", "medium-ha") # -> fails: no verified multi-node path
+cat.kubeconfigStage                         # -> Stage
+cat.sizeNames, cat.distributionNames        # sorted names, for error messages
+```
+
+## Test
+
+```bash
+kcl test .     # 11 tests, no Crossplane and no cluster required
+```
+
+The tests are the point: these rules — CNI ownership, the mandatory cilium var, the inventory groups, the separate upload stage — are exactly what should fail in CI rather than on a live cluster.

--- a/crossplane/xplane-cluster-catalog/catalog_test.k
+++ b/crossplane/xplane-cluster-catalog/catalog_test.k
@@ -1,0 +1,94 @@
+# Unit tests for the cluster catalog. Run with `kcl test`.
+# These validate the catalog's own invariants — no Crossplane, no cluster.
+import .main as c
+
+test_distributions_registered = lambda {
+    assert "k3s" in c.distributions
+    assert "kind" in c.distributions
+
+    # rke2 is deliberately absent until a reference run exists — if someone adds
+    # it, this test should be updated in the same commit as the reference run,
+    # not before.
+    assert "rke2" not in c.distributions
+}
+
+test_sizes_registered = lambda {
+    assert c.getSize("small").cpu == "2"
+    assert c.getSize("medium").memory == "8192"
+    assert c.getSize("large").disk == "100"
+}
+
+test_unknown_names_fail_loudly = lambda {
+    # Cannot assert on the failure itself in KCL, so assert the precondition the
+    # error message is built from: the known-name lists are non-empty and sorted.
+    assert len(c.distributionNames) > 0
+    assert len(c.sizeNames) > 0
+    assert c.distributionNames == sorted(c.distributionNames)
+}
+
+# --- The rule this catalog exists to make checkable ------------------------
+# "A k3s cluster must NOT get a Platform CNI; a kind cluster must." Until now
+# that lived only as a prose comment in two XR files.
+test_cni_ownership_is_opposite_for_k3s_and_kind = lambda {
+    assert c.getDistribution("k3s").cniOwnership == "self"
+    assert c.getDistribution("kind").cniOwnership == "platform"
+    assert not c.platformCniEnabled("k3s")
+    assert c.platformCniEnabled("kind")
+}
+
+# k3s writes flannel-backend=none + disable-kube-proxy=true, so the role MUST
+# install cilium. A k3s entry without it produces a cluster with no pod network
+# at all — the exact failure that made ansible/exec/labul/k3s-target-k3s useless.
+test_k3s_installs_cilium = lambda {
+    assert c.getDistribution("k3s").vars["install_cilium"] == "true"
+}
+
+# The role branches on groups['initial_master_node'] and
+# groups['additional_master_nodes']; a flat `all` inventory fails with an
+# undefined group.
+test_k3s_declares_the_required_inventory_groups = lambda {
+    _g = c.getDistribution("k3s").inventoryGroups
+    assert "initial_master_node" in _g
+    assert "additional_master_nodes" in _g
+    assert "workers" in _g
+}
+
+# kind must not rebuild on every reconcile (it would move the API port) and must
+# rewrite the kubeconfig address away from 0.0.0.0, which the API server cert is
+# not valid for.
+test_kind_is_reconcile_safe = lambda {
+    _v = c.getDistribution("kind").vars
+    assert _v["rebuild_kind_cluster"] == "false"
+    assert _v["update_kubeconfig_ip"] == "true"
+}
+
+# --- Multi-node gating -----------------------------------------------------
+test_multi_node_sizes_are_rejected_by_single_node_distributions = lambda {
+    # Both current distributions are single-node only, so every size with
+    # masters > 1 must be unbuildable through them. assertSizeSupported would
+    # fail the render; here we assert the data it decides on.
+    assert not c.getDistribution("k3s").multiNode
+    assert not c.getDistribution("kind").multiNode
+    assert c.getSize("medium-ha").masters == 3
+}
+
+test_single_node_sizes_are_supported = lambda {
+    assert c.assertSizeSupported("k3s", "medium")
+    assert c.assertSizeSupported("kind", "large")
+}
+
+# --- Shared stage ----------------------------------------------------------
+# The kubeconfig upload is its own stage precisely so it can be re-run without
+# re-running the cluster build; if it ever migrates into a distribution's
+# playbooks, that is a regression worth failing on.
+test_kubeconfig_upload_is_a_separate_stage = lambda {
+    assert c.kubeconfigStage.playbooks == ["sthings.container.upload_kubeconfig_vault"]
+    # KCL has no for-statement inside a lambda; count via a comprehension.
+    assert len([1 for _, d in c.distributions if "sthings.container.upload_kubeconfig_vault" in d.playbooks]) == 0
+}
+
+# Sizes are consumed as strings by both VM XRDs; an int would fail schema
+# validation on the composed resource.
+test_size_values_are_strings = lambda {
+    assert len([1 for _, s in c.sizes if typeof(s.cpu) != "str" or typeof(s.memory) != "str" or typeof(s.disk) != "str"]) == 0
+}

--- a/crossplane/xplane-cluster-catalog/distributions/k3s.k
+++ b/crossplane/xplane-cluster-catalog/distributions/k3s.k
@@ -1,0 +1,35 @@
+# k3s — single-node today.
+#
+# Every var here is load-bearing; see the header of
+# stuttgart-things/crossplane xrs/ansiblerun/labul/kind1/ansiblerun-k3s-u26-kind1.yaml
+# for the incident history behind them.
+import ..schema as s
+
+k3s: s.Distribution = s.Distribution {
+    playbooks = ["sthings.rke.k3s_cluster"]
+    vars = {
+        install_k3s = "true"
+        k3s_state = "present"
+        cluster_setup = "singlenode"
+        # MANDATORY. The role's k3s_config default writes flannel-backend=none,
+        # disable-kube-proxy=true and disable-network-policy=true — k3s comes up
+        # deliberately without a CNI and without kube-proxy. With this false the
+        # cluster has no working pod network at all.
+        install_cilium = "true"
+        prepare_rancher_ha_nodes = "true"
+        install_helm_diff = "false"
+        # Fetched to the ansible controller, i.e. the Tekton pod's ephemeral
+        # filesystem. On the node it stays at /etc/rancher/k3s/k3s.yaml with the
+        # API server address rewritten to the VM IP.
+        fetched_kubeconfig_path = "/tmp/kubeconfig"
+        ansible_become = "true"
+        ansible_become_method = "sudo"
+    }
+    inventoryGroups = ["initial_master_node", "additional_master_nodes", "workers"]
+    # The role installs cilium itself (see install_cilium above), so a Platform
+    # for a k3s cluster must leave cni.enabled off.
+    cniOwnership = "self"
+    # cluster_setup would have to become "multinode" and the groups populated
+    # from N VM IPs. Not verified in this fleet yet -> #170.
+    multiNode = False
+}

--- a/crossplane/xplane-cluster-catalog/distributions/kind.k
+++ b/crossplane/xplane-cluster-catalog/distributions/kind.k
@@ -1,0 +1,28 @@
+# kind — a Kubernetes-in-Docker cluster on a provisioned VM.
+#
+# Mirrors what nativevspherevm-kind-test1.yaml runs today.
+import ..schema as s
+
+kind: s.Distribution = s.Distribution {
+    playbooks = ["sthings.container.kind"]
+    vars = {
+        install_kind = "true"
+        create_kind_cluster = "true"
+        # false, so re-reconciles are idempotent instead of destroying and
+        # rebuilding the cluster (and moving the API port) on every run.
+        rebuild_kind_cluster = "false"
+        # `kind export kubeconfig` emits 0.0.0.0, which the API server
+        # certificate is not valid for — rewrite it to the VM's external IP.
+        update_kubeconfig_ip = "true"
+        fetch_kubeconfig = "true"
+        ansible_become = "true"
+        ansible_become_method = "sudo"
+    }
+    # The kind role targets the VM directly; no master/worker split (the kind
+    # NODES are containers on that one VM, expressed via count_* vars).
+    inventoryGroups = ["all"]
+    # kind is built deliberately WITHOUT a CNI, so the Platform's Cni component
+    # is required — the mirror image of k3s.
+    cniOwnership = "platform"
+    multiNode = False
+}

--- a/crossplane/xplane-cluster-catalog/kcl.mod
+++ b/crossplane/xplane-cluster-catalog/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "xplane-cluster-catalog"
+edition = "v0.12.3"
+version = "0.1.0"

--- a/crossplane/xplane-cluster-catalog/main.k
+++ b/crossplane/xplane-cluster-catalog/main.k
@@ -43,7 +43,8 @@ getSize = lambda name: str -> s.Size {
 # A SEPARATE stage, not appended to the distribution playbooks: a completed
 # Tekton PipelineRun is immutable, so folding the upload into the distribution
 # run would mean re-running the whole cluster build (including `cilium install`
-# against a live cluster) to redo an upload. cluster_name and the Vault path are
+# against a live cluster) to redo an upload. This is option A of
+# crossplane-configurations#168, decided — not an open assumption. cluster_name and the Vault path are
 # supplied by the consumer, not the catalog — they are per-cluster values.
 kubeconfigStage: s.Stage = s.Stage {
     playbooks = ["sthings.container.upload_kubeconfig_vault"]

--- a/crossplane/xplane-cluster-catalog/main.k
+++ b/crossplane/xplane-cluster-catalog/main.k
@@ -1,0 +1,76 @@
+# The cluster catalog registry.
+#
+# KCL has no file globbing, so every distribution is registered explicitly: add
+# distributions/<name>.k, then one import and one entry here. Keeping it manual
+# is the point — adding a distribution is a reviewable two-line diff.
+#
+# rke2 is DELIBERATELY ABSENT. The fleet runs multinode rke2 clusters through
+# ansible (exec/labul/sthings-infra-rke2), but no Crossplane path has ever built
+# one, so an entry here would be a guess wearing the same clothes as a verified
+# fact. Add it after a reference run, not before.
+import .distributions.k3s as k3s
+import .distributions.kind as kind
+import sizes as sz
+import schema as s
+
+distributions: {str:s.Distribution} = {
+    k3s = k3s.k3s
+    kind = kind.kind
+}
+
+sizes: {str:s.Size} = sz.sizeTable
+
+distributionNames = sorted(distributions)
+sizeNames = sorted(sizes)
+
+_knownDist = ", ".join(distributionNames)
+_knownSize = ", ".join(sizeNames)
+
+# Look up by name, failing loudly. KCL does NOT interpolate ${} inside assert
+# messages — it prints the placeholder literally — so concatenate.
+getDistribution = lambda name: str -> s.Distribution {
+    assert name in distributions, "unknown distribution '" + name + "' — known: " + _knownDist
+    distributions[name]
+}
+
+getSize = lambda name: str -> s.Size {
+    assert name in sizes, "unknown size '" + name + "' — known: " + _knownSize
+    sizes[name]
+}
+
+# The kubeconfig-upload stage, shared by every distribution.
+#
+# A SEPARATE stage, not appended to the distribution playbooks: a completed
+# Tekton PipelineRun is immutable, so folding the upload into the distribution
+# run would mean re-running the whole cluster build (including `cilium install`
+# against a live cluster) to redo an upload. cluster_name and the Vault path are
+# supplied by the consumer, not the catalog — they are per-cluster values.
+kubeconfigStage: s.Stage = s.Stage {
+    playbooks = ["sthings.container.upload_kubeconfig_vault"]
+    vars = {
+        secret_path_kubeconfig = "kubeconfigs"
+        # No-op safety net on k3s (the role already rewrote 127.0.0.1 to the VM
+        # IP) and on kind (update_kubeconfig_ip did it); harmless either way.
+        replace_ip = "true"
+        ansible_become = "true"
+        ansible_become_method = "sudo"
+    }
+    inventoryGroups = ["all"]
+}
+
+# Whether a Platform for a cluster of this distribution should enable its Cni
+# component. Derived, never declared twice: "self" means the distribution's own
+# role installed a CNI, so a second one would break the cluster.
+platformCniEnabled = lambda name: str -> bool {
+    getDistribution(name).cniOwnership == "platform"
+}
+
+# Reject a size the distribution cannot actually build. A consumer calling this
+# gets a readable error instead of silently provisioning one node when three
+# were asked for.
+assertSizeSupported = lambda distribution: str, size: str -> bool {
+    _d = getDistribution(distribution)
+    _s = getSize(size)
+    assert _s.masters == 1 or _d.multiNode, "distribution '" + distribution + "' has no verified multi-node path in this catalog — size '" + size + "' asks for " + str(_s.masters) + " masters (see crossplane-configurations#170)"
+    True
+}

--- a/crossplane/xplane-cluster-catalog/schema.k
+++ b/crossplane/xplane-cluster-catalog/schema.k
@@ -1,0 +1,101 @@
+"""
+Structural definitions for the stuttgart-things cluster catalog.
+
+Deliberately holds STRUCTURAL facts only — how many cores a `medium` has, which
+playbook installs k3s, which inventory groups its role requires, who owns the
+CNI. Environment-specific VALUES (IPs, endpoints, Vault roles, credentials,
+template UUIDs) are not here: they live in the per-environment EnvironmentConfig
+or on the XR. Same line xplane-flux-catalog draws for apps.
+
+The point is that the rules connecting these facts stop being prose. Today
+"a k3s cluster must not get a Platform CNI, a kind cluster must" exists only as
+a comment in two XR files in stuttgart-things/crossplane; here it is a field a
+consumer can check.
+"""
+
+schema Size:
+    """
+    A t-shirt size. cpu/memory/disk are STRINGS because both VM XRDs
+    (NativeProxmoxVM, NativeVsphereVM) take strings — emitting ints would fail
+    schema validation on the composed resource.
+    """
+    cpu: str
+    """vCPU count. -> vm.cpu on both providers."""
+
+    memory: str
+    """MiB. -> vm.memory (Proxmox) / vm.ram (vSphere). The rename is the
+    consumer's job; the catalog states the fact once."""
+
+    disk: str
+    """GiB. -> vm.disk on both providers."""
+
+    masters: int = 1
+    """Control-plane node count. 1 = singlenode. >1 requires static addressing
+    and an aggregate ready gate (crossplane-configurations#170), so a consumer
+    that cannot do those must reject it rather than silently building one node."""
+
+    workers: int = 0
+    """Worker node count."""
+
+    check:
+        int(cpu) > 0, "cpu must be a positive integer string"
+        int(memory) > 0, "memory must be a positive integer string (MiB)"
+        int(disk) > 0, "disk must be a positive integer string (GiB)"
+        masters > 0, "masters must be > 0"
+        workers >= 0, "workers must be >= 0"
+        masters == 1 or masters % 2 == 1, "masters must be odd — an even control-plane count cannot hold etcd quorum"
+
+schema Distribution:
+    """
+    How a Kubernetes distribution is installed on an already-provisioned VM.
+
+    This describes ONE ansible stage: the distribution install. The base-OS stage
+    runs from the VM XR's own `spec.ansible`, and the kubeconfig-upload stage is
+    shared across distributions (see `kubeconfigStage` in main.k) — they are
+    separate Tekton PipelineRuns because a completed run is immutable, so folding
+    them together would make re-doing one mean re-doing all.
+    """
+    playbooks: [str]
+    """Ansible playbooks for the distribution install."""
+
+    vars: {str:str}
+    """varsFile entries as key/value. The consumer renders them into the
+    ansible-run `key+-value` syntax; keeping them a map here means a consumer
+    can override one without re-stating the set."""
+
+    inventoryGroups: [str]
+    """Inventory groups the role REQUIRES to exist, in order. Not cosmetic:
+    sthings.rke.deploy_configure_rke branches on `groups['initial_master_node']`
+    and `groups['additional_master_nodes']`, so a flat `all+[...]` inventory
+    fails with an undefined-group error. Empty groups render as header-only INI
+    sections, which ansible registers as existing-but-empty — which is what the
+    role's `in groups[...]` tests need."""
+
+    cniOwnership: str
+    """Who installs the CNI:
+
+      "self"     — the distribution's own role does it (k3s: its config writes
+                   flannel-backend=none + disable-kube-proxy=true, so the role
+                   MUST install cilium). A Platform for such a cluster must
+                   leave cni.enabled off or it installs a second CNI.
+      "platform" — the cluster comes up deliberately without one (kind), and the
+                   Platform's Cni component is required.
+
+    This is the field that turns the rule into something checkable."""
+
+    multiNode: bool = False
+    """Whether this distribution supports masters > 1 through this catalog. False
+    is not a statement about the upstream distribution — it means the fleet has
+    no verified multi-node path for it here yet."""
+
+    check:
+        len(playbooks) > 0, "a distribution needs at least one playbook"
+        cniOwnership in ["self", "platform"], "cniOwnership must be 'self' or 'platform'"
+        len(inventoryGroups) > 0, "inventoryGroups must name at least one group"
+
+schema Stage:
+    """A shared ansible stage that is not distribution-specific."""
+    playbooks: [str]
+    vars: {str:str}
+    inventoryGroups: [str]
+

--- a/crossplane/xplane-cluster-catalog/sizes.k
+++ b/crossplane/xplane-cluster-catalog/sizes.k
@@ -1,0 +1,36 @@
+# T-shirt sizes.
+#
+# Values are a deliberate rounding of what the fleet actually runs, not new
+# invention: `small` is the vspherevm XRD default (2/4096), `medium` matches
+# nativeproxmoxvm-u26-eva (6/6144/40) rounded to 4/8192, `large` matches
+# nativevspherevm-kind-test1 (8/16384/100), which is sized for a kind cluster
+# plus crossplane + flux + the app catalog on top.
+import schema as s
+
+sizeTable: {str:s.Size} = {
+    small = s.Size {
+        cpu = "2"
+        memory = "4096"
+        disk = "40"
+    }
+    medium = s.Size {
+        cpu = "4"
+        memory = "8192"
+        disk = "64"
+    }
+    large = s.Size {
+        cpu = "8"
+        memory = "16384"
+        disk = "100"
+    }
+    # Three control-plane nodes. Gated on crossplane-configurations#170 (static
+    # addressing + aggregate ready gate) AND #171 (the API endpoint is a single
+    # node IP today, so 3 masters would be HA in name only). Present so the
+    # shape is reviewable; a consumer without those must reject masters > 1.
+    "medium-ha" = s.Size {
+        cpu = "4"
+        memory = "8192"
+        disk = "64"
+        masters = 3
+    }
+}

--- a/crossplane/xplane-cluster/README.md
+++ b/crossplane/xplane-cluster/README.md
@@ -1,0 +1,74 @@
+# xplane-cluster
+
+Composition logic for the `ClusterStack` XR in [stuttgart-things/crossplane-configurations](https://github.com/stuttgart-things/crossplane-configurations) (`bootstrap/cluster`, issue #169): one XR that builds a cluster from a bare VM up through its platform.
+
+Depends on [`xplane-cluster-catalog`](../xplane-cluster-catalog/) for sizes and distributions.
+
+## What it emits
+
+```
+ClusterStack
+├─ NativeProxmoxVM | NativeVsphereVM   {name}-vm            VM + base-OS ansible
+├─ AnsibleRun                          {name}-distribution  k3s / kind install
+├─ AnsibleRun                          {name}-kubeconfig    kubeconfig -> Vault
+├─ ClusterAccess                       {name}-access        -> the ClusterProviderConfigs
+├─ Platform                            {name}-platform      flux, apps, cilium, …
+└─ Usage ×3                                                 teardown ordering
+```
+
+## The two things that make this non-trivial
+
+### Sticky, success-based gates
+
+Every stage is gated on `(the previous stage SUCCEEDED) OR (this child already exists)`.
+
+The second clause is not defensive programming — it is the difference between working and destructive. **Not emitting a composed resource is what makes Crossplane delete it**, and bpg / VMware Tools both read the VM address from the guest agent, so a momentarily empty value is normal rather than exceptional. Without stickiness a blip deletes an `AnsibleRun`, and its recreation re-runs the play against a live machine. That failure was real (crossplane-configurations#163).
+
+The `AnsibleRun` children are additionally re-emitted **verbatim from `ocds`** rather than rebuilt: during the very blip being defended against the IP is empty, so a rebuild would rewrite the inventory to nothing — and since the wrapped Object excludes `Update`, that rewrite would silently never reach Tekton.
+
+Gates check **`succeeded`, not `Ready`**. An `AnsibleRun` whose PipelineRun failed still reports Ready once its Object is applied; unblocking on that would run a kubeconfig upload against a cluster that was never installed.
+
+### Teardown ordering
+
+Three `Usage` resources, only the pairs whose absence strands a finalizer:
+
+| `of` (dies last) | `by` (dies first) | why |
+|---|---|---|
+| VM | Platform | else every Platform Object hangs against a dead API server |
+| ClusterAccess | Platform | else the ClusterProviderConfigs its Objects reference are gone before they can be finalized |
+| VM | ClusterAccess | so the Vault read ends before the machine does |
+
+`Usage` orders **deletion only, never creation** — build order stays the ready gates. The AnsibleRuns need no protection: they only create PipelineRuns on the management cluster, and those disappearing blocks nobody.
+
+## Provider differences: exactly one
+
+`vm.memory` (Proxmox) vs `vm.ram` (vSphere), plus the fact that only Proxmox has a `cloudInit` block. Staging, gating and everything downstream are identical — that is option **A** of crossplane-configurations#168. A unit test asserts there is no second difference; if one appears, the "provider is a one-word switch" claim is no longer true and the README should stop saying it.
+
+## What the user cannot set
+
+`Platform.cni.enabled` comes from the catalog's `cniOwnership`, never from `spec.platform.cni.enabled`. A k3s role installs cilium itself; a kind cluster is built without one. Setting it by hand is how a cluster ends up with two CNIs. The user's other `cni` keys (chart version, values) pass through untouched — only `enabled` is overridden, and a test covers both halves.
+
+`Platform.clusterName` is likewise supplied, not passed through.
+
+## Layout
+
+| file | role |
+|---|---|
+| `logic.k` | pure resource construction — explicit args in, dict out, unit-tested |
+| `main.k` | wiring: reads `option("params")`, decides which gates are open, patches status |
+| `logic_test.k` | 15 tests, no Crossplane and no cluster required |
+
+`main.k` is deliberately thin and untested-by-unit: it is exercised by the Configuration's `crossplane render` with synthetic `--observed-resources`, which is the only way to test gate transitions honestly.
+
+## Test
+
+```bash
+kcl test .
+```
+
+## Gotchas found while writing this (KCL, not Crossplane)
+
+- **Commas are load-bearing in multi-line list literals.** `[a]` followed by a line starting with `[` parses as a *subscript*, silently dropping entries instead of failing. Cost an hour; the assembled `items` list carries a comment.
+- **No `enumerate()`**, and no multi-line ternary chains — both are single-line or comprehension-only.
+- **A dict literal is typed by its keys**, so `base | {newKey = …}` fails type checking. Tests write specs out in full instead of merging.
+- **A bare top-level name is part of the output document.** `oxr`/`ocds` must be `_`-prefixed or `kcl run` echoes the whole observed state.

--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,0 +1,7 @@
+[package]
+name = "xplane-cluster"
+edition = "v0.12.3"
+version = "0.1.0"
+
+[dependencies]
+xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-cluster/kcl.mod.lock
+++ b/crossplane/xplane-cluster/kcl.mod.lock
@@ -1,0 +1,9 @@
+[dependencies]
+  [dependencies.xplane-cluster-catalog]
+    name = "xplane-cluster-catalog"
+    full_name = "xplane-cluster-catalog_0.1.0"
+    version = "0.1.0"
+    sum = "o0qoOtvf7+vKAHre1LXbWlu6PqV6uVq35CCuf+LXFPg="
+    reg = "ghcr.io"
+    repo = "stuttgart-things/xplane-cluster-catalog"
+    oci_tag = "0.1.0"

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -1,0 +1,251 @@
+"""
+Resource construction for the ClusterStack XR.
+
+Pure functions only — everything here takes explicit arguments and returns a
+dict, so it can be unit-tested without Crossplane, a cluster, or an ocds map.
+main.k does the wiring: it reads option("params"), decides which stages are
+open, and calls these.
+
+The build order is:
+
+    VM (+ base-OS ansible)  ->  distribution run  ->  kubeconfig upload
+                            ->  ClusterAccess     ->  Platform
+
+Each stage is gated on the previous one having actually SUCCEEDED, and every
+gate is sticky (see main.k): once a child exists it keeps being emitted, because
+not emitting a composed resource is what makes Crossplane delete it — and a
+deleted, recreated AnsibleRun re-runs its play against a live machine.
+"""
+
+import xplane_cluster_catalog as cat
+
+# --- small helpers ---------------------------------------------------------
+
+# The ansible-run XR takes vars as "key+-value" strings; the catalog holds them
+# as a map so a consumer can override one entry without restating the set.
+renderVars = lambda vars: {str:str} -> [str] {
+    ["{}+-{}".format(k, v) for k, v in vars]
+}
+
+# Inventory in the ansible-run `group+[...]` syntax. The FIRST group gets the
+# host; the rest are emitted present-but-empty.
+#
+# Empty groups are not decoration: sthings.rke.deploy_configure_rke branches on
+# `groups['initial_master_node']` and `groups['additional_master_nodes']`, so a
+# flat `all+[...]` inventory fails with an undefined-group error. Header-only
+# INI sections register as existing-but-empty, which is what the role's
+# `in groups[...]` tests need.
+renderInventory = lambda groups: [str], ip: str -> [str] {
+    # No enumerate() in KCL — index by position against the first element.
+    [('{}+["{}"]'.format(g, ip) if g == groups[0] else "{}+[]".format(g)) for g in groups]
+}
+
+# --- the VM child ----------------------------------------------------------
+vmChild = lambda name: str, ns: str, spec: {str:any}, size: any -> {str:any} {
+    _provider = spec?.provider or "proxmox"
+    _cluster = spec?.clusterName or name
+    _vm = spec?.vm or {}
+    _ans = spec?.ansible or {}
+
+    # Base-OS stage. vm_hostname is not cosmetic on Proxmox: bpg cloud-init
+    # cannot set the guest hostname without a snippets datastore, so
+    # sthings.baseos.setup does it from this var.
+    _baseVars = [
+        "manage_filesystem+-true"
+        "update_packages+-true"
+        "vm_hostname+-{}".format(_cluster)
+    ] + (_ans?.extraVars or [])
+
+    _ansible = {
+        enabled = True
+        playbooks = ["sthings.baseos.setup"]
+        varsFile = _baseVars
+        crossplaneProviderConfig = _ans?.crossplaneProviderConfig or "in-cluster"
+        pipelineNamespace = _ans?.pipelineNamespace or "tekton-ci"
+        if _ans?.extraCollections:
+            extraCollections = _ans.extraCollections
+        if _ans?.ansibleWorkingImage:
+            ansibleWorkingImage = _ans.ansibleWorkingImage
+    }
+
+    _common = {
+        metadata = {
+            name = "{}-vm".format(name)
+            namespace = ns
+            annotations = {"krm.kcl.dev/composition-resource-name" = "vm"}
+        }
+    }
+
+    # The ONLY place the two providers differ: field names. Staging, gating and
+    # everything downstream are identical (crossplane-configurations#168,
+    # option A).
+    _res = {
+        if _provider == "vsphere":
+            apiVersion = "resources.stuttgart-things.com/v1alpha1"
+            kind = "NativeVsphereVM"
+            spec = {
+                environmentConfig = spec?.environmentConfig or "labul"
+                vm = {
+                    name = _cluster
+                    cpu = size.cpu
+                    ram = size.memory
+                    disk = size.disk
+                    if _vm?.templateUuid:
+                        templateUuid = _vm.templateUuid
+                }
+                ansible = _ansible
+            }
+        else:
+            apiVersion = "resources.stuttgart-things.com/v1alpha1"
+            kind = "NativeProxmoxVM"
+            spec = {
+                environmentConfig = spec?.environmentConfig or "labul"
+                vm = {
+                    name = _cluster
+                    cpu = size.cpu
+                    memory = size.memory
+                    disk = size.disk
+                    if _vm?.templateVmId:
+                        templateVmId = _vm.templateVmId
+                }
+                cloudInit = {
+                    ipv4Address = _vm?.ipv4Address or "dhcp"
+                }
+                ansible = _ansible
+            }
+    }
+    _res | _common
+}
+
+# --- the two ansible stages ------------------------------------------------
+_ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks: [str], vars: [str], inventory: [str] -> {str:any} {
+    _ans = spec?.ansible or {}
+    _runID = spec?.runID or ""
+    _suffix = "-{}".format(_runID) if _runID else ""
+    _runName = "{}-{}{}".format(name, stage, _suffix)
+    {
+        apiVersion = "resources.stuttgart-things.com/v1alpha1"
+        kind = "AnsibleRun"
+        metadata = {
+            name = "{}-{}".format(name, stage)
+            namespace = ns
+            annotations = {"krm.kcl.dev/composition-resource-name" = stage}
+        }
+        spec = {
+            pipelineRunName = _runName
+            namespace = _ans?.pipelineNamespace or "tekton-ci"
+            ansiblePlaybooks = playbooks
+            ansibleVarsFile = vars
+            ansibleVarsInventory = inventory
+            crossplaneObjectName = _runName
+            crossplaneNamespace = ns
+            crossplaneProviderConfig = _ans?.crossplaneProviderConfig or "in-cluster"
+            if _ans?.extraCollections:
+                ansibleExtraCollections = _ans.extraCollections
+            if _ans?.extraCollections:
+                installExtraCollections = "true"
+            if _ans?.ansibleWorkingImage:
+                ansibleWorkingImage = _ans.ansibleWorkingImage
+        }
+    }
+}
+
+distributionRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any} {
+    _cluster = spec?.clusterName or name
+    _dist = cat.getDistribution(spec?.distribution or "k3s")
+    _vars = renderVars(_dist.vars) + ["cluster_name+-{}".format(_cluster)] + (spec?.ansible?.extraVars or [])
+    _ansibleRun(name, ns, "distribution", spec, _dist.playbooks, _vars, renderInventory(_dist.inventoryGroups, ip))
+}
+
+kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any} {
+    _cluster = spec?.clusterName or name
+    _stage = cat.kubeconfigStage
+    _dist = cat.getDistribution(spec?.distribution or "k3s")
+
+    # Where the kubeconfig sits on the node differs per distribution; the k3s
+    # server writes /etc/rancher/k3s/k3s.yaml, while the kind role fetches to the
+    # user's home. Only k3s needs the override.
+    _paths = ["kubeconfig_path+-/etc/rancher/k3s/k3s.yaml"] if (spec?.distribution or "k3s") == "k3s" else []
+    _vars = renderVars(_stage.vars) + ["cluster_name+-{}".format(_cluster)] + _paths
+    _ansibleRun(name, ns, "kubeconfig", spec, _stage.playbooks, _vars, renderInventory(_stage.inventoryGroups, ip))
+}
+
+# --- the two downstream XRs ------------------------------------------------
+clusterAccess = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
+    _cluster = spec?.clusterName or name
+    _kc = spec?.kubeconfig or {}
+    {
+        apiVersion = "config.stuttgart-things.com/v1alpha1"
+        kind = "ClusterAccess"
+        metadata = {
+            name = "{}-access".format(name)
+            namespace = ns
+            annotations = {"krm.kcl.dev/composition-resource-name" = "access"}
+        }
+        spec = {
+            clusterName = _cluster
+            source = {
+                type = "vault"
+                path = _kc?.vaultPath or _cluster
+                key = "kubeconfig"
+            }
+            secretNamespace = _kc?.secretNamespace or "crossplane-system"
+            kubeconfigProviderConfigRef = _kc?.providerConfigRef or "vault-kubeconfigs"
+        }
+    }
+}
+
+# The Platform child. clusterName and cni.enabled are supplied HERE, not by the
+# user: cni.enabled follows from the distribution's CNI ownership, and setting it
+# by hand is how a cluster ends up with two CNIs (a k3s role installs cilium
+# itself; a kind cluster is deliberately built without one).
+platformChild = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
+    _cluster = spec?.clusterName or name
+    _passthrough = {k: v for k, v in (spec?.platform or {}) if k not in ["enabled", "clusterName", "cni"]}
+    _userCni = (spec?.platform or {})?.cni or {}
+    _cniEnabled = cat.platformCniEnabled(spec?.distribution or "k3s")
+    {
+        apiVersion = "config.stuttgart-things.com/v1alpha1"
+        kind = "Platform"
+        metadata = {
+            name = "{}-platform".format(name)
+            namespace = ns
+            annotations = {"krm.kcl.dev/composition-resource-name" = "platform"}
+        }
+        spec = _passthrough | {
+            clusterName = _cluster
+            cni = _userCni | {enabled = _cniEnabled}
+        }
+    }
+}
+
+# --- teardown ordering -----------------------------------------------------
+
+# `of` is what must die LAST, `by` is the user. replayDeletion re-issues the
+# delete on the protected resource once the user is gone — without it a
+# `kubectl delete` is swallowed and has to be issued twice.
+#
+# Usage orders DELETION ONLY, never creation: build order stays the ready gates.
+usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str -> {str:any} {
+    {
+        apiVersion = "protection.crossplane.io/v1beta1"
+        kind = "Usage"
+        metadata = {
+            name = label
+            annotations = {"krm.kcl.dev/composition-resource-name" = label}
+        }
+        spec = {
+            replayDeletion = True
+            of = {
+                apiVersion = "resources.stuttgart-things.com/v1alpha1" if ofKind in ["NativeProxmoxVM", "NativeVsphereVM"] else "config.stuttgart-things.com/v1alpha1"
+                kind = ofKind
+                resourceRef.name = ofName
+            }
+            by = {
+                apiVersion = "config.stuttgart-things.com/v1alpha1"
+                kind = byKind
+                resourceRef.name = byName
+            }
+        }
+    }
+}

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -1,0 +1,145 @@
+# Unit tests for the resource construction. Run with `kcl test`.
+# These import logic.k, not main.k — main.k reads option("params") and is
+# exercised by the Configuration's `crossplane render`, not here.
+import .logic as l
+import xplane_cluster_catalog as cat
+
+# Specs are written out in full rather than merged from a base: KCL types a dict
+# literal by its keys, so `base | {clusterName = ...}` fails type checking on the
+# key the base does not have. Verbose, but explicit is fine in tests.
+
+# --- inventory -------------------------------------------------------------
+# The first group gets the host, the rest are present-but-empty. Not cosmetic:
+# deploy_configure_rke branches on groups['initial_master_node'] and
+# groups['additional_master_nodes'], so a flat inventory fails with an
+# undefined-group error, and an omitted empty group fails the same way.
+test_inventory_puts_the_host_in_the_first_group_only = lambda {
+    _inv = l.renderInventory(["initial_master_node", "additional_master_nodes", "workers"], "10.0.0.1")
+    assert _inv == [
+        'initial_master_node+["10.0.0.1"]'
+        "additional_master_nodes+[]"
+        "workers+[]"
+    ]
+}
+
+test_single_group_inventory = lambda {
+    assert l.renderInventory(["all"], "10.0.0.1") == ['all+["10.0.0.1"]']
+}
+
+test_vars_render_to_the_ansible_run_syntax = lambda {
+    assert l.renderVars({a = "1"}) == ["a+-1"]
+}
+
+# --- provider field names --------------------------------------------------
+# The ONLY thing that differs between providers. If this ever grows a second
+# difference, the "provider is a one-word switch" claim in the README is wrong.
+test_proxmox_uses_memory_vsphere_uses_ram = lambda {
+    _size = cat.getSize("medium")
+    _px = l.vmChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, _size)
+    _vs = l.vmChild("c", "ns", {provider = "vsphere", distribution = "k3s", size = "medium"}, _size)
+    assert _px.kind == "NativeProxmoxVM"
+    assert _px.spec.vm.memory == "8192"
+    assert "ram" not in _px.spec.vm
+    assert _vs.kind == "NativeVsphereVM"
+    assert _vs.spec.vm.ram == "8192"
+    assert "memory" not in _vs.spec.vm
+}
+
+# vSphere has no cloudInit block in its XRD at all — emitting one would be a
+# schema error on the composed resource.
+test_only_proxmox_gets_cloudinit = lambda {
+    _size = cat.getSize("medium")
+    assert "cloudInit" in l.vmChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, _size).spec
+    assert "cloudInit" not in l.vmChild("c", "ns", {provider = "vsphere", distribution = "k3s", size = "medium"}, _size).spec
+}
+
+test_vm_name_follows_clusterName_not_xr_name = lambda {
+    _size = cat.getSize("small")
+    _r = l.vmChild("xr-name", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "u26-kind1"}, _size)
+    assert _r.spec.vm.name == "u26-kind1"
+    assert _r.metadata.name == "xr-name-vm"
+
+    # The hostname var is what actually sets the guest hostname on Proxmox —
+    # bpg cloud-init cannot without a snippets datastore.
+    assert "vm_hostname+-u26-kind1" in _r.spec.ansible.varsFile
+}
+
+# --- the ansible stages ----------------------------------------------------
+test_distribution_run_carries_the_catalog_vars_and_cluster_name = lambda {
+    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "k1"}, "10.0.0.1")
+    assert _r.spec.ansiblePlaybooks == ["sthings.rke.k3s_cluster"]
+    # Without this the cluster has no pod network at all.
+    assert "install_cilium+-true" in _r.spec.ansibleVarsFile
+    assert "cluster_name+-k1" in _r.spec.ansibleVarsFile
+    assert _r.spec.ansibleVarsInventory[0] == 'initial_master_node+["10.0.0.1"]'
+}
+
+test_kubeconfig_run_is_a_separate_run_with_the_k3s_path = lambda {
+    _r = l.kubeconfigRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
+    assert _r.spec.ansiblePlaybooks == ["sthings.container.upload_kubeconfig_vault"]
+    assert "kubeconfig_path+-/etc/rancher/k3s/k3s.yaml" in _r.spec.ansibleVarsFile
+    # kind writes elsewhere, so it must NOT get the k3s server path.
+    _k = l.kubeconfigRun("c", "ns", {provider = "proxmox", distribution = "kind", size = "medium"}, "10.0.0.1")
+    assert "kubeconfig_path+-/etc/rancher/k3s/k3s.yaml" not in _k.spec.ansibleVarsFile
+}
+
+# runID is the supported way to force a deliberate re-run; it must reach BOTH
+# derived names, because provider-kubernetes only creates a new PipelineRun for
+# a new Object.
+test_runid_suffixes_both_names = lambda {
+    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", runID = "2"}, "10.0.0.1")
+    assert _r.spec.pipelineRunName == "c-distribution-2"
+    assert _r.spec.crossplaneObjectName == "c-distribution-2"
+
+    # The composed-resource name must NOT move, or bumping runID would orphan
+    # the previous child instead of replacing the run.
+    assert _r.metadata.name == "c-distribution"
+}
+
+test_no_runid_keeps_the_plain_names = lambda {
+    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
+    assert _r.spec.pipelineRunName == "c-distribution"
+}
+
+# --- the platform child ----------------------------------------------------
+# THE rule this whole thing exists to enforce: cni.enabled follows from the
+# distribution, never from the user. A k3s role installs cilium itself; setting
+# it by hand is how a cluster ends up with two CNIs.
+test_platform_cni_follows_the_distribution = lambda {
+    assert not l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}).spec.cni.enabled
+    assert l.platformChild("c", "ns", {provider = "proxmox", distribution = "kind", size = "medium"}).spec.cni.enabled
+}
+
+test_user_cannot_override_cni_enabled = lambda {
+    _r = l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", platform = {
+        cni = {enabled = True, chart = {version = "1.19.6"}}
+    }})
+    # The user's enabled is discarded...
+    assert not _r.spec.cni.enabled
+    # ...but the rest of their cni block survives.
+    assert _r.spec.cni.chart.version == "1.19.6"
+}
+
+test_platform_passthrough_and_derived_clusterName = lambda {
+    _r = l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "k1", platform = {fluxInit = {enabled = True}, enabled = True}})
+    assert _r.spec.clusterName == "k1"
+    assert _r.spec.fluxInit.enabled
+    # `enabled` is this Configuration's own switch, not a Platform field.
+    assert "enabled" not in _r.spec
+}
+
+# --- teardown --------------------------------------------------------------
+# `of` dies LAST, `by` dies first. Getting these backwards is the difference
+# between an ordered teardown and Objects stuck on finalizers against a dead
+# API server.
+test_usage_protects_the_vm_from_the_platform = lambda {
+    _u = l.usage("NativeProxmoxVM", "c-vm", "Platform", "c-platform", "platform-uses-vm")
+    assert _u.spec.of.kind == "NativeProxmoxVM"
+    assert _u.spec.by.kind == "Platform"
+    assert _u.spec.replayDeletion
+}
+
+test_usage_resolves_the_group_per_kind = lambda {
+    assert l.usage("NativeVsphereVM", "a", "Platform", "b", "u").spec.of.apiVersion == "resources.stuttgart-things.com/v1alpha1"
+    assert l.usage("ClusterAccess", "a", "Platform", "b", "u").spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
+}

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -1,0 +1,177 @@
+"""
+ClusterStack — one XR for VM -> distribution -> access -> platform.
+
+This file does the wiring: read observed state, decide which stages are open,
+call logic.k to build the children, and patch the status.
+
+STICKY GATES. Not emitting a composed resource is what makes Crossplane DELETE
+it, so every gate here is `(the previous stage succeeded) OR (this child already
+exists)`. Without the second clause a VM blip — bpg and VMware Tools both read
+the address from the guest agent, so a momentarily empty value is normal —
+would delete an AnsibleRun and its recreation would re-run the play against a
+live machine. That failure was real (crossplane-configurations#163); the
+AnsibleRun children are re-emitted VERBATIM from _ocds for the same reason: a
+rebuilt spec would rewrite the inventory from a now-empty IP, and the wrapped
+PipelineRun has no Update policy so it would never reach Tekton anyway.
+
+Gating on SUCCEEDED, not Ready: an AnsibleRun whose PipelineRun failed still
+reports Ready once its Object is applied, and unblocking the next stage on that
+would run a kubeconfig upload against a cluster that was never installed.
+"""
+
+import .logic as l
+import xplane_cluster_catalog as cat
+
+_params = option("params") or {}
+
+# Underscore-prefixed so `kcl run` does not echo them as part of the document —
+# function-kcl only reads `items`, but a bare top-level name is output too.
+# All optional-chained so `kcl test` (which evaluates this file with no params)
+# does not blow up before reaching the tests in logic_test.k.
+_oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
+
+_meta = _oxr?.metadata or {}
+_name = _meta?.name or "cluster"
+_ns = _meta?.namespace or "crossplane-system"
+_spec = _oxr?.spec or {}
+_cluster = _spec?.clusterName or _name
+
+# Fails loudly with the list of known names rather than silently building a
+# default — an unknown size or distribution is a typo, not an intent.
+_size = cat.getSize(_spec?.size or "medium")
+_dist = cat.getDistribution(_spec?.distribution or "k3s")
+_supported = cat.assertSizeSupported(_spec?.distribution or "k3s", _spec?.size or "medium")
+
+_platformEnabled = (_spec?.platform or {})?.enabled if "enabled" in (_spec?.platform or {}) else True
+
+# --- observed children -----------------------------------------------------
+_byKind = lambda kind: str -> [any] {
+    [v.Resource for _, v in _ocds if v?.Resource?.kind == kind]
+}
+_byName = lambda name: str -> [any] {
+    [v.Resource for _, v in _ocds if v?.Resource?.metadata?.name == name]
+}
+
+_vmKind = "NativeVsphereVM" if (_spec?.provider or "proxmox") == "vsphere" else "NativeProxmoxVM"
+_vmObs = _byKind(_vmKind)
+_vm = _vmObs[0] if _vmObs else {}
+_vmShare = _vm?.status?.share or {}
+_vmIPs = _vmShare?.ip or []
+_vmIP = _vmIPs[0] if _vmIPs else ""
+_vmConds = _vm?.status?.conditions or []
+_vmReady = len([c for c in _vmConds if c?.type == "Ready" and c?.status == "True"]) > 0
+
+# Published by proxmoxvm/vspherevm since the sticky-gate release: the base-OS
+# PipelineRun's own verdict, not merely the AnsibleRun XR's readiness.
+_baseosOk = (_vmShare?.ansibleSucceeded or "") == "True"
+
+_distObs = _byName("{}-distribution".format(_name))
+_distRun = _distObs[0] if _distObs else {}
+_distOk = (_distRun?.status?.succeeded or "") == "True"
+
+_kcObs = _byName("{}-kubeconfig".format(_name))
+_kcRun = _kcObs[0] if _kcObs else {}
+_kcOk = (_kcRun?.status?.succeeded or "") == "True"
+
+_accessObs = _byKind("ClusterAccess")
+_access = _accessObs[0] if _accessObs else {}
+_accessReady = _access?.status?.ready or False
+_accessShare = _access?.status?.share or {}
+
+_platObs = _byKind("Platform")
+_plat = _platObs[0] if _platObs else {}
+_platReady = len([c for c in (_plat?.status?.conditions or []) if c?.type == "Ready" and c?.status == "True"]) > 0
+
+# --- gates -----------------------------------------------------------------
+_distOpen = (_vmReady and _vmIP != "" and _baseosOk) or len(_distObs) > 0
+_kcOpen = (_distOk and _vmIP != "") or len(_kcObs) > 0
+_accessOpen = _kcOk or len(_accessObs) > 0
+_platOpen = _platformEnabled and (_accessReady or len(_platObs) > 0)
+
+# Verbatim re-emission for the ansible children (see the module docstring).
+_reemit = lambda prev: any, stage: str -> {str:any} {
+    {
+        # Defaulted, not read blindly: an observed resource missing apiVersion
+        # would otherwise emit a resource without one, which Crossplane accepts
+        # into desired state and then cannot apply.
+        apiVersion = prev?.apiVersion or "resources.stuttgart-things.com/v1alpha1"
+        kind = prev?.kind or "AnsibleRun"
+        metadata = {
+            name = prev?.metadata?.name or "{}-{}".format(_name, stage)
+            namespace = prev?.metadata?.namespace or _ns
+            annotations = {"krm.kcl.dev/composition-resource-name" = stage}
+        }
+        spec = prev?.spec or {}
+    }
+}
+
+_distChild = _reemit(_distRun, "distribution") if _distObs else l.distributionRun(_name, _ns, _spec, _vmIP)
+_kcChild = _reemit(_kcRun, "kubeconfig") if _kcObs else l.kubeconfigRun(_name, _ns, _spec, _vmIP)
+
+# --- teardown ordering -----------------------------------------------------
+# Only the pairs that matter. Usage is not transitive, so a full mesh would be
+# noise; these three are the ones whose absence strands a finalizer:
+#   - VM must outlive the Platform, else every Platform Object hangs against a
+#     dead API server.
+#   - ClusterAccess must outlive the Platform, else the ClusterProviderConfigs
+#     its Objects reference are gone before they can be finalized.
+#   - the VM must outlive ClusterAccess, so the Vault read ends before the
+#     machine does.
+# The AnsibleRuns need no protection: they only create PipelineRuns on the
+# management cluster, and those disappearing blocks nobody.
+# COMMAS ARE LOAD-BEARING: without them KCL parses `[a]` followed by a line
+# starting with `[` as a SUBSCRIPT, silently dropping entries instead of failing.
+_usageGroups = [
+    [l.usage(_vmKind, "{}-vm".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-vm")] if _platOpen else []
+    [l.usage("ClusterAccess", "{}-access".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-access")] if (_platOpen and _accessOpen) else []
+    [l.usage(_vmKind, "{}-vm".format(_name), "ClusterAccess", "{}-access".format(_name), "access-uses-vm")] if _accessOpen else []
+]
+_usages = sum(_usageGroups, [])
+
+# --- status ----------------------------------------------------------------
+
+# The one field to look at when a build is stuck.
+_stage = "ready" if (_platReady or (not _platformEnabled and _accessReady)) else ("platform" if _platOpen else ("access" if _accessOpen else ("kubeconfig" if _kcOpen else ("distribution" if _distOpen else ("baseos" if (_vmReady and _vmIP != "") else "vm")))))
+
+_dxr = _params?.dxr or {}
+_dxrPatched = _dxr | {
+    status = (_dxr?.status or {}) | {
+        ready = _platReady if _platformEnabled else _accessReady
+        stage = _stage
+        share = {
+            clusterName = _cluster
+            cniOwnership = _dist.cniOwnership
+            if _vmIP:
+                ip = _vmIP
+            if _accessShare?.apiEndpoint:
+                apiEndpoint = _accessShare.apiEndpoint
+            if _accessShare?.clusterType:
+                clusterType = _accessShare.clusterType
+            if _accessShare?.serverVersion:
+                serverVersion = _accessShare.serverVersion
+        }
+        stages = {
+            vm = {ready = _vmReady, ip = _vmIP}
+            baseos = {succeeded = _baseosOk}
+            distribution = {succeeded = _distOk, emitted = _distOpen}
+            kubeconfig = {succeeded = _kcOk, emitted = _kcOpen}
+            access = {ready = _accessReady, emitted = _accessOpen}
+            platform = {ready = _platReady, emitted = _platOpen}
+        }
+    }
+}
+
+# --- items -----------------------------------------------------------------
+# Single-expression concatenation, not `+=` accumulation — the mutable pattern
+# double-emitted groups in bootstrap/cilium.
+_groups = [
+    [l.vmChild(_name, _ns, _spec, _size)]
+    [_distChild] if _distOpen else []
+    [_kcChild] if _kcOpen else []
+    [l.clusterAccess(_name, _ns, _spec)] if _accessOpen else []
+    [l.platformChild(_name, _ns, _spec)] if _platOpen else []
+    _usages
+    [_dxrPatched]
+]
+items = sum(_groups, [])


### PR DESCRIPTION
Composition logic for the `ClusterStack` XR — the module half of stuttgart-things/crossplane-configurations#169. Depends on `xplane-cluster-catalog:0.1.0`.

## What it emits

```
ClusterStack
├─ NativeProxmoxVM | NativeVsphereVM   {name}-vm            VM + base-OS ansible
├─ AnsibleRun                          {name}-distribution  k3s / kind install
├─ AnsibleRun                          {name}-kubeconfig    kubeconfig -> Vault
├─ ClusterAccess                       {name}-access        -> the ClusterProviderConfigs
├─ Platform                            {name}-platform      flux, apps, cilium, …
└─ Usage ×3                                                 teardown ordering
```

## Sticky, success-based gates

Every stage is gated on `(previous stage SUCCEEDED) OR (this child already exists)`.

The second clause is not defensive programming. **Not emitting a composed resource is what makes Crossplane delete it**, and bpg / VMware Tools read the VM address from the guest agent, so a momentarily empty value is normal. Without stickiness a blip deletes an `AnsibleRun` and its recreation re-runs the play against a live machine — the failure fixed in #163, now designed in from the start. The `AnsibleRun` children are re-emitted **verbatim from `ocds`**, because during that same blip a rebuilt spec would rewrite the inventory to an empty IP, and with `Update` excluded from the wrapped Object it would silently never reach Tekton.

Gates check **`succeeded`, not `Ready`**: an `AnsibleRun` whose PipelineRun failed still reports Ready once its Object is applied, and unblocking on that would upload a kubeconfig from a cluster that was never installed.

## Teardown (issue #166, folded in here)

Three `Usage`s — only the pairs whose absence strands a finalizer. `Usage` orders deletion only, never creation; build order stays the gates.

## Verified

`kcl test .` → **15/15**, covering the rules rather than the plumbing: provider field names, the k3s inventory groups, `install_cilium`, the separate kubeconfig stage, `runID` reaching both derived names but *not* the composed-resource name, and that a user cannot override `cni.enabled` while the rest of their `cni` block survives.

Gate transitions were exercised with `kcl run` against synthetic observed state — the five stages emit exactly the expected children in order, and a VM flap at full chain keeps all eight resources with the distribution run's original inventory intact.

## Four KCL gotchas worth knowing (all documented in the README)

- **Commas are load-bearing in multi-line list literals.** `[a]` followed by a line starting with `[` parses as a *subscript* and silently drops entries. This bit me mid-review and looked exactly like a gate bug.
- No `enumerate()`; no multi-line ternary chains.
- A dict literal is typed by its keys, so `base | {newKey = …}` fails type checking — the tests write specs out in full.
- A bare top-level name is part of the output document; `oxr`/`ocds` must be `_`-prefixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr
