### PR TITLE
fix(xplane-cluster): read platformEnabled as a sibling of platform (0.1.1)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -201,7 +201,8 @@ clusterAccess = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
 # itself; a kind cluster is deliberately built without one).
 platformChild = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
     _cluster = spec?.clusterName or name
-    _passthrough = {k: v for k, v in (spec?.platform or {}) if k not in ["enabled", "clusterName", "cni"]}
+    # `enabled` is no longer filtered here — it lives on spec.platformEnabled.
+    _passthrough = {k: v for k, v in (spec?.platform or {}) if k not in ["clusterName", "cni"]}
     _userCni = (spec?.platform or {})?.cni or {}
     _cniEnabled = cat.platformCniEnabled(spec?.distribution or "k3s")
     {

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -121,11 +121,11 @@ test_user_cannot_override_cni_enabled = lambda {
 }
 
 test_platform_passthrough_and_derived_clusterName = lambda {
-    _r = l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "k1", platform = {fluxInit = {enabled = True}, enabled = True}})
+    _r = l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "k1", platform = {
+        fluxInit = {enabled = True}
+    }})
     assert _r.spec.clusterName == "k1"
     assert _r.spec.fluxInit.enabled
-    # `enabled` is this Configuration's own switch, not a Platform field.
-    assert "enabled" not in _r.spec
 }
 
 # --- teardown --------------------------------------------------------------

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -43,7 +43,11 @@ _size = cat.getSize(_spec?.size or "medium")
 _dist = cat.getDistribution(_spec?.distribution or "k3s")
 _supported = cat.assertSizeSupported(_spec?.distribution or "k3s", _spec?.size or "medium")
 
-_platformEnabled = (_spec?.platform or {})?.enabled if "enabled" in (_spec?.platform or {}) else True
+# A SIBLING of spec.platform, not a key inside it: `platform` is a verbatim
+# passthrough of the Platform XRD's spec, and a preserve-unknown-fields block
+# that also declares known properties makes schema converters emit
+# additionalProperties:false and reject every passthrough key.
+_platformEnabled = _spec?.platformEnabled if "platformEnabled" in _spec else True
 
 # --- observed children -----------------------------------------------------
 _byKind = lambda kind: str -> [any] {


### PR DESCRIPTION
`spec.platform` is a verbatim passthrough of the `Platform` XRD spec, so it carries `x-kubernetes-preserve-unknown-fields`. Declaring a known property (`enabled`) alongside makes schema converters emit `additionalProperties: false`, and the Configuration's `verify` CI then rejects every passthrough key — `fluxInit`, `apps`, `ipReservation`, `cilium`, `vaultIssuer`. Caught by CI on crossplane-configurations#181.

`enabled` never belonged in that block anyway: it is the Configuration's own switch, not a Platform field — which is why the module had to filter it back out before passing the block through. It moves to `spec.platformEnabled`, and the filter drops to `[clusterName, cni]`.

This matches the shape `platform` itself uses for `cni.cilium` and `apps.*.substitute`: a preserve-unknown block declares no properties.

15/15 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr