### PR TITLE
feat(xplane-cluster-catalog): pin each distribution's versions (0.2.0)

### DIFF
--- a/crossplane/xplane-cluster-catalog/README.md
+++ b/crossplane/xplane-cluster-catalog/README.md
@@ -38,6 +38,7 @@ All values are **strings** — both VM XRDs take strings, and emitting ints fail
 | | `k3s` | `kind` |
 |---|---|---|
 | playbook | `sthings.rke.k3s_cluster` | `sthings.container.kind` |
+| version pin | `k3s_k8s_version 1.35.1`, `k3s_release_kind k3s1` | `kind_version 0.31.0`, `kubectl_version 1.35.0` |
 | CNI ownership | `self` — the role installs cilium | `platform` — built deliberately without one |
 | inventory groups | `initial_master_node`, `additional_master_nodes`, `workers` | `all` |
 | multi-node | no | no |
@@ -46,6 +47,17 @@ Every var in the tables is load-bearing, with the incident history in the commen
 
 - **k3s `install_cilium: "true"` is mandatory.** The role's `k3s_config` default writes `flannel-backend=none`, `disable-kube-proxy=true` and `disable-network-policy=true` — k3s comes up deliberately without a CNI *and* without kube-proxy. With it false the cluster has no working pod network at all.
 - **k3s's three inventory groups are not cosmetic.** `sthings.rke.deploy_configure_rke` branches on `groups['initial_master_node']` and `groups['additional_master_nodes']`; a flat `all+[...]` inventory fails with an undefined-group error. Empty groups render as header-only INI sections, which ansible registers as existing-but-empty — exactly what the role's `in groups[...]` tests need.
+
+### Versions are pinned per distribution, not globally
+
+Each distribution pins its own versions, and a test asserts that none is left unpinned. Unpinned meant real drift: a live build produced k3s **v1.36.1** while the hand-written XR this catalog replaces pins **1.35.1**, so two clusters from the same profile could differ by build date.
+
+There is deliberately **no shared `kubernetesVersion` field**, because the two distributions do not pin the same thing:
+
+- `k3s` pins **Kubernetes** (`k3s_k8s_version` + `k3s_release_kind`);
+- `kind` pins the **kind binary** (`kind_version`) — its Kubernetes version follows from the node image that binary defaults to.
+
+One field mapped onto both would be accurate for one and a lie for the other. If a per-cluster override is ever wanted, it belongs per distribution and only once *changing* it is supported — today a version change re-runs the install play against a live cluster, which is [#172](https://github.com/stuttgart-things/crossplane-configurations/issues/172) territory.
 
 **`rke2` is deliberately absent.** The fleet runs multinode rke2 through ansible (`exec/labul/sthings-infra-rke2`), but no Crossplane path has ever built one, so an entry here would be a guess wearing the same clothes as a verified fact. Add it after a reference run — a unit test currently asserts its absence, so adding it forces updating that test in the same commit.
 

--- a/crossplane/xplane-cluster-catalog/catalog_test.k
+++ b/crossplane/xplane-cluster-catalog/catalog_test.k
@@ -92,3 +92,27 @@ test_kubeconfig_upload_is_a_separate_stage = lambda {
 test_size_values_are_strings = lambda {
     assert len([1 for _, s in c.sizes if typeof(s.cpu) != "str" or typeof(s.memory) != "str" or typeof(s.disk) != "str"]) == 0
 }
+
+# --- version pinning -------------------------------------------------------
+# An unpinned distribution means two clusters built from the same profile can
+# run different Kubernetes versions depending on the day they were built. A
+# live build produced v1.36.1 where the hand-written XR pins 1.35.1.
+test_k3s_pins_its_kubernetes_version = lambda {
+    _v = c.getDistribution("k3s").vars
+    assert _v["k3s_k8s_version"] == "1.35.1"
+    assert _v["k3s_release_kind"] == "k3s1"
+}
+
+# kind pins the KIND BINARY, not Kubernetes — the k8s version follows from the
+# node image. Asserted separately so nobody "harmonises" the two into one field.
+test_kind_pins_the_kind_binary_not_kubernetes = lambda {
+    _v = c.getDistribution("kind").vars
+    assert "kind_version" in _v
+    assert "k3s_k8s_version" not in _v
+}
+
+# Every distribution must pin something; an entry with no version at all is the
+# drift this catalog exists to remove.
+test_every_distribution_pins_a_version = lambda {
+    assert len([1 for _, d in c.distributions if len([k for k, _ in d.vars if "version" in k]) == 0]) == 0
+}

--- a/crossplane/xplane-cluster-catalog/distributions/k3s.k
+++ b/crossplane/xplane-cluster-catalog/distributions/k3s.k
@@ -10,6 +10,13 @@ k3s: s.Distribution = s.Distribution {
     vars = {
         install_k3s = "true"
         k3s_state = "present"
+        # PINNED. Without these the role installs whatever its own default is —
+        # a live build produced v1.36.1 while the hand-written XR this catalog
+        # replaces pins 1.35.1, so two clusters from the same profile could
+        # differ by build date. A profile that does not pin its Kubernetes
+        # version is not really a profile.
+        k3s_k8s_version = "1.35.1"
+        k3s_release_kind = "k3s1"
         cluster_setup = "singlenode"
         # MANDATORY. The role's k3s_config default writes flannel-backend=none,
         # disable-kube-proxy=true and disable-network-policy=true — k3s comes up

--- a/crossplane/xplane-cluster-catalog/distributions/kind.k
+++ b/crossplane/xplane-cluster-catalog/distributions/kind.k
@@ -8,6 +8,14 @@ kind: s.Distribution = s.Distribution {
     vars = {
         install_kind = "true"
         create_kind_cluster = "true"
+        # PINNED — but note what is pinned: kind takes a KIND BINARY version,
+        # not a Kubernetes version (the k8s version comes from the node image
+        # that binary defaults to). This is why the catalog pins per
+        # distribution rather than exposing one `kubernetesVersion` field: the
+        # two distributions genuinely pin different things, and a shared field
+        # would be a lie for one of them.
+        kind_version = "0.31.0"
+        kubectl_version = "1.35.0"
         # false, so re-reconciles are idempotent instead of destroying and
         # rebuilding the cluster (and moving the API port) on every run.
         rebuild_kind_cluster = "false"

--- a/crossplane/xplane-cluster-catalog/kcl.mod
+++ b/crossplane/xplane-cluster-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-cluster-catalog"
 edition = "v0.12.3"
-version = "0.1.0"
+version = "0.2.0"


### PR DESCRIPTION
Fixes the drift half of stuttgart-things/crossplane-configurations#186.

## The problem

The catalog pinned no versions, so each role installed whatever its own default was. The first live cluster came up as **k3s v1.36.1**, while the hand-written XR this catalog replaces pins **1.35.1**. Nothing failed — but two clusters built from the same profile could differ by the day they were built, which is exactly the drift a profile is supposed to remove.

## The part that changed my mind mid-way

The issue proposed a `spec.kubernetesVersion` field overriding a catalog default. Checking what the roles actually consume shows that would not be honest:

| | pins | var |
|---|---|---|
| `k3s` | **Kubernetes** | `k3s_k8s_version` + `k3s_release_kind` |
| `kind` | the **kind binary** | `kind_version` (+ `kubectl_version`) — the Kubernetes version follows from the node image that binary defaults to |

One field mapped onto both would be accurate for one distribution and a lie for the other. So versions are pinned **per distribution**, and a test fails any entry that pins nothing.

## No XR-level override, deliberately

An override is only useful once *changing* it is supported, and today changing a version re-runs the install play against a live cluster — #172 territory. Adding the field now would advertise an upgrade path that does not exist. The README says so rather than leaving it as an open question.

14 tests (3 new): the k3s pins, that kind pins the binary and **not** `k3s_k8s_version` (so nobody "harmonises" the two later), and that no distribution is left unpinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr
