### PR TITLE
fix(xplane-cluster): target the kubeconfigs Vault, and unfreeze fixable stages (0.1.2)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -118,7 +118,7 @@ vmChild = lambda name: str, ns: str, spec: {str:any}, size: any -> {str:any} {
 }
 
 # --- the two ansible stages ------------------------------------------------
-_ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks: [str], vars: [str], inventory: [str] -> {str:any} {
+_ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks: [str], vars: [str], inventory: [str], vaultSecret: str -> {str:any} {
     _ans = spec?.ansible or {}
     _runID = spec?.runID or ""
     _suffix = "-{}".format(_runID) if _runID else ""
@@ -140,6 +140,10 @@ _ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks:
             crossplaneObjectName = _runName
             crossplaneNamespace = ns
             crossplaneProviderConfig = _ans?.crossplaneProviderConfig or "in-cluster"
+            # Emitted only when non-empty, so the distribution run's params stay
+            # byte-identical to before this field existed.
+            if vaultSecret:
+                vaultSecretName = vaultSecret
             if _ans?.extraCollections:
                 ansibleExtraCollections = _ans.extraCollections
             if _ans?.extraCollections:
@@ -154,7 +158,7 @@ distributionRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:an
     _cluster = spec?.clusterName or name
     _dist = cat.getDistribution(spec?.distribution or "k3s")
     _vars = renderVars(_dist.vars) + ["cluster_name+-{}".format(_cluster)] + (spec?.ansible?.extraVars or [])
-    _ansibleRun(name, ns, "distribution", spec, _dist.playbooks, _vars, renderInventory(_dist.inventoryGroups, ip))
+    _ansibleRun(name, ns, "distribution", spec, _dist.playbooks, _vars, renderInventory(_dist.inventoryGroups, ip), "")
 }
 
 kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any} {
@@ -167,7 +171,15 @@ kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any}
     # user's home. Only k3s needs the override.
     _paths = ["kubeconfig_path+-/etc/rancher/k3s/k3s.yaml"] if (spec?.distribution or "k3s") == "k3s" else []
     _vars = renderVars(_stage.vars) + ["cluster_name+-{}".format(_cluster)] + _paths
-    _ansibleRun(name, ns, "kubeconfig", spec, _stage.playbooks, _vars, renderInventory(_stage.inventoryGroups, ip))
+
+    # THE KUBECONFIGS VAULT IS NOT THE INFRA VAULT. ansible-run defaults
+    # vaultSecretName to `vault`, which in this fleet points at the infra Vault
+    # and carries no AppRole; the kubeconfigs KV mount lives in a different
+    # Vault entirely. Leaving it unset fails the upload with
+    # "failed to determine alias name from login request" — found on the first
+    # live cluster build, invisible to render.
+    _vaultSecret = (spec?.kubeconfig or {})?.vaultSecretName or "vault-kubeconfigs"
+    _ansibleRun(name, ns, "kubeconfig", spec, _stage.playbooks, _vars, renderInventory(_stage.inventoryGroups, ip), _vaultSecret)
 }
 
 # --- the two downstream XRs ------------------------------------------------

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -143,3 +143,26 @@ test_usage_resolves_the_group_per_kind = lambda {
     assert l.usage("NativeVsphereVM", "a", "Platform", "b", "u").spec.of.apiVersion == "resources.stuttgart-things.com/v1alpha1"
     assert l.usage("ClusterAccess", "a", "Platform", "b", "u").spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
 }
+
+# --- the kubeconfigs Vault -------------------------------------------------
+# ansible-run defaults vaultSecretName to `vault`, which in this fleet points at
+# the INFRA Vault and carries no AppRole; the kubeconfigs KV mount lives in a
+# different Vault. Leaving it unset failed the first live cluster build with
+# "failed to determine alias name from login request" — a failure no render can
+# see, so it is pinned here instead.
+test_kubeconfig_run_targets_the_kubeconfigs_vault = lambda {
+    _r = l.kubeconfigRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
+    assert _r.spec.vaultSecretName == "vault-kubeconfigs"
+}
+
+test_kubeconfig_vault_secret_is_overridable = lambda {
+    _r = l.kubeconfigRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", kubeconfig = {vaultSecretName = "other-vault"}}, "10.0.0.1")
+    assert _r.spec.vaultSecretName == "other-vault"
+}
+
+# The distribution run talks to no Vault, so it must not carry a secret name at
+# all — an unset field keeps the rendered params byte-identical to before.
+test_distribution_run_has_no_vault_secret = lambda {
+    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
+    assert "vaultSecretName" not in _r.spec
+}

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -110,8 +110,15 @@ _reemit = lambda prev: any, stage: str -> {str:any} {
     }
 }
 
-_distChild = _reemit(_distRun, "distribution") if _distObs else l.distributionRun(_name, _ns, _spec, _vmIP)
-_kcChild = _reemit(_kcRun, "kubeconfig") if _kcObs else l.kubeconfigRun(_name, _ns, _spec, _vmIP)
+# Verbatim re-emission is a FLAP guard, not a freeze: it applies only while the
+# live IP is missing, which is the exact condition that would corrupt a rebuilt
+# inventory. With the IP present the spec is rebuilt normally, so a genuine fix
+# (a corrected vaultSecretName, a catalog change) can still land — the derived
+# names are stable, so nothing re-runs until runID is bumped. Freezing
+# unconditionally, as this did first, made a broken stage unfixable without
+# deleting the child.
+_distChild = _reemit(_distRun, "distribution") if (len(_distObs) > 0 and _vmIP == "") else l.distributionRun(_name, _ns, _spec, _vmIP)
+_kcChild = _reemit(_kcRun, "kubeconfig") if (len(_kcObs) > 0 and _vmIP == "") else l.kubeconfigRun(_name, _ns, _spec, _vmIP)
 
 # --- teardown ordering -----------------------------------------------------
 # Only the pairs that matter. Usage is not transitive, so a full mesh would be


### PR DESCRIPTION
Two fixes, both found by the **first live cluster build** on kind1 (crossplane-configurations#169). Neither is visible to `crossplane render` — which is the argument for having done the live test.

## 1. The upload targeted the wrong Vault

`ansible-run` defaults `vaultSecretName` to `vault`. In this fleet that Secret points at the **infra** Vault and carries no AppRole; the `kubeconfigs` KV mount lives in a *different* Vault. The upload stage failed with:

```
failed to determine alias name from login request, on post
https://vault.infra.sthings-vsphere.labul.sva.de/v1/auth/approle/login
```

The hand-written XR this Configuration replaces documents exactly this in a comment — the module simply never carried it over. The kubeconfig run now sets `vaultSecretName`, defaulting to `vault-kubeconfigs` and overridable via `spec.kubeconfig.vaultSecretName`. The distribution run talks to no Vault and deliberately emits no such field, so its rendered params stay byte-identical.

## 2. Verbatim re-emission froze broken stages

This is the more interesting one. Re-emitting an existing `AnsibleRun` child verbatim from observed state was **unconditional**, so a child’s spec was frozen at whatever the first reconcile produced. Fixing the Vault secret above would therefore never have reached the cluster — the only way out was deleting the child.

Verbatim re-emission is a **flap guard**, not a freeze. It now applies only while the live IP is missing, which is the exact condition that would corrupt a rebuilt inventory. With the IP present the spec rebuilds normally; the derived names are stable, so nothing re-runs until `runID` is bumped — which is precisely the intended interaction between the two mechanisms.

18 tests (3 new), including one that pins the Vault secret name so this cannot silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr