### PR TITLE
chore(xplane-cluster): consume catalog 0.2.0 with pinned versions (0.1.4)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
-xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.1.0" }
+xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-cluster/kcl.mod.lock
+++ b/crossplane/xplane-cluster/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-cluster-catalog]
     name = "xplane-cluster-catalog"
-    full_name = "xplane-cluster-catalog_0.1.0"
-    version = "0.1.0"
-    sum = "o0qoOtvf7+vKAHre1LXbWlu6PqV6uVq35CCuf+LXFPg="
+    full_name = "xplane-cluster-catalog_0.2.0"
+    version = "0.2.0"
+    sum = "81LrsUKHB37hCS9XM0U+2gqCIdyu80DlYKNdrrtHUyU="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-cluster-catalog"
-    oci_tag = "0.1.0"
+    oci_tag = "0.2.0"

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -182,3 +182,11 @@ test_runid_lookup_tolerates_missing_stage = lambda {
         runIDs = {kubeconfig = "1"}
     }, "distribution") == ""
 }
+
+# The catalog's version pins must actually reach the rendered run. A pin nobody
+# passes through is decoration — and this is the drift #186 was about.
+test_distribution_run_carries_the_version_pins = lambda {
+    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
+    assert "k3s_k8s_version+-1.35.1" in _r.spec.ansibleVarsFile
+    assert "k3s_release_kind+-k3s1" in _r.spec.ansibleVarsFile
+}


### PR DESCRIPTION
Picks up the version pins from #93.

No logic change — the pinned vars flow through the existing `renderVars` path. But a new test asserts they actually reach the rendered `AnsibleRun`:

```python
assert "k3s_k8s_version+-1.35.1" in _r.spec.ansibleVarsFile
assert "k3s_release_kind+-k3s1" in _r.spec.ansibleVarsFile
```

A pin that nobody passes through is decoration, and unnoticed decoration is precisely the drift stuttgart-things/crossplane-configurations#186 is about. 21 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr