### PR TITLE
fix(xplane-cluster): stage overrides must replace, not unify (0.2.1)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -54,7 +54,13 @@ stageAnsible = lambda spec: {str:any}, stage: str -> {str:any} {
     _stages = _ans?.stages or {}
     _over = _stages[stage] if stage in _stages else {}
     _shared = {k: v for k, v in _ans if k not in ["stages"]}
-    _shared | _over
+
+    # KCL's `|` UNIFIES, it does not override: a key holding a list on BOTH
+    # sides is a conflict ("conflicting values on the attribute ..."), not a
+    # replacement. Drop the overridden keys from the shared side first, so the
+    # union has nothing to conflict about. Unit tests with literal dicts did not
+    # catch this — it only surfaced rendering a real XR.
+    {k: v for k, v in _shared if k not in _over} | _over
 }
 
 # --- the VM child ----------------------------------------------------------

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -239,3 +239,25 @@ test_hostname_var_can_be_turned_off = lambda {
     # the other base-OS vars must survive
     assert "manage_filesystem+-true" in _r.spec.ansible.varsFile
 }
+
+# Regression: `|` unifies rather than overrides, so a key holding a LIST on both
+# sides raised "conflicting values on the attribute extraCollections" — but only
+# when rendering a real XR, not with the literal dicts the other tests use.
+# Asserting the winning value is not enough; the merge must not raise at all.
+test_stage_override_replaces_a_list_without_conflict = lambda {
+    _spec = {
+        provider = "proxmox"
+        distribution = "k3s"
+        size = "medium"
+        ansible = {
+            extraCollections = ["shared:1", "shared:2"]
+            extraVars = ["a+-1"]
+            stages = {
+                distribution = {extraCollections = ["dist:1"]}
+            }
+        }
+    }
+    _d = l.stageAnsible(_spec, "distribution")
+    assert _d.extraCollections == ["dist:1"]
+    assert _d.extraVars == ["a+-1"]
+}


### PR DESCRIPTION
Follow-up to #95, caught immediately by rendering the Configuration's `xr-max` example.

KCL's `|` **unifies** rather than overrides. A key holding a **list** on both the shared and the per-stage side is therefore a conflict, not a replacement:

```
cannot render composite resource: pipeline step "cluster" returned a fatal result:
EvaluationError | conflicting values on the attribute 'extraCollections' between ...
```

Fixed by dropping the overridden keys from the shared side before the union.

## Why the tests missed it

`kcl test` passed 25/25 with literal dicts — the union resolved fine there. Only the schema-shaped `oxr` from a real render triggered the conflict. That is a decent argument for rendering an example as part of the loop rather than trusting unit tests alone, and it is why the new test asserts the merge **does not raise** rather than only checking the winning value: the previous test checked the result and still missed the failure.

26 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr