### PR TITLE
feat(xplane-cluster): catalog 0.4.0, and the rke2 kubeconfig path it exposes (0.4.0)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.3.2"
+version = "0.4.0"
 
 [dependencies]
-xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.3.0" }
+xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/kcl.mod.lock
+++ b/crossplane/xplane-cluster/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-cluster-catalog]
     name = "xplane-cluster-catalog"
-    full_name = "xplane-cluster-catalog_0.3.0"
-    version = "0.3.0"
-    sum = "hRaDYRDJT7Z39B2RlFKtLSC0uvpgk3ljerD4P3ks9Tg="
+    full_name = "xplane-cluster-catalog_0.4.0"
+    version = "0.4.0"
+    sum = "/nr/cQg+BPPO0yZJETHWYUct125P8RGwTcxPXrrsiGA="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-cluster-catalog"
-    oci_tag = "0.3.0"
+    oci_tag = "0.4.0"

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -229,15 +229,31 @@ kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any}
     _cluster = spec?.clusterName or name
     _stage = cat.kubeconfigStage
 
-    # Where the kubeconfig sits on the node differs per distribution; the k3s
-    # server writes /etc/rancher/k3s/k3s.yaml, while the kind role fetches to the
-    # user's home. Only k3s needs the override — the kind side is left to the
-    # play's own `/home/{{ ansible_user }}/.kube/{{ kind_cluster_name }}`, which
-    # is correct precisely BECAUSE clusterNameVars sets kind_cluster_name in this
-    # stage too. Hard-coding the path here instead would need ansible_user, which
-    # this module does not know.
-    _paths = ["kubeconfig_path+-/etc/rancher/k3s/k3s.yaml"] if (spec?.distribution or "k3s") == "k3s" else []
-    _vars = renderVars(_stage.vars) + clusterNameVars(spec?.distribution or "k3s", _cluster) + _paths
+    # Where the kubeconfig sits on the node differs per distribution, and the
+    # upload play cannot guess: its default is
+    # `/home/{{ ansible_user }}/.kube/{{ kind_cluster_name }}` — a KIND path,
+    # with kind_cluster_name defaulting to `dev`.
+    #
+    #   k3s   /etc/rancher/k3s/k3s.yaml
+    #   rke2  /etc/rancher/rke2/rke2.yaml
+    #   kind  no override — the play's own default is correct, precisely BECAUSE
+    #         clusterNameVars sets kind_cluster_name in THIS stage too. Hard-
+    #         coding it here would need ansible_user, which this module does not
+    #         know.
+    #
+    # rke2 was added on 2026-08-11 with catalog 0.4.0. Without it an rke2
+    # ClusterStack inherits the kind default and the upload looks for
+    # /home/sthings/.kube/dev on a host that only has
+    # /etc/rancher/rke2/rke2.yaml — verified on the reference-run VM. That is
+    # the same shape of bug as crossplane-configurations#232: a distribution-
+    # specific fact the consumer has to supply, invisible to `crossplane render`.
+    _serverPaths = {
+        k3s = "/etc/rancher/k3s/k3s.yaml"
+        rke2 = "/etc/rancher/rke2/rke2.yaml"
+    }
+    _dist = spec?.distribution or "k3s"
+    _paths = ["kubeconfig_path+-" + _serverPaths[_dist]] if _dist in _serverPaths else []
+    _vars = renderVars(_stage.vars) + clusterNameVars(_dist, _cluster) + _paths
 
     # THE KUBECONFIGS VAULT IS NOT THE INFRA VAULT. ansible-run defaults
     # vaultSecretName to `vault`, which in this fleet points at the infra Vault

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -83,6 +83,37 @@ test_kubeconfig_run_is_a_separate_run_with_the_k3s_path = lambda {
     assert "kubeconfig_path+-/etc/rancher/k3s/k3s.yaml" not in _k.spec.ansibleVarsFile
 }
 
+# rke2 writes to its OWN path. The upload play's default is a kind path
+# (/home/<user>/.kube/<kind_cluster_name>, defaulting to `dev`), so without an
+# override an rke2 cluster's upload looks for a file that does not exist —
+# confirmed on the reference-run VM, which has /etc/rancher/rke2/rke2.yaml and
+# no k3s path at all. Same shape as crossplane-configurations#232.
+test_rke2_gets_its_own_kubeconfig_path = lambda {
+    _r = l.kubeconfigRun("c", "ns", {provider = "proxmox", distribution = "rke2", size = "medium"}, "10.0.0.1")
+    assert "kubeconfig_path+-/etc/rancher/rke2/rke2.yaml" in _r.spec.ansibleVarsFile
+    # And emphatically not the k3s one — they are different directories.
+    assert "kubeconfig_path+-/etc/rancher/k3s/k3s.yaml" not in _r.spec.ansibleVarsFile
+}
+
+# The catalog entry has to survive the whole distribution stage, not just exist.
+test_rke2_distribution_run_carries_the_verified_pins = lambda {
+    _r = l.distributionRun("c", "ns", {provider = "proxmox", distribution = "rke2", size = "medium", clusterName = "r1"}, "10.0.0.1")
+    assert _r.spec.ansiblePlaybooks == ["sthings.rke.rke2_cluster"]
+    # The fleet pair, not the play defaults (1.36.1 / rke2r2).
+    assert "rke2_k8s_version+-1.35.1" in _r.spec.ansibleVarsFile
+    assert "rke2_release_kind+-rke2r1" in _r.spec.ansibleVarsFile
+    # rke2_cni: none means the role must bring cilium, or there is no pod network.
+    assert "install_cilium+-true" in _r.spec.ansibleVarsFile
+    assert "cluster_name+-r1" in _r.spec.ansibleVarsFile
+    # Same role as k3s, so the same three groups.
+    assert _r.spec.ansibleVarsInventory[0] == 'initial_master_node+["10.0.0.1"]'
+}
+
+# rke2 owns its CNI, so a Platform must NOT add one — the k3s rule, not the kind one.
+test_rke2_platform_does_not_add_a_second_cni = lambda {
+    assert not cat.platformCniEnabled("rke2")
+}
+
 # THE kind BUG (crossplane-configurations#232). sthings.container.kind ignores
 # `cluster_name` and names the cluster from `kind_cluster_name`, defaulting it to
 # `dev` — so the XR's identity never reached the cluster, and the Cni child then


### PR DESCRIPTION
Bumps the catalog dependency **0.3.0 → 0.4.0**, which is what makes `distribution: rke2` resolvable at all (kcl#100).

## The bump alone would not have worked

`kubeconfigRun()` set `kubeconfig_path` only for k3s, on the reasoning that everything else could fall through to the upload play's own default. That default is `/home/{{ ansible_user }}/.kube/{{ kind_cluster_name }}` — a **kind** path, with `kind_cluster_name` defaulting to `dev`.

rke2 writes to `/etc/rancher/rke2/rke2.yaml` and has no k3s path at all. Verified on the reference-run VM:

```
$ sudo ls /etc/rancher/rke2/rke2.yaml /etc/rancher/k3s/k3s.yaml
ls: cannot access '/etc/rancher/k3s/k3s.yaml': No such file or directory
/etc/rancher/rke2/rke2.yaml
```

So an rke2 `ClusterStack` would have uploaded from `/home/sthings/.kube/dev` and failed at the fetch — the same shape as [crossplane-configurations#232](https://github.com/stuttgart-things/crossplane-configurations/issues/232): a distribution-specific fact the consumer must supply, invisible to `crossplane render` and only reachable on a live host.

The path becomes a per-distribution lookup instead of an `if == "k3s"`. **kind stays deliberately absent from it** — the play's default is correct there precisely because `clusterNameVars` sets `kind_cluster_name` in this stage too.

## Tests

Three added, each asserting something that would otherwise only surface on a real cluster:

| test | what it pins down |
|---|---|
| `test_rke2_gets_its_own_kubeconfig_path` | rke2 gets its path, and emphatically not the k3s one |
| `test_rke2_distribution_run_carries_the_verified_pins` | the fleet pair `1.35.1` / `rke2r1` (not the play's `1.36.1` / `rke2r2`) plus the mandatory `install_cilium` |
| `test_rke2_platform_does_not_add_a_second_cni` | rke2 follows the k3s rule, not the kind one |

**36/36 PASS.**

Module `0.3.2` → `0.4.0`.

## Follow-up, deliberately not here

The kubeconfig path belongs in the **catalog**, next to `playbooks`, `inventoryGroups` and `cniOwnership` — it is exactly the kind of structural fact that module exists to hold, and keeping it in the consumer means the next distribution repeats this bug. Left out to keep this PR a dependency bump plus the fix it exposes, rather than a schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSYX5dsdVdzLCuB6xYhaLK
