### PR TITLE
feat(xplane-platform): catalog 0.4.0, so openebs reaches a Platform (0.6.1)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.2.1" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.2.1"
-    version = "0.2.1"
-    sum = "SqTtGS1jVbiTiFxRVMuYfo5Tct5n9/MMwXDRol0gnTw="
+    full_name = "xplane-flux-catalog_0.4.0"
+    version = "0.4.0"
+    sum = "wvUbz0bKPg8fFGd/onZ0T/YcBvka3SINQu8nfCmTXNA="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.2.1"
+    oci_tag = "0.4.0"

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -290,3 +290,22 @@ test_vault_issuer_still_opt_in = lambda {
         vaultIssuer = {enabled = True}
     }) == True
 }
+
+# openebs reaches the platform, and reaches it with an EMPTY spec. The catalog
+# entry has no required substitutions and no dependsOn, so `apps.openebs.enabled`
+# alone must render both halves — the flux-init source and the flux-apps
+# Kustomization — with nothing else supplied. Asserted here rather than only in
+# the catalog, because the app -> (source, kustomization) fan-out is this
+# module's job and a missing source is invisible until Flux reports
+# ArtifactFailed on the target cluster.
+test_openebs_renders_from_a_bare_enable = lambda {
+    _spec = {clusterName = "c", apps = {
+        openebs = {enabled = True}
+    }}
+    _srcs = l.appSources(_spec)
+    _named = [s for s in _srcs if s.name == "openebs"]
+    assert len(_named) == 1
+    assert _named[0].url == "oci://ghcr.io/stuttgart-things/flux/infra/openebs"
+    # The floor that can say no to Loki/MinIO/Alloy — see the catalog entry.
+    assert _named[0].ref == "v1.19.1"
+}


### PR DESCRIPTION
Picks up [#104](https://github.com/stuttgart-things/kcl/pull/104).

The pin was **0.2.1** while the catalog had already moved to 0.3.0 — so the `approle-issuer` component added there was invisible to a `Platform`, and openebs would have been too. This bump takes both.

## A test at this level, not only in the catalog

`test_openebs_renders_from_a_bare_enable` asserts that `apps.openebs.enabled` **alone** produces both halves — the flux-init `OCIRepository` and the flux-apps `Kustomization` — with nothing else supplied.

It belongs here because the app → (source, kustomization) fan-out is this module's job, and a missing source is invisible until Flux reports `ArtifactFailed` on the **target** cluster, one indirection away from anything `crossplane render` can see.

The assertion pins `v1.19.1` as a literal rather than reading it back from the catalog — a test that reads the value it is checking would pass no matter what the catalog said. That tag is the floor at which the artifact can say no to Loki, MinIO and Alloy ([flux#192](https://github.com/stuttgart-things/flux/pull/192)).

`kcl test` — 29/29.