### PR TITLE
feat(xplane-flux-catalog): openebs, the first storage entry (0.4.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/openebs.k
+++ b/crossplane/xplane-flux-catalog/apps/openebs.k
@@ -1,0 +1,53 @@
+import ..schema as s
+
+# openebs — https://github.com/stuttgart-things/flux/tree/main/infra/openebs
+#
+# The fleet's local-storage provisioner. Installed for exactly one thing: the
+# `openebs-hostpath` StorageClass. Every other engine the chart can ship — lvm,
+# zfs, mayastor, rawfile — is off in the artifact.
+#
+# NO REQUIRED SUBSTITUTIONS, which is unusual here and the reason this is a good
+# first storage entry: every variable in the artifact carries a manifest default,
+# so `apps: {openebs: {enabled: true}}` is a complete spec. Contrast headlamp,
+# which needs DOMAIN/HOSTNAME/GATEWAY_NAME and a Gateway that already exists.
+#
+# NO dependsOn. It installs before anything and depends on nothing — which is
+# also why it is worth having early: several catalogued-adjacent apps (vault,
+# prometheus, harbor, keycloak) default their PVCs to a StorageClass that has to
+# come from somewhere.
+#
+# VERSION IS THE FLUX ARTIFACT TAG, NOT THE CHART VERSION. v1.19.1 is the first
+# release carrying flux#192; the openebs chart it installs is pinned separately
+# inside the artifact (OPENEBS_VERSION, default 4.2.0).
+#
+# THAT DISTINCTION IS LOAD-BEARING HERE. `OPENEBS_VERSION` is substitutable from
+# the XR, and the chart changes shape between 4.2 and 4.5:
+#
+#   loki   6.29.0  condition loki.enabled   — added in 4.5, DEFAULT TRUE
+#   alloy  1.0.1   condition alloy.enabled  — added in 4.5, DEFAULT TRUE
+#   localpv-provisioner  became conditional on engines.local.hostpath.enabled
+#
+# Before flux#192 the artifact had no keys for any of those, so raising
+# OPENEBS_VERSION would have silently deployed a Loki StatefulSet, the MinIO
+# StatefulSet backing it (MinIO is Loki's object store, a sub-dependency with no
+# toggle of its own), an Alloy DaemonSet and two extra StorageClasses — and on a
+# small cluster Loki cannot even schedule, wanting three replicas with pod
+# anti-affinity. Pinning v1.19.1 or later is what makes an OPENEBS_VERSION bump
+# safe rather than a surprise.
+openebs: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/infra/openebs"
+    defaultVersion = "v1.19.1"
+    components = [
+        s.Component {
+            name = "install"
+            # Single-Kustomization artifact: requirements.yaml (Namespace +
+            # HelmRepository) and release.yaml sit at the root, so there is
+            # nothing under ./components to address.
+            path = "./"
+            wrapsHelmRelease = True
+            # The chart pulls five subcharts and runs a pre-upgrade hook; 10m is
+            # not enough on a cold node.
+            timeout = "15m"
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -78,3 +78,28 @@ test_optional_components_are_marked = lambda {
     assert not cm["install"].optional, "the base install is not optional"
     assert cm["selfsigned"].optional
 }
+
+# openebs — the first entry with no required substitutions at all, which is the
+# whole reason it went in first: `apps: {openebs: {enabled: true}}` is a
+# complete spec. Asserted so nobody "helpfully" adds a required var and turns a
+# one-line enable into a broken deploy.
+test_openebs_needs_no_substitutions = lambda {
+    _a = c.get("openebs")
+    assert len(_a.components) == 1
+    assert _a.components[0].requiredSubstitutions == []
+    assert _a.components[0].dependsOn == []
+    assert _a.components[0].path == "./"
+    assert _a.components[0].wrapsHelmRelease
+}
+
+# The catalog version is the FLUX ARTIFACT tag, never the openebs chart version
+# (which the artifact pins separately as OPENEBS_VERSION, default 4.2.0). v1.19.1
+# is the floor because it is the first release that carries flux#192 — before
+# it, the artifact had no loki/alloy keys, so raising OPENEBS_VERSION to 4.5.x
+# would have silently deployed Loki, MinIO and Alloy with no way to say no.
+test_openebs_pins_a_release_that_can_say_no_to_loki = lambda {
+    _v = c.get("openebs").defaultVersion
+    assert _v.startswith("v")
+    assert _v != "v4.2.0"
+    assert _v == "v1.19.1"
+}

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.3.0"
+version = "0.4.0"

--- a/crossplane/xplane-flux-catalog/main.k
+++ b/crossplane/xplane-flux-catalog/main.k
@@ -6,6 +6,7 @@
 import .apps.cert_manager as cert_manager
 import .apps.dapr as dapr
 import .apps.headlamp as headlamp
+import .apps.openebs as openebs
 import .apps.trust_manager as trust_manager
 import schema as s
 
@@ -13,6 +14,7 @@ catalog: {str:s.App} = {
     "cert-manager" = cert_manager.certManager
     dapr = dapr.dapr
     headlamp = headlamp.headlamp
+    openebs = openebs.openebs
     "trust-manager" = trust_manager.trustManager
 }
 


### PR DESCRIPTION
The catalog holds **4 apps against 40 published flux artifacts**, and none of them provide storage.

`openebs` is the cheapest useful addition:

- **zero required substitutions** — `apps: {openebs: {enabled: true}}` is a complete spec. Contrast `headlamp`, which needs `DOMAIN`/`HOSTNAME`/`GATEWAY_NAME` *and* a Gateway that already exists.
- no cross-artifact `dependsOn`
- single Kustomization at the artifact root

It is also what several catalogued-adjacent apps quietly assume: vault, prometheus, harbor and keycloak all default their PVCs to a StorageClass that has to come from somewhere.

## The version field is the flux artifact tag, not the chart version

Here that distinction is load-bearing rather than pedantic. The artifact pins the openebs **chart** separately as `OPENEBS_VERSION` (default `4.2.0`), and the chart changes shape between 4.2 and 4.5:

| | 4.2.0 | 4.5.1 |
|---|---|---|
| `loki` | not a dependency | `6.29.0`, `condition: loki.enabled`, **default true** |
| `alloy` | not a dependency | `1.0.1`, `condition: alloy.enabled`, **default true** |
| `localpv-provisioner` | unconditional | `condition: engines.local.hostpath.enabled` |

Before [flux#192](https://github.com/stuttgart-things/flux/pull/192) the artifact carried **no keys** for any of those. Raising `OPENEBS_VERSION` from an XR would have silently deployed a Loki StatefulSet, the MinIO StatefulSet backing it (MinIO is Loki's object store — a sub-dependency with no toggle of its own), an Alloy DaemonSet and two extra StorageClasses. On a small cluster Loki cannot even schedule: three replicas with pod anti-affinity.

`v1.19.1` is the first release that can say no. That is why it is the pinned floor, and why `test_openebs_pins_a_release_that_can_say_no_to_loki` asserts it rather than leaving it to a comment.

## Tests

`kcl test` — 11/11, including an assertion that openebs keeps **zero** required substitutions, so nobody turns a one-line enable into a broken deploy by adding one.

## Follow-up

`xplane-platform` pins the catalog at `0.2.1` and will need a bump to see this entry.
