### PR TITLE
feat(xplane-cluster): per-stage runIDs, replacing the global runID (0.1.3)

### DIFF
--- a/crossplane/xplane-cluster/README.md
+++ b/crossplane/xplane-cluster/README.md
@@ -44,6 +44,19 @@ Three `Usage` resources, only the pairs whose absence strands a finalizer:
 
 `vm.memory` (Proxmox) vs `vm.ram` (vSphere), plus the fact that only Proxmox has a `cloudInit` block. Staging, gating and everything downstream are identical — that is option **A** of crossplane-configurations#168. A unit test asserts there is no second difference; if one appears, the "provider is a one-word switch" claim is no longer true and the README should stop saying it.
 
+## Re-runs are per stage
+
+`spec.runIDs` is a map, not a single value:
+
+```yaml
+runIDs:
+  kubeconfig: "2"    # re-runs the upload only
+```
+
+A single global `runID` was the first design and it is a footgun by construction: bumping it renames **every** stage, so repairing the kubeconfig upload also re-ran the k3s install against a live cluster. That happened on the first live build, and it is exactly the hazard the fleet's hand-written XRs warn about in their headers. A re-run has to name its stage.
+
+The base-OS stage is deliberately absent from the map: it runs from the VM XR's own `spec.ansible`, whose XRD has no re-run knob, so it is not expressible from here.
+
 ## What the user cannot set
 
 `Platform.cni.enabled` comes from the catalog's `cniOwnership`, never from `spec.platform.cni.enabled`. A k3s role installs cilium itself; a kind cluster is built without one. Setting it by hand is how a cluster ends up with two CNIs. The user's other `cni` keys (chart version, values) pass through untouched — only `enabled` is overridden, and a test covers both halves.

--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.1.2"
+version = "0.1.3"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -118,9 +118,21 @@ vmChild = lambda name: str, ns: str, spec: {str:any}, size: any -> {str:any} {
 }
 
 # --- the two ansible stages ------------------------------------------------
+# Per-stage re-run IDs. NOT one global runID: bumping that renamed EVERY stage,
+# so repairing the kubeconfig upload also re-ran the k3s install against a live
+# cluster — observed on the first live build, and exactly the hazard the fleet's
+# hand-written XRs warn about in their headers. A re-run has to name its stage.
+#
+# The base-OS stage is deliberately absent: it runs from the VM XR's own
+# spec.ansible, whose XRD has no runID, so it is not expressible from here.
+runIDFor = lambda spec: {str:any}, stage: str -> str {
+    _ids = spec?.runIDs or {}
+    str(_ids[stage]) if stage in _ids else ""
+}
+
 _ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks: [str], vars: [str], inventory: [str], vaultSecret: str -> {str:any} {
     _ans = spec?.ansible or {}
-    _runID = spec?.runID or ""
+    _runID = runIDFor(spec, stage)
     _suffix = "-{}".format(_runID) if _runID else ""
     _runName = "{}-{}{}".format(name, stage, _suffix)
     {

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -87,7 +87,7 @@ test_kubeconfig_run_is_a_separate_run_with_the_k3s_path = lambda {
 # derived names, because provider-kubernetes only creates a new PipelineRun for
 # a new Object.
 test_runid_suffixes_both_names = lambda {
-    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", runID = "2"}, "10.0.0.1")
+    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", runIDs = {distribution = "2"}}, "10.0.0.1")
     assert _r.spec.pipelineRunName == "c-distribution-2"
     assert _r.spec.crossplaneObjectName == "c-distribution-2"
 
@@ -165,4 +165,20 @@ test_kubeconfig_vault_secret_is_overridable = lambda {
 test_distribution_run_has_no_vault_secret = lambda {
     _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
     assert "vaultSecretName" not in _r.spec
+}
+
+# A re-run must not spread. Bumping one stage's id renames that stage only —
+# the first live build proved the alternative: a single global runID re-ran the
+# k3s install while repairing the kubeconfig upload.
+test_runid_is_per_stage = lambda {
+    _spec = {provider = "proxmox", distribution = "k3s", size = "medium", runIDs = {kubeconfig = "3"}}
+    assert l.kubeconfigRun("c", "ns", _spec, "10.0.0.1").spec.pipelineRunName == "c-kubeconfig-3"
+    assert l.distributionRun("c", "ns", _spec, "10.0.0.1").spec.pipelineRunName == "c-distribution"
+}
+
+test_runid_lookup_tolerates_missing_stage = lambda {
+    assert l.runIDFor({}, "distribution") == ""
+    assert l.runIDFor({
+        runIDs = {kubeconfig = "1"}
+    }, "distribution") == ""
 }


### PR DESCRIPTION
Found by the first live cluster build (crossplane-configurations#169).

## The problem

A single global `runID` renames **every** stage. Bumping it to repair the kubeconfig upload also restarted the **k3s install against the live cluster** — precisely the hazard the fleet's hand-written XRs warn about in their own headers:

> renaming the PipelineRun to force a new one would re-run the whole k3s deploy (including `cilium install`) against a live cluster

I wrote that warning into the README and then shipped the mechanism that triggers it. The live build made it visible within minutes.

## The change

`spec.runID` is **replaced**, not supplemented, by `spec.runIDs` — a map keyed by stage:

```yaml
runIDs:
  kubeconfig: "2"    # re-runs the upload only
```

A re-run now has to name its stage, so there is no way to spread one by accident. Nothing is released yet, so there is no compatibility burden — better to remove the footgun than to leave it as a shortcut.

The base-OS stage is deliberately absent from the map: it runs from the VM XR's own `spec.ansible`, whose XRD has no re-run knob, so it is not expressible from here.

20 tests (2 new), one pinning that bumping a stage does not rename its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr