### PR TITLE
fix(ci): pin the KCL CLI — 0.12.8 formatting broke function-kcl (xplane-cluster 0.3.2)

### DIFF
--- a/.github/workflows/kcl-module-ci.yaml
+++ b/.github/workflows/kcl-module-ci.yaml
@@ -31,6 +31,25 @@ permissions:
   contents: read
   packages: write
 
+env:
+  # PINNED — do not float to latest. The consumer of these modules is
+  # `function-kcl` (v0.12.0 in the Configurations), and its embedded KCL is
+  # older than the CLI's HEAD. kcl 0.12.8's formatter rewrites a long lambda
+  # parameter list into a multi-line block:
+  #
+  #     _ansibleRun = lambda {
+  #         name: str,
+  #         ...
+  #     } -> {str:any} {
+  #
+  # which older KCL cannot parse at all ('expected one of ["="] got ,').
+  # With the CLI unpinned the fmt gate therefore *demanded* source the runtime
+  # rejects: it went red on untouched code, and formatting to satisfy it
+  # published an xplane-cluster that failed to compile inside function-kcl.
+  # Raise this only together with the function-kcl version in
+  # stuttgart-things/crossplane-configurations.
+  KCL_VERSION: "0.12.4"
+
 jobs:
   detect-changed-modules:
     runs-on: ubuntu-latest

--- a/crossplane/xplane-cluster/README.md
+++ b/crossplane/xplane-cluster/README.md
@@ -119,6 +119,7 @@ kcl test .
 
 ## Gotchas found while writing this (KCL, not Crossplane)
 
+- **`kcl fmt` from a newer CLI can emit source the runtime cannot parse.** kcl 0.12.8 rewrites a long `lambda a: str, b: str -> T {` parameter list into a multi-line `lambda { a: str, … } -> T {` block. `function-kcl` v0.12.0 — the thing that actually runs this module — rejects that outright (`expected one of ["="] got ,`), so 0.3.1 was published unrenderable and superseded by 0.3.2. CI now pins `KCL_VERSION`; keep the two in step.
 - **Commas are load-bearing in multi-line list literals.** `[a]` followed by a line starting with `[` parses as a *subscript*, silently dropping entries instead of failing. Cost an hour; the assembled `items` list carries a comment.
 - **No `enumerate()`**, and no multi-line ternary chains — both are single-line or comprehension-only.
 - **A dict literal is typed by its keys**, so `base | {newKey = …}` fails type checking. Tests write specs out in full instead of merging.

--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.3.0" }

--- a/crossplane/xplane-cluster/kcl.mod.lock
+++ b/crossplane/xplane-cluster/kcl.mod.lock
@@ -3,6 +3,7 @@
     name = "xplane-cluster-catalog"
     full_name = "xplane-cluster-catalog_0.3.0"
     version = "0.3.0"
+    sum = "hRaDYRDJT7Z39B2RlFKtLSC0uvpgk3ljerD4P3ks9Tg="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-cluster-catalog"
     oci_tag = "0.3.0"

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -182,16 +182,7 @@ runIDFor = lambda spec: {str:any}, stage: str -> str {
     str(_ids[stage]) if stage in _ids else ""
 }
 
-_ansibleRun = lambda {
-    name: str,
-    ns: str,
-    stage: str,
-    spec: {str:any},
-    playbooks: [str],
-    vars: [str],
-    inventory: [str],
-    vaultSecret: str,
-} -> {str:any} {
+_ansibleRun = lambda name: str, ns: str, stage: str, spec: {str:any}, playbooks: [str], vars: [str], inventory: [str], vaultSecret: str -> {str:any} {
     _ans = stageAnsible(spec, stage)
     _runID = runIDFor(spec, stage)
     _suffix = "-{}".format(_runID) if _runID else ""
@@ -337,13 +328,7 @@ platformChild = lambda name: str, ns: str, spec: {str:any}, apiEndpoint: str -> 
 # `kubectl delete` is swallowed and has to be issued twice.
 #
 # Usage orders DELETION ONLY, never creation: build order stays the ready gates.
-usage = lambda {
-    ofKind: str,
-    ofName: str,
-    byKind: str,
-    byName: str,
-    label: str,
-} -> {str:any} {
+usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str -> {str:any} {
     {
         apiVersion = "protection.crossplane.io/v1beta1"
         kind = "Usage"


### PR DESCRIPTION
Follow-up to #98, which shipped an **unrenderable** `xplane-cluster` 0.3.1.

## What broke

The `lint-and-test` fmt gate installs the latest KCL CLI. When it floated to **0.12.8**, its formatter started rewriting a long lambda parameter list into a multi-line block:

```kcl
_ansibleRun = lambda {
    name: str,
    ...
} -> {str:any} {
```

Older KCL cannot parse that at all (`expected one of ["="] got ,`). That turned a *style* gate into a *correctness* trap in two steps:

1. the gate went red on code neither commit in #98 touched;
2. formatting to satisfy it produced source that `function-kcl` **v0.12.0** — the runtime that actually executes these modules in `crossplane-configurations` — rejects. The published 0.3.1 fails every `ClusterStack` render with `name 'spec' is not defined`, which is how it was caught (verify on crossplane-configurations#237).

## What this does

- **Pins `KCL_VERSION: "0.12.4"`** for both the lint and the publish jobs, with the reason in a comment. The CLI's formatter must not be newer than the runtime's parser; raise it only together with the function-kcl version in `crossplane-configurations`.
- **Restores the single-line lambda signatures** in `logic.k` (`_ansibleRun`, `usage`) — no behaviour change, `kcl test .` 33/33.
- **Bumps `xplane-cluster` to 0.3.2.** 0.3.1 stays on ghcr (tags are immutable) but must not be referenced; `crossplane-configurations` moves its pin to 0.3.2.
- Records the catalog `0.3.0` sum in `kcl.mod.lock`, now that the catalog is published.
- Notes the trap in the module README's KCL-gotchas list.

`xplane-cluster-catalog` 0.3.0 is unaffected — its only fmt change was a trailing blank line.
