### PR TITLE
feat(xplane-cluster): make the one-phase teardown impossible, not lossy (0.4.2)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -367,7 +367,7 @@ platformChild = lambda name: str, ns: str, spec: {str:any}, apiEndpoint: str -> 
 # `kubectl delete` is swallowed and has to be issued twice.
 #
 # Usage orders DELETION ONLY, never creation: build order stays the ready gates.
-usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str -> {str:any} {
+usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str, replay: bool -> {str:any} {
     {
         apiVersion = "protection.crossplane.io/v1beta1"
         kind = "Usage"
@@ -376,7 +376,7 @@ usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str ->
             annotations = {"krm.kcl.dev/composition-resource-name" = label}
         }
         spec = {
-            replayDeletion = True
+            replayDeletion = replay
             of = {
                 apiVersion = "resources.stuttgart-things.com/v1alpha1" if ofKind in ["NativeProxmoxVM", "NativeVsphereVM"] else "config.stuttgart-things.com/v1alpha1"
                 kind = ofKind

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -204,15 +204,32 @@ test_platform_passthrough_and_derived_clusterName = lambda {
 # between an ordered teardown and Objects stuck on finalizers against a dead
 # API server.
 test_usage_protects_the_vm_from_the_platform = lambda {
-    _u = l.usage("NativeProxmoxVM", "c-vm", "Platform", "c-platform", "platform-uses-vm")
+    _u = l.usage("NativeProxmoxVM", "c-vm", "Platform", "c-platform", "platform-uses-vm", True)
     assert _u.spec.of.kind == "NativeProxmoxVM"
     assert _u.spec.by.kind == "Platform"
     assert _u.spec.replayDeletion
 }
 
 test_usage_resolves_the_group_per_kind = lambda {
-    assert l.usage("NativeVsphereVM", "a", "Platform", "b", "u").spec.of.apiVersion == "resources.stuttgart-things.com/v1alpha1"
-    assert l.usage("ClusterAccess", "a", "Platform", "b", "u").spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
+    assert l.usage("NativeVsphereVM", "a", "Platform", "b", "u", True).spec.of.apiVersion == "resources.stuttgart-things.com/v1alpha1"
+    assert l.usage("ClusterAccess", "a", "Platform", "b", "u", True).spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
+
+    # The teardown guard points at the COMPOSITE, which lives in the same group
+    # as ClusterAccess and Platform — so it needs no special case in the lambda.
+    assert l.usage("ClusterStack", "a", "Platform", "b", "u", False).spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
+}
+
+# The guard that makes a one-phase teardown impossible rather than silently
+# lossy. replayDeletion MUST stay false on it: replay re-issues a blocked delete
+# once the blocker is gone, which is convenient for a child and dangerous for
+# the whole stack — an abandoned `kubectl delete` would turn a later, unrelated
+# `platformEnabled: false` into a surprise teardown of the entire cluster.
+test_stack_guard_does_not_replay_deletion = lambda {
+    _g = l.usage("ClusterStack", "c", "Platform", "c-platform", "stack-uses-platform", False)
+    assert _g.spec.of.kind == "ClusterStack"
+    assert _g.spec.of.resourceRef.name == "c"
+    assert _g.spec.by.kind == "Platform"
+    assert not _g.spec.replayDeletion
 }
 
 # --- the kubeconfigs Vault -------------------------------------------------

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -131,12 +131,45 @@ _kcChild = _reemit(_kcRun, "kubeconfig") if (len(_kcObs) > 0 and _vmIP == "") el
 #     machine does.
 # The AnsibleRuns need no protection: they only create PipelineRuns on the
 # management cluster, and those disappearing blocks nobody.
+#
+# THOSE THREE CANNOT ORDER THE TEARDOWN OF THEIR OWN PARENT, and that is not a
+# bug in them. They are composed children of this XR, so deleting the
+# ClusterStack removes them in the SAME parallel sweep as the resources they
+# protect, and a Usage whose own object is gone blocks nothing. A live run tore
+# the tree down in about three seconds and stranded four resources — a wedged
+# flux-instance Object, a flux-operator Release that was never deleted at all,
+# and both ClusterProviderConfigs.
+#
+# The fourth entry below is what fixes that, and it escapes the sweep for one
+# reason: it protects the COMPOSITE ITSELF, so the webhook rejects the DELETE at
+# ADMISSION — before Crossplane starts deleting anything. Verified on
+# u26-rke2-1, 2026-08-12:
+#
+#   kubectl delete clusterstack u26-rke2-1 --dry-run=server
+#   Error: admission webhook "nousages.protection.crossplane.io" denied the
+#   request: This resource is in-use by 1 usage(s) ... by resource Platform/...
+#
+# It does not automate the two-phase teardown; it makes the one-phase teardown
+# IMPOSSIBLE instead of silently lossy. `platformEnabled: false` removes both
+# the Platform child and this guard, and the delete then goes through.
+#
+# GATED ON _platOpen, i.e. it exists exactly when the Platform child exists.
+# Emitting it unconditionally would make a ClusterStack undeletable, since the
+# only thing that clears it is the child going away.
+#
+# replayDeletion = FALSE here, unlike the three above, and deliberately. Replay
+# re-issues a blocked delete once the blocker is gone — convenient when the
+# protected thing is a child, dangerous when it is the whole stack: an abandoned
+# `kubectl delete` leaves a blocked-delete marker, and a later, unrelated
+# `platformEnabled: false` would then tear down the entire cluster by surprise.
+#
 # COMMAS ARE LOAD-BEARING: without them KCL parses `[a]` followed by a line
 # starting with `[` as a SUBSCRIPT, silently dropping entries instead of failing.
 _usageGroups = [
-    [l.usage(_vmKind, "{}-vm".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-vm")] if _platOpen else []
-    [l.usage("ClusterAccess", "{}-access".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-access")] if (_platOpen and _accessOpen) else []
-    [l.usage(_vmKind, "{}-vm".format(_name), "ClusterAccess", "{}-access".format(_name), "access-uses-vm")] if _accessOpen else []
+    [l.usage(_vmKind, "{}-vm".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-vm", True)] if _platOpen else []
+    [l.usage("ClusterAccess", "{}-access".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-access", True)] if (_platOpen and _accessOpen) else []
+    [l.usage(_vmKind, "{}-vm".format(_name), "ClusterAccess", "{}-access".format(_name), "access-uses-vm", True)] if _accessOpen else []
+    [l.usage("ClusterStack", _name, "Platform", "{}-platform".format(_name), "stack-uses-platform", False)] if _platOpen else []
 ]
 _usages = sum(_usageGroups, [])
 


### PR DESCRIPTION
## The problem

Deleting a `ClusterStack` that has a `Platform` child **in one step does not work**. A live run tore the tree down in ~3 seconds, the `ClusterAccess` went while the Platform's own Objects still needed its ClusterProviderConfigs, and four resources were stranded — a wedged `flux-instance` Object, a `flux-operator` Release that was never deleted at all, and both ClusterProviderConfigs.

The documented fix is a two-phase procedure that **nothing enforces**, so the failure is silent.

## Why the three existing Usages cannot fix it

Structural, not a bug in them: they are composed children of the same XR, so deleting the ClusterStack removes them in the *same parallel sweep* as the resources they protect. A Usage whose own object is gone blocks nothing.

## What does work

A fourth Usage that protects the **composite itself**. Crossplane's no-usages webhook is broader than it looks:

```
crossplane-no-usages / nousages.protection.crossplane.io
  rule: apiGroups[*] apiVersions[*] resources[*] operations[DELETE] scope[*]
  objectSelector: matchLabels{crossplane.io/in-use: "true"}
```

It fires on an XR just as well as on a managed resource — and it fires at **admission**, before Crossplane deletes anything. That is the whole trick.

Verified on the live `u26-rke2-1` before writing this:

```
$ kubectl delete clusterstack u26-rke2-1 --dry-run=server
Error: admission webhook "nousages.protection.crossplane.io" denied the request:
This resource is in-use by 1 usage(s), including the *v1beta1.Usage
"..." (in namespace "default") by resource Platform/u26-rke2-1-platform.
```

Deleting the Usage removed the `crossplane.io/in-use` label and the delete was accepted again, so the escape path works too. The stack stayed `Ready=True` throughout.

**This does not automate the two phases.** It converts the wrong order from silently lossy into a loud rejection that names the blocker.

## Two deliberate choices, both spelled out at the call site

**Gated on `_platOpen`** — it exists exactly when the Platform child exists. Emitting it unconditionally would make a `ClusterStack` undeletable, since only the child going away clears it.

**`replayDeletion: false`**, unlike the other three. Replay re-issues a blocked delete once the blocker is gone — convenient when the protected thing is a child, *dangerous* when it is the whole stack: an abandoned `kubectl delete` leaves a blocked-delete marker, and a later unrelated `platformEnabled: false` would then tear down the entire cluster by surprise.

`usage` grows an explicit `replay` parameter rather than defaulting it, so every call site states which semantics it wants.

## Tests

`kcl test` — 38/38, including `test_stack_guard_does_not_replay_deletion` and an added assertion that `ClusterStack` needs no special case in the apiVersion switch (it shares a group with ClusterAccess and Platform).

## Known footgun, documented

Namespace deletion. The namespace controller issues DELETE per object, hits the same webhook and leaves the namespace `Terminating`. True of Usages generally, worse here because the blocked object is the composite.
