### PR TITLE
feat(xplane-cluster): per-stage ansible overrides and a hostname knob (0.2.0)

### DIFF
--- a/crossplane/xplane-cluster/README.md
+++ b/crossplane/xplane-cluster/README.md
@@ -57,6 +57,26 @@ A single global `runID` was the first design and it is a footgun by construction
 
 The base-OS stage is deliberately absent from the map: it runs from the VM XR's own `spec.ansible`, whose XRD has no re-run knob, so it is not expressible from here.
 
+## Per-stage ansible overrides
+
+`ansible` is the shared block; `ansible.stages.<stage>` is **merged over** it, so the common case stays a single list:
+
+```yaml
+ansible:
+  extraCollections: [...]                 # every stage
+  stages:
+    baseos:       {extraCollections: [...]}   # this stage only
+    distribution: {extraCollections: [...]}
+```
+
+Why it exists: the shared list reaches every run, so pinning one collection for the base-OS stage silently replaced the set the k3s stage needed. On the first live build that meant restating `sthings-rke` — required only by the distribution stage — in order to bump `sthings-baseos`, required only by the base-OS stage.
+
+### `setHostname`
+
+The base-OS stage sets `vm_hostname` by default; on Proxmox that is what actually names the guest, since bpg cloud-init cannot without a snippets datastore.
+
+It needs **`sthings-baseos >= 26.5.695`**. On an older collection set the var is **silently ignored** — the guest keeps the template's hostname and nothing reports an error. `ansible.setHostname: false` turns it off, so a fleet still on an older pin can make that explicit rather than wonder why the hostname is unset.
+
 ## What the user cannot set
 
 `Platform.cni.enabled` comes from the catalog's `cniOwnership`, never from `spec.platform.cni.enabled`. A k3s role installs cilium itself; a kind cluster is built without one. Setting it by hand is how a cluster ends up with two CNIs. The user's other `cni` keys (chart version, values) pass through untouched — only `enabled` is overridden, and a test covers both halves.

--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.1.4"
+version = "0.2.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -40,21 +40,44 @@ renderInventory = lambda groups: [str], ip: str -> [str] {
     [('{}+["{}"]'.format(g, ip) if g == groups[0] else "{}+[]".format(g)) for g in groups]
 }
 
+# Per-stage ansible overrides. `ansible.extraCollections` is the shared list; a
+# stage entry is MERGED OVER it rather than replacing it, so the common case
+# stays a single list.
+#
+# Why per stage at all: the shared list is passed to every run, so pinning one
+# collection for the base-OS stage silently replaced the default set for the k3s
+# stage too. On the first live build that meant restating sthings-rke — needed
+# only by the distribution stage — in order to bump sthings-baseos, needed only
+# by the base-OS stage.
+stageAnsible = lambda spec: {str:any}, stage: str -> {str:any} {
+    _ans = spec?.ansible or {}
+    _stages = _ans?.stages or {}
+    _over = _stages[stage] if stage in _stages else {}
+    _shared = {k: v for k, v in _ans if k not in ["stages"]}
+    _shared | _over
+}
+
 # --- the VM child ----------------------------------------------------------
 vmChild = lambda name: str, ns: str, spec: {str:any}, size: any -> {str:any} {
     _provider = spec?.provider or "proxmox"
     _cluster = spec?.clusterName or name
     _vm = spec?.vm or {}
-    _ans = spec?.ansible or {}
+    _ans = stageAnsible(spec, "baseos")
 
     # Base-OS stage. vm_hostname is not cosmetic on Proxmox: bpg cloud-init
     # cannot set the guest hostname without a snippets datastore, so
     # sthings.baseos.setup does it from this var.
+    # setHostname defaults TRUE, but is a knob rather than a hard-wire: the var
+    # needs sthings-baseos >= 26.5.695, and on an older collection set it is
+    # SILENTLY IGNORED — the guest simply keeps the template hostname with no
+    # error anywhere. A fleet still on an older pin can turn it off and know why
+    # the hostname is not set, instead of wondering.
+    _setHostname = _ans?.setHostname if "setHostname" in _ans else True
+    _hostnameVars = ["vm_hostname+-{}".format(_cluster)] if _setHostname else []
     _baseVars = [
         "manage_filesystem+-true"
         "update_packages+-true"
-        "vm_hostname+-{}".format(_cluster)
-    ] + (_ans?.extraVars or [])
+    ] + _hostnameVars + (_ans?.extraVars or [])
 
     _ansible = {
         enabled = True
@@ -131,7 +154,7 @@ runIDFor = lambda spec: {str:any}, stage: str -> str {
 }
 
 _ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks: [str], vars: [str], inventory: [str], vaultSecret: str -> {str:any} {
-    _ans = spec?.ansible or {}
+    _ans = stageAnsible(spec, stage)
     _runID = runIDFor(spec, stage)
     _suffix = "-{}".format(_runID) if _runID else ""
     _runName = "{}-{}{}".format(name, stage, _suffix)
@@ -169,7 +192,7 @@ _ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks:
 distributionRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any} {
     _cluster = spec?.clusterName or name
     _dist = cat.getDistribution(spec?.distribution or "k3s")
-    _vars = renderVars(_dist.vars) + ["cluster_name+-{}".format(_cluster)] + (spec?.ansible?.extraVars or [])
+    _vars = renderVars(_dist.vars) + ["cluster_name+-{}".format(_cluster)] + (stageAnsible(spec, "distribution")?.extraVars or [])
     _ansibleRun(name, ns, "distribution", spec, _dist.playbooks, _vars, renderInventory(_dist.inventoryGroups, ip), "")
 }
 

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -190,3 +190,52 @@ test_distribution_run_carries_the_version_pins = lambda {
     assert "k3s_k8s_version+-1.35.1" in _r.spec.ansibleVarsFile
     assert "k3s_release_kind+-k3s1" in _r.spec.ansibleVarsFile
 }
+
+# --- per-stage ansible overrides -------------------------------------------
+# The shared list reaches every stage; a stage entry is merged OVER it. Without
+# this, pinning a collection for the base-OS stage silently replaced the set the
+# k3s stage needed -- on the first live build that forced restating sthings-rke
+# in order to bump sthings-baseos.
+test_stage_overrides_merge_over_the_shared_ansible_block = lambda {
+    _spec = {
+        provider = "proxmox"
+        distribution = "k3s"
+        size = "medium"
+        ansible = {
+            extraCollections = ["shared:1"]
+            pipelineNamespace = "tekton-ci"
+            stages = {
+                baseos = {extraCollections = ["baseos:2"]}
+            }
+        }
+    }
+    # the base-OS stage sees its own list...
+    assert l.vmChild("c", "ns", _spec, cat.getSize("small")).spec.ansible.extraCollections == ["baseos:2"]
+    # ...the distribution stage still sees the shared one...
+    assert l.distributionRun("c", "ns", _spec, "10.0.0.1").spec.ansibleExtraCollections == ["shared:1"]
+    # ...and unrelated shared keys survive the merge.
+    assert l.distributionRun("c", "ns", _spec, "10.0.0.1").spec.namespace == "tekton-ci"
+}
+
+test_no_stage_overrides_keeps_the_shared_list_everywhere = lambda {
+    _spec = {provider = "proxmox", distribution = "k3s", size = "medium", ansible = {extraCollections = ["only:1"]}}
+    assert l.vmChild("c", "ns", _spec, cat.getSize("small")).spec.ansible.extraCollections == ["only:1"]
+    assert l.kubeconfigRun("c", "ns", _spec, "10.0.0.1").spec.ansibleExtraCollections == ["only:1"]
+}
+
+# --- the hostname floor ----------------------------------------------------
+# vm_hostname needs sthings-baseos >= 26.5.695. On an older set it is silently
+# ignored, so this is a knob rather than a hard-wire -- a fleet on an older pin
+# can turn it off and know why, instead of wondering why the hostname is unset.
+test_hostname_var_is_set_by_default = lambda {
+    _r = l.vmChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "k1"}, cat.getSize("small"))
+    assert "vm_hostname+-k1" in _r.spec.ansible.varsFile
+}
+
+test_hostname_var_can_be_turned_off = lambda {
+    _spec = {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "k1", ansible = {setHostname = False}}
+    _r = l.vmChild("c", "ns", _spec, cat.getSize("small"))
+    assert len([v for v in _r.spec.ansible.varsFile if "vm_hostname" in v]) == 0
+    # the other base-OS vars must survive
+    assert "manage_filesystem+-true" in _r.spec.ansible.varsFile
+}


### PR DESCRIPTION
Two of the three items in stuttgart-things/crossplane-configurations#182. Both were found while building the first live cluster, not by review.

## Per-stage ansible overrides

`ansible` stays the shared block; `ansible.stages.<stage>` is **merged over** it, so the common case remains a single list:

```yaml
ansible:
  extraCollections: [...]                     # every stage
  stages:
    baseos:       {extraCollections: [...]}   # this stage only
    distribution: {extraCollections: [...]}
```

The shared list reaches every run, so pinning one collection for the base-OS stage silently replaced the set the k3s stage needed. On the first live build that meant restating `sthings-rke` — required only by the *distribution* stage — in order to bump `sthings-baseos`, required only by the *base-OS* stage. Merging rather than replacing keeps the simple case simple.

## `setHostname`

The base-OS stage sets `vm_hostname`, which on Proxmox is what names the guest at all (bpg cloud-init cannot, without a snippets datastore). The var needs **`sthings-baseos >= 26.5.695`** and on an older collection set it is **silently ignored** — the guest keeps the template's hostname and nothing anywhere reports a problem. kind1's `ansible-run-defaults` currently pins `26.0.532`, so this is not hypothetical.

It stays **default-true** rather than becoming opt-in: the hostname is genuinely wanted, and making everyone ask for it would trade a silent no-op for a silent omission. The knob exists so a fleet on an older pin can turn it off *explicitly* and know why the hostname is unset.

The other half of that item — moving the fleet EnvironmentConfig to a newer baseos — is a change in `stuttgart-things/crossplane` and stays with #182.

## Not in this PR: sharpening `size` immutability

The third item needs a decision I would rather surface than make silently. Moving the check from CEL into the Composition means a size change is rejected by a *failing render* (XR goes `Synced=False`) instead of at admission with a readable message. That is a worse experience for the common typo, in exchange for allowing cpu/memory changes that the VM providers may or may not apply in place. Given #172 (day-2 scaling) is deferred anyway, leaving `size` immutable seems the better trade — but it is the issue's call, and I have written it up there rather than deciding it here.

25 tests (4 new), covering the merge in both directions and that turning the hostname off leaves the other base-OS vars intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr
