### PR TITLE
feat(xplane-cluster): derive vaultIssuer.kubernetesHost from ClusterAccess (0.3.0)

### DIFF
--- a/crossplane/xplane-cluster/README.md
+++ b/crossplane/xplane-cluster/README.md
@@ -77,6 +77,14 @@ The base-OS stage sets `vm_hostname` by default; on Proxmox that is what actuall
 
 It needs **`sthings-baseos >= 26.5.695`**. On an older collection set the var is **silently ignored** — the guest keeps the template's hostname and nothing reports an error. `ansible.setHostname: false` turns it off, so a fleet still on an older pin can make that explicit rather than wonder why the hostname is unset.
 
+## The API endpoint is derived, not copied
+
+Every `Platform` in the fleet states `vaultIssuer.kubernetesHost` by hand today — a copied node IP such as `https://10.31.102.108:6443`. It goes stale the moment the machine is rebuilt, and nothing notices until an issuer stops working.
+
+`ClusterAccess` **discovers** the endpoint from the running cluster, so when `vaultIssuer` is enabled and `kubernetesHost` is not set, it is injected from `status.share.apiEndpoint`. An explicit value always wins — it may deliberately differ, e.g. a VIP or a load balancer in front of the API.
+
+**This does not make the endpoint highly available.** It is still one node's address. It removes the hand-copied-value failure, not the single point of failure — see [crossplane-configurations#171](https://github.com/stuttgart-things/crossplane-configurations/issues/171), which also carries the finding that the fleet's ansible layer has no `tls-san` or kube-vip support today, so a real VIP needs work there first.
+
 ## What the user cannot set
 
 `Platform.cni.enabled` comes from the catalog's `cniOwnership`, never from `spec.platform.cni.enabled`. A k3s role installs cilium itself; a kind cluster is built without one. Setting it by hand is how a cluster ends up with two CNIs. The user's other `cni` keys (chart version, values) pass through untouched — only `enabled` is overridden, and a test covers both halves.

--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -252,12 +252,34 @@ clusterAccess = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
 # user: cni.enabled follows from the distribution's CNI ownership, and setting it
 # by hand is how a cluster ends up with two CNIs (a k3s role installs cilium
 # itself; a kind cluster is deliberately built without one).
-platformChild = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
+platformChild = lambda name: str, ns: str, spec: {str:any}, apiEndpoint: str -> {str:any} {
     _cluster = spec?.clusterName or name
     # `enabled` is no longer filtered here — it lives on spec.platformEnabled.
-    _passthrough = {k: v for k, v in (spec?.platform or {}) if k not in ["clusterName", "cni"]}
+    _passthrough = {k: v for k, v in (spec?.platform or {}) if k not in ["clusterName", "cni", "vaultIssuer"]}
     _userCni = (spec?.platform or {})?.cni or {}
     _cniEnabled = cat.platformCniEnabled(spec?.distribution or "k3s")
+
+    # vaultIssuer.kubernetesHost is the API server address Vault's Kubernetes
+    # auth mount is configured with. Every Platform in the fleet states it by
+    # hand today (`https://10.31.102.108:6443`), which is a copied node IP: it
+    # goes stale the moment the machine is rebuilt, and nothing notices until an
+    # issuer stops working.
+    #
+    # ClusterAccess DISCOVERS it from the running cluster, so derive it — but
+    # only when the user did not set it, because an explicit value may
+    # deliberately differ (a VIP or a load balancer in front of the API).
+    #
+    # NOTE this does not make the endpoint highly available: it is still one
+    # node's address. It removes the hand-copied-value failure, not the SPOF.
+    # See crossplane-configurations#171.
+    _userVault = (spec?.platform or {})?.vaultIssuer or {}
+    _wantVault = _userVault?.enabled or False
+    _hasHost = (_userVault?.kubernetesHost or "") != ""
+    _deriveHost = _wantVault and not _hasHost and apiEndpoint != ""
+    _vaultDerived = {k: v for k, v in _userVault if k != "kubernetesHost"} | {kubernetesHost = apiEndpoint}
+    _vaultPassthrough = {vaultIssuer = _userVault} if _userVault else {}
+    _vaultBlock = {vaultIssuer = _vaultDerived} if _deriveHost else _vaultPassthrough
+
     {
         apiVersion = "config.stuttgart-things.com/v1alpha1"
         kind = "Platform"
@@ -266,7 +288,7 @@ platformChild = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
             namespace = ns
             annotations = {"krm.kcl.dev/composition-resource-name" = "platform"}
         }
-        spec = _passthrough | {
+        spec = _passthrough | _vaultBlock | {
             clusterName = _cluster
             cni = _userCni | {enabled = _cniEnabled}
         }

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -106,14 +106,14 @@ test_no_runid_keeps_the_plain_names = lambda {
 # distribution, never from the user. A k3s role installs cilium itself; setting
 # it by hand is how a cluster ends up with two CNIs.
 test_platform_cni_follows_the_distribution = lambda {
-    assert not l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}).spec.cni.enabled
-    assert l.platformChild("c", "ns", {provider = "proxmox", distribution = "kind", size = "medium"}).spec.cni.enabled
+    assert not l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "").spec.cni.enabled
+    assert l.platformChild("c", "ns", {provider = "proxmox", distribution = "kind", size = "medium"}, "").spec.cni.enabled
 }
 
 test_user_cannot_override_cni_enabled = lambda {
     _r = l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", platform = {
         cni = {enabled = True, chart = {version = "1.19.6"}}
-    }})
+    }}, "")
     # The user's enabled is discarded...
     assert not _r.spec.cni.enabled
     # ...but the rest of their cni block survives.
@@ -123,7 +123,7 @@ test_user_cannot_override_cni_enabled = lambda {
 test_platform_passthrough_and_derived_clusterName = lambda {
     _r = l.platformChild("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium", clusterName = "k1", platform = {
         fluxInit = {enabled = True}
-    }})
+    }}, "")
     assert _r.spec.clusterName == "k1"
     assert _r.spec.fluxInit.enabled
 }
@@ -260,4 +260,48 @@ test_stage_override_replaces_a_list_without_conflict = lambda {
     _d = l.stageAnsible(_spec, "distribution")
     assert _d.extraCollections == ["dist:1"]
     assert _d.extraVars == ["a+-1"]
+}
+
+# --- the API endpoint (#171) -----------------------------------------------
+# Every Platform in the fleet states vaultIssuer.kubernetesHost by hand today --
+# a copied node IP that goes stale the moment the machine is rebuilt, with
+# nothing noticing until an issuer breaks. ClusterAccess discovers it, so derive
+# it. This does NOT make the endpoint highly available; it removes the
+# hand-copied value, not the single point of failure.
+test_kubernetes_host_is_derived_when_unset = lambda {
+    _spec = {provider = "proxmox", distribution = "k3s", size = "medium", platform = {
+        vaultIssuer = {enabled = True, pkiRole = "sthings-vsphere"}
+    }}
+    _r = l.platformChild("c", "ns", _spec, "https://10.0.0.9:6443")
+    assert _r.spec.vaultIssuer.kubernetesHost == "https://10.0.0.9:6443"
+    # the rest of the user's block survives
+    assert _r.spec.vaultIssuer.pkiRole == "sthings-vsphere"
+}
+
+# An explicit value may deliberately differ -- a VIP or a load balancer in front
+# of the API. Deriving over it would silently undo that.
+test_explicit_kubernetes_host_wins = lambda {
+    _spec = {provider = "proxmox", distribution = "k3s", size = "medium", platform = {
+        vaultIssuer = {enabled = True, kubernetesHost = "https://api.example.com:6443"}
+    }}
+    _r = l.platformChild("c", "ns", _spec, "https://10.0.0.9:6443")
+    assert _r.spec.vaultIssuer.kubernetesHost == "https://api.example.com:6443"
+}
+
+test_no_vault_issuer_means_no_injection = lambda {
+    _spec = {provider = "proxmox", distribution = "k3s", size = "medium", platform = {
+        fluxInit = {enabled = True}
+    }}
+    _r = l.platformChild("c", "ns", _spec, "https://10.0.0.9:6443")
+    assert "vaultIssuer" not in _r.spec
+}
+
+# No endpoint discovered yet (ClusterAccess not ready) must not inject an empty
+# host -- that would be worse than leaving it unset.
+test_no_endpoint_means_no_injection = lambda {
+    _spec = {provider = "proxmox", distribution = "k3s", size = "medium", platform = {
+        vaultIssuer = {enabled = True}
+    }}
+    _r = l.platformChild("c", "ns", _spec, "")
+    assert "kubernetesHost" not in _r.spec.vaultIssuer
 }

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -181,7 +181,7 @@ _groups = [
     [_distChild] if _distOpen else []
     [_kcChild] if _kcOpen else []
     [l.clusterAccess(_name, _ns, _spec)] if _accessOpen else []
-    [l.platformChild(_name, _ns, _spec)] if _platOpen else []
+    [l.platformChild(_name, _ns, _spec, _accessShare?.apiEndpoint or "")] if _platOpen else []
     _usages
     [_dxrPatched]
 ]


### PR DESCRIPTION
Partial for stuttgart-things/crossplane-configurations#171 — the part that is actually fixable in this repo.

## What this does

`vaultIssuer.kubernetesHost` is injected from `ClusterAccess`'s discovered `status.share.apiEndpoint` when `vaultIssuer` is enabled and the host is unset.

Every `Platform` in the fleet states it by hand today — `https://10.31.102.108:6443` — which goes stale the moment the machine is rebuilt, and nothing notices until an issuer stops working.

Three guards, each with a test:

- an **explicit** value always wins (it may deliberately point at a VIP or a load balancer);
- **no `vaultIssuer`** means no injection at all;
- **no endpoint discovered yet** injects nothing rather than an empty string, which would be worse than leaving the field unset.

## What this explicitly does not do

**It does not make the endpoint highly available.** It is still one node's address. This removes the hand-copied-value failure, not the single point of failure.

While looking into the real fix, two things worth recording on #171:

1. **The fleet's ansible layer has no `tls-san` or kube-vip support at all** — no such variable appears in any `exec/*/vars.yaml`. A VIP therefore needs role work before any Crossplane-side change would matter.
2. **`ip-reservation` cannot supply the API name as-is.** It creates a *wildcard* record (`*.cluster.domain`) aimed at the Gateway's LoadBalancer IP, not an A record for the API server on a node's `:6443`.

And the constraint that makes this urgent rather than cosmetic: whatever address is eventually chosen must be in the API server certificate's SANs **at install time**. Retrofitting a SAN onto a running cluster means regenerating certificates, so the decision wants making before the next HA cluster is built, not after.

30 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEYo3Hs9W5La291N7N1xr
