### PR TITLE
feat(cluster-catalog): add the rke2 distribution, with its reference run (0.4.0)

### DIFF
--- a/crossplane/xplane-cluster-catalog/README.md
+++ b/crossplane/xplane-cluster-catalog/README.md
@@ -35,18 +35,19 @@ All values are **strings** — both VM XRDs take strings, and emitting ints fail
 
 ## Distributions
 
-| | `k3s` | `kind` |
-|---|---|---|
-| playbook | `sthings.rke.k3s_cluster` | `sthings.container.kind` |
-| version pin | `k3s_k8s_version 1.35.1`, `k3s_release_kind k3s1` | `kind_version 0.31.0`, `kubectl_version 1.35.0` |
-| CNI ownership | `self` — the role installs cilium | `platform` — built deliberately without one |
-| inventory groups | `initial_master_node`, `additional_master_nodes`, `workers` | `all` |
-| cluster-name vars | — (`cluster_name` only) | `kind_cluster_name` |
-| multi-node | no | no |
+| | `k3s` | `kind` | `rke2` |
+|---|---|---|---|
+| playbook | `sthings.rke.k3s_cluster` | `sthings.container.kind` | `sthings.rke.rke2_cluster` |
+| version pin | `k3s_k8s_version 1.35.1`, `k3s_release_kind k3s1` | `kind_version 0.31.0`, `kubectl_version 1.35.0` | `rke2_k8s_version 1.35.1`, `rke2_release_kind rke2r1` |
+| CNI ownership | `self` — the role installs cilium | `platform` — built deliberately without one | `self` — `rke2_cni: none`, the role installs cilium |
+| inventory groups | `initial_master_node`, `additional_master_nodes`, `workers` | `all` | `initial_master_node`, `additional_master_nodes`, `workers` |
+| cluster-name vars | — (`cluster_name` only) | `kind_cluster_name` | — (`cluster_name` only) |
+| multi-node | no | no | no |
 
-Every var in the tables is load-bearing, with the incident history in the comments. Two worth repeating:
+Every var in the tables is load-bearing, with the incident history in the comments. Three worth repeating:
 
 - **k3s `install_cilium: "true"` is mandatory.** The role's `k3s_config` default writes `flannel-backend=none`, `disable-kube-proxy=true` and `disable-network-policy=true` — k3s comes up deliberately without a CNI *and* without kube-proxy. With it false the cluster has no working pod network at all.
+- **rke2 pins the pair the fleet runs, not the play's defaults.** `sthings.rke.rke2_cluster` defaults to `1.36.1` / `rke2r2`; every rke2 cluster in this fleet is on `1.35.1` / `rke2r1`. Shipping the default would pin a combination nobody here has ever booted. The entry was added only after a reference run on 2026-08-11 — an `AnsibleRun` on the u26-kind3 machinery cluster driving the play against a Proxmox VM, which produced `Ready control-plane,etcd v1.35.1+rke2r1` with cilium up. That rule ("no entry without a reference run") is enforced by `catalog_test.k`, not just stated here.
 - **k3s's three inventory groups are not cosmetic.** `sthings.rke.deploy_configure_rke` branches on `groups['initial_master_node']` and `groups['additional_master_nodes']`; a flat `all+[...]` inventory fails with an undefined-group error. Empty groups render as header-only INI sections, which ansible registers as existing-but-empty — exactly what the role's `in groups[...]` tests need.
 
 ### The cluster name is not one var

--- a/crossplane/xplane-cluster-catalog/catalog_test.k
+++ b/crossplane/xplane-cluster-catalog/catalog_test.k
@@ -5,11 +5,31 @@ import .main as c
 test_distributions_registered = lambda {
     assert "k3s" in c.distributions
     assert "kind" in c.distributions
+    # rke2 joined on 2026-08-11, in the same commit as its reference run — an
+    # AnsibleRun on u26-kind3 that brought up v1.35.1+rke2r1 with cilium. The
+    # rule this assertion used to enforce ("no entry without a reference run")
+    # was satisfied, not waived.
+    assert "rke2" in c.distributions
+}
 
-    # rke2 is deliberately absent until a reference run exists — if someone adds
-    # it, this test should be updated in the same commit as the reference run,
-    # not before.
-    assert "rke2" not in c.distributions
+# rke2 pins the pair the FLEET runs, not the pair the play defaults to
+# (1.36.1 / rke2r2). A catalog that ships an unbooted combination is the exact
+# failure k3s.k documents, so the two values are asserted rather than trusted.
+test_rke2_pins_the_verified_version_pair = lambda {
+    _v = c.getDistribution("rke2").vars
+    assert _v["rke2_k8s_version"] == "1.35.1"
+    assert _v["rke2_release_kind"] == "rke2r1"
+}
+
+# rke2 is told to ship no CNI, so its role must install cilium — and a Platform
+# for such a cluster must therefore NOT enable its own Cni component. Same shape
+# as k3s, opposite of kind.
+test_rke2_owns_its_own_cni = lambda {
+    _d = c.getDistribution("rke2")
+    assert _d.vars["rke2_cni"] == "none"
+    assert _d.vars["install_cilium"] == "true"
+    assert _d.cniOwnership == "self"
+    assert not c.platformCniEnabled("rke2")
 }
 
 test_sizes_registered = lambda {

--- a/crossplane/xplane-cluster-catalog/catalog_test.k
+++ b/crossplane/xplane-cluster-catalog/catalog_test.k
@@ -5,6 +5,7 @@ import .main as c
 test_distributions_registered = lambda {
     assert "k3s" in c.distributions
     assert "kind" in c.distributions
+
     # rke2 joined on 2026-08-11, in the same commit as its reference run — an
     # AnsibleRun on u26-kind3 that brought up v1.35.1+rke2r1 with cilium. The
     # rule this assertion used to enforce ("no entry without a reference run")

--- a/crossplane/xplane-cluster-catalog/distributions/rke2.k
+++ b/crossplane/xplane-cluster-catalog/distributions/rke2.k
@@ -1,0 +1,68 @@
+# rke2 — single-node through this catalog.
+#
+# Added only after a reference run, as main.k demanded. That run, on
+# 2026-08-11, was an AnsibleRun on the u26-kind3 machinery cluster driving
+# sthings.rke.rke2_cluster against a Proxmox VM u26-kind3 had itself built and
+# base-OS'd (VMID 132, 10.31.102.147). Result:
+#
+#   rke2-server                    active
+#   u26-baseos-test.labul.sva.de   Ready   control-plane,etcd   v1.35.1+rke2r1
+#   cilium                         3 pods
+#
+# Every value below is what that run used. None of it is copied from the play's
+# defaults.
+import ..schema as s
+
+rke2: s.Distribution = s.Distribution {
+    playbooks = ["sthings.rke.rke2_cluster"]
+    vars = {
+        rke_state = "present"
+        # PINNED, AND DELIBERATELY NOT THE PLAY DEFAULT. sthings.rke.rke2_cluster
+        # defaults to 1.36.1 / rke2r2, but every rke2 cluster this fleet runs is
+        # on 1.35.1 / rke2r1 (exec/labul/{infra,platform,sthings-infra}-rke2 all
+        # agree). Shipping the play default here would pin a combination nobody
+        # in this fleet has ever booted — the same trap distributions/k3s.k
+        # already records, where a live build produced v1.36.1 against an XR
+        # pinning 1.35.1. The reference run used the pair below and came up
+        # Ready; that is the only reason it is here.
+        rke2_k8s_version = "1.35.1"
+        rke2_release_kind = "rke2r1"
+        cluster_setup = "singlenode"
+        # MANDATORY PAIR, and the whole reason cniOwnership is "self". rke2 is
+        # told to ship no CNI at all, so the role must install cilium itself.
+        # Drop install_cilium and the cluster has no pod network; let a Platform
+        # add its own Cni component on top and two CNIs fight over the datapath.
+        rke2_cni = "none"
+        install_cilium = "true"
+        # Cilium replaces kube-proxy, matching the CNI-less config above.
+        disableKubeProxy = "true"
+        # The role's own install path in this fleet — every exec/labul/*rke2*
+        # vars.yaml sets it. Not an airgap statement about the environment.
+        rke2_airgapped_installation = "true"
+        prepare_rancher_ha_nodes = "true"
+        install_helm_diff = "false"
+        # Fetched to the ansible controller, i.e. the Tekton pod's ephemeral
+        # filesystem. On the node the kubeconfig stays at
+        # /etc/rancher/rke2/rke2.yaml.
+        fetched_kubeconfig_path = "/tmp/kubeconfig"
+        ansible_become = "true"
+        ansible_become_method = "sudo"
+    }
+    # Same role as k3s (sthings.rke.deploy_configure_rke), so the same three
+    # groups: it branches on groups['initial_master_node'] and
+    # groups['additional_master_nodes'], and a flat `all+[...]` inventory fails
+    # with an undefined-group error.
+    inventoryGroups = ["initial_master_node", "additional_master_nodes", "workers"]
+    # The role installs cilium (see the pair above), so a Platform for an rke2
+    # cluster must leave cni.enabled off.
+    cniOwnership = "self"
+    # NOT a statement about rke2 upstream — the fleet runs multinode rke2 today
+    # through ansible (exec/labul/sthings-infra-rke2 sets cluster_setup:
+    # multinode). It is a statement about THIS path: a ClusterStack composes one
+    # VM child, so N masters would need N VMs, static addressing and an
+    # aggregate ready gate. Same open item as k3s -> #170.
+    multiNode = False
+    # clusterNameVars stays empty: sthings.rke.rke2_cluster reads `cluster_name`
+    # directly (`cluster_name: "{{ cluster_name | default('rke2') }}"`), unlike
+    # sthings.container.kind, which ignores it and needs kind_cluster_name.
+}

--- a/crossplane/xplane-cluster-catalog/kcl.mod
+++ b/crossplane/xplane-cluster-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-cluster-catalog"
 edition = "v0.12.3"
-version = "0.3.0"
+version = "0.4.0"

--- a/crossplane/xplane-cluster-catalog/main.k
+++ b/crossplane/xplane-cluster-catalog/main.k
@@ -4,18 +4,22 @@
 # distributions/<name>.k, then one import and one entry here. Keeping it manual
 # is the point — adding a distribution is a reviewable two-line diff.
 #
-# rke2 is DELIBERATELY ABSENT. The fleet runs multinode rke2 clusters through
-# ansible (exec/labul/sthings-infra-rke2), but no Crossplane path has ever built
-# one, so an entry here would be a guess wearing the same clothes as a verified
-# fact. Add it after a reference run, not before.
+# rke2 was absent until 2026-08-11 on the rule that an entry without a reference
+# run is "a guess wearing the same clothes as a verified fact". That run has now
+# happened — an AnsibleRun on the u26-kind3 machinery cluster drove
+# sthings.rke.rke2_cluster against a Proxmox VM and produced a Ready
+# control-plane on v1.35.1+rke2r1 with cilium up. See distributions/rke2.k for
+# the run and for why its pins are not the play's defaults.
 import .distributions.k3s as k3s
 import .distributions.kind as kind
+import .distributions.rke2 as rke2
 import sizes as sz
 import schema as s
 
 distributions: {str:s.Distribution} = {
     k3s = k3s.k3s
     kind = kind.kind
+    rke2 = rke2.rke2
 }
 
 sizes: {str:s.Size} = sz.sizeTable

--- a/crossplane/xplane-cluster-catalog/schema.k
+++ b/crossplane/xplane-cluster-catalog/schema.k
@@ -119,3 +119,4 @@ schema Stage:
     playbooks: [str]
     vars: {str:str}
     inventoryGroups: [str]
+


### PR DESCRIPTION
`main.k` held rke2 out on an explicit rule:

> rke2 is **DELIBERATELY ABSENT**. The fleet runs multinode rke2 clusters through ansible, but no Crossplane path has ever built one, so an entry here would be **a guess wearing the same clothes as a verified fact**. Add it after a reference run, not before.

`catalog_test.k` enforced it with `assert "rke2" not in c.distributions`.

## The reference run happened

On 2026-08-11 an `AnsibleRun` on the **u26-kind3** machinery cluster drove `sthings.rke.rke2_cluster` against a Proxmox VM that u26-kind3 had itself built and base-OS'd (VMID 132, 10.31.102.147):

```
rke2-server                    active
u26-baseos-test.labul.sva.de   Ready   control-plane,etcd   v1.35.1+rke2r1
cilium                         3 pods
```

Every value in `distributions/rke2.k` is what that run used. The absence assertion is flipped **in this same commit**, as the comment asked.

## The version pin is the point

| | play default | what the fleet runs | what this entry pins |
|---|---|---|---|
| `rke2_k8s_version` | 1.36.1 | **1.35.1** | **1.35.1** |
| `rke2_release_kind` | rke2r2 | **rke2r1** | **rke2r1** |

`exec/labul/{infra,platform,sthings-infra}-rke2` all agree on the fleet pair. Copying the play default into the catalog would have pinned a combination nobody here has ever booted — precisely the failure `distributions/k3s.k` already documents ("a live build produced v1.36.1 while the hand-written XR pins 1.35.1"). A new test asserts both values rather than trusting them.

## CNI ownership

`self` — same shape as k3s, opposite of kind. rke2 is told `rke2_cni: none`, so the role must install cilium, and a Platform for such a cluster must leave `cni.enabled` off or two CNIs fight over the datapath. Asserted, not just commented.

## multiNode stays False

Not a claim about rke2 upstream — the fleet runs multinode rke2 through ansible today. It is a claim about **this path**: a `ClusterStack` composes one VM child, so N masters need N VMs, static addressing and an aggregate ready gate. Same open item as k3s ([crossplane-configurations#170](https://github.com/stuttgart-things/crossplane-configurations/issues/170)).

## Tests

`kcl test` → **18/18 PASS**, including two new ones and the pre-existing `test_every_distribution_pins_a_version`, which now covers rke2.

Module `0.3.0` → `0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSYX5dsdVdzLCuB6xYhaLK
