### PR TITLE
fix(xplane-cluster): the kubeconfig upload wants `vault`, not `vault-kubeconfigs` (0.4.1)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -255,13 +255,36 @@ kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any}
     _paths = ["kubeconfig_path+-" + _serverPaths[_dist]] if _dist in _serverPaths else []
     _vars = renderVars(_stage.vars) + clusterNameVars(_dist, _cluster) + _paths
 
-    # THE KUBECONFIGS VAULT IS NOT THE INFRA VAULT. ansible-run defaults
-    # vaultSecretName to `vault`, which in this fleet points at the infra Vault
-    # and carries no AppRole; the kubeconfigs KV mount lives in a different
-    # Vault entirely. Leaving it unset fails the upload with
-    # "failed to determine alias name from login request" — found on the first
-    # live cluster build, invisible to render.
-    _vaultSecret = (spec?.kubeconfig or {})?.vaultSecretName or "vault-kubeconfigs"
+    # STATED EXPLICITLY, even though `vault` is also ansible-run's own default.
+    # Which Vault the upload authenticates against is a decision this module
+    # makes, not one it inherits: if ansible-run's default ever moves, an
+    # unset field here would follow it silently and the upload would write
+    # kubeconfigs into whatever Vault that is.
+    #
+    # `vault` is CORRECT and `vault-kubeconfigs` WAS WRONG, which is the reverse
+    # of what this comment said until 0.4.1. The old claim — "vault points at the
+    # infra Vault and carries no AppRole" — described kind1 in July 2026 and has
+    # not been true since: secrets/vault.enc.yaml carries VAULT_ADDR
+    # https://vault-vsphere.labul.sva.de:8200 plus the AppRole that owns the
+    # kubeconfigs mount (policy `superuser`), and the infra credential moved to
+    # its own blob, `vault-infra`. The two names cannot collide any more.
+    #
+    # Nothing ever created a Secret called `vault-kubeconfigs`. The fleet's
+    # sops-git-secrets chart derives a Secret's name from metadata.name inside
+    # its encrypted blob, so the name could only have come from a fourth blob
+    # duplicating a credential that is already on every cluster — a second copy
+    # to rotate, and a silent breakage the day someone rotates only one. Verified
+    # on u26-kind3 (2026-08-12): VAULT_ADDR, VAULT_ROLE_ID and VAULT_SECRET_ID of
+    # a hand-made `vault-kubeconfigs` sha256-matched `vault` exactly.
+    #
+    # So an rke2/k3s upload on a fresh machinery cluster failed with "failed to
+    # determine alias name from login request" — the same symptom the old comment
+    # blamed on leaving the field unset — until someone hand-created the alias.
+    #
+    # NOT the same name as ClusterAccess's kubeconfigProviderConfigRef below,
+    # which stays `vault-kubeconfigs`: that is a ClusterProviderConfig created by
+    # the provider-kubeconfig-vault chart, not a Secret.
+    _vaultSecret = (spec?.kubeconfig or {})?.vaultSecretName or "vault"
     _ansibleRun(name, ns, "kubeconfig", spec, _stage.playbooks, _vars, renderInventory(_stage.inventoryGroups, ip), _vaultSecret)
 }
 

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -216,14 +216,31 @@ test_usage_resolves_the_group_per_kind = lambda {
 }
 
 # --- the kubeconfigs Vault -------------------------------------------------
-# ansible-run defaults vaultSecretName to `vault`, which in this fleet points at
-# the INFRA Vault and carries no AppRole; the kubeconfigs KV mount lives in a
-# different Vault. Leaving it unset failed the first live cluster build with
-# "failed to determine alias name from login request" — a failure no render can
-# see, so it is pinned here instead.
+# The name must be EMITTED, not left to ansible-run's default: which Vault the
+# upload authenticates against is this module's decision, and an unset field
+# would follow a downstream default change silently.
+#
+# The value is `vault` — the fleet's vault-vsphere credential, which owns the
+# kubeconfigs KV mount. Until 0.4.1 this asserted `vault-kubeconfigs`, a Secret
+# nothing has ever created: sops-git-secrets names a Secret from metadata.name
+# inside its blob, so that name required a fourth blob duplicating a credential
+# already present as `vault` (sha256-identical on kind3, 2026-08-12). The upload
+# failed with "failed to determine alias name from login request" on every fresh
+# machinery cluster until someone hand-made the alias.
 test_kubeconfig_run_targets_the_kubeconfigs_vault = lambda {
     _r = l.kubeconfigRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
-    assert _r.spec.vaultSecretName == "vault-kubeconfigs"
+    assert _r.spec.vaultSecretName == "vault"
+}
+
+# The ClusterAccess side keeps the name `vault-kubeconfigs`, and that is not an
+# oversight: it is a ClusterProviderConfig emitted by the provider-kubeconfig-vault
+# chart, not a Secret. Asserted next to the change above so nobody "harmonises"
+# the two names in either direction.
+test_cluster_access_provider_config_is_not_the_secret_name = lambda {
+    _a = l.clusterAccess("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"})
+    assert _a.spec.kubeconfigProviderConfigRef == "vault-kubeconfigs"
+    _r = l.kubeconfigRun("c", "ns", {provider = "proxmox", distribution = "k3s", size = "medium"}, "10.0.0.1")
+    assert _r.spec.vaultSecretName != _a.spec.kubeconfigProviderConfigRef
 }
 
 test_kubeconfig_vault_secret_is_overridable = lambda {


### PR DESCRIPTION
## The bug

`kubeconfigRun` defaulted `vaultSecretName` to **`vault-kubeconfigs`** — a Secret nothing in this fleet has ever created.

`sops-git-secrets` derives a Secret's name from `metadata.name` *inside* the encrypted blob; the `path` value only picks which file to read. So there is no aliasing: that name could only have come from a fourth blob duplicating a credential already on every cluster as `vault`.

Verified on u26-kind3, 2026-08-12 — a hand-made `vault-kubeconfigs` is byte-identical to `vault`:

```
tekton-ci/vault              tekton-ci/vault-kubeconfigs
  VAULT_ADDR       cf66ec9698ef      cf66ec9698ef
  VAULT_ROLE_ID    79894f8a96e5      79894f8a96e5
  VAULT_SECRET_ID  9637df66a5e2      9637df66a5e2
```

Consequence: every fresh machinery cluster failed its kubeconfig upload with `failed to determine alias name from login request` until someone hand-created the alias — **the same symptom the old comment blamed on leaving the field unset.**

## The comment was stale in both halves

> ansible-run defaults vaultSecretName to `vault`, which in this fleet points at the infra Vault and carries no AppRole

That described kind1 in July 2026. Today `secrets/vault.enc.yaml` carries `VAULT_ADDR=https://vault-vsphere.labul.sva.de:8200` plus the AppRole that owns the `kubeconfigs` mount (policy `superuser`, confirmed `create/update` on `kubeconfigs/data/*`), and the infra credential has moved to its own blob, `vault-infra`. The two names cannot collide any more.

## Still emitted, not omitted

`vault` is also ansible-run's own default, but the field stays explicit: which Vault the upload authenticates against is this module's decision, and an unset field would follow a downstream default change silently.

## What deliberately does NOT change

`ClusterAccess.kubeconfigProviderConfigRef` stays `vault-kubeconfigs` — that is a **ClusterProviderConfig** emitted by the provider-kubeconfig-vault chart, not a Secret. A new test asserts the two names differ, so neither gets "harmonised" into the other.

## Verification

- `kcl test` — 37/37 pass, including the new `test_cluster_access_provider_config_is_not_the_secret_name`.
- The upload path itself was proven live before this change: an rke2 kubeconfig fetched from `/etc/rancher/rke2/rke2.yaml`, IP-rewritten to the node address, stored raw under `kubeconfigs/rke2-reference`, and `kubectl` against it returned the `Ready` node.

## Blast radius

Zero live `ClusterStack`s (kind1 retired 2026-08-11), and `spec.kubeconfig.vaultSecretName` still overrides.
