### PR TITLE
fix(xplane-flux-apps): always emit postBuild (0.2.0)

### DIFF
--- a/crossplane/xplane-flux-apps/kcl.mod
+++ b/crossplane/xplane-flux-apps/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-apps"
 edition = "v0.11.2"
-version = "0.1.0"
+version = "0.2.0"

--- a/crossplane/xplane-flux-apps/main.k
+++ b/crossplane/xplane-flux-apps/main.k
@@ -69,8 +69,27 @@ _appObject = lambda app: {str:} -> {str:} {
     }
     _sub = app?.substitute or {}
     _subFrom = app?.substituteFrom or []
+    # ALWAYS EMITTED, even when the XR supplies nothing. This used to be
+    # conditional, and the conditional form is a trap: kustomize-controller runs
+    # its variable-substitution pass only when spec.postBuild is non-nil, so an
+    # app with no substitute block got NO substitution at all — and every
+    # `${VAR:-default}` fallback in its manifests silently stopped being a
+    # fallback. What reaches the cluster is the literal string:
+    #
+    #   Namespace/${OPENEBS_NAMESPACE:-openebs} dry-run failed (Invalid):
+    #   metadata.name: Invalid value: "${OPENEBS_NAMESPACE:-openebs}"
+    #
+    # Found on u26-rke2-1 (2026-08-12) enabling openebs, whose catalog entry
+    # declares zero required substitutions precisely because every variable has
+    # a manifest default. "No REQUIRED substitutions" and "needs no substitute
+    # block" are different claims, and the conditional made the second one false
+    # for every app in the catalog.
+    #
+    # An empty substitute map is enough: PostBuild != nil is the whole condition
+    # upstream. substituteFrom stays conditional because an empty list is
+    # meaningful there — it would be a source list with no sources.
     _postBuild = {
-        **({substitute = _sub} if _sub else {})
+        substitute = _sub
         **({substituteFrom = _subFrom} if _subFrom else {})
     }
     _appCommon = app?.commonMetadata or _commonMeta
@@ -115,7 +134,8 @@ _appObject = lambda app: {str:} -> {str:} {
                         **({patches = app.patches} if app?.patches else {})
                         **({images = app.images} if app?.images else {})
                         **({decryption = app.decryption} if app?.decryption else {})
-                        **({postBuild = _postBuild} if _postBuild else {})
+                        # Unconditional, deliberately — see _postBuild above.
+                        postBuild = _postBuild
                     }
                 }
             }

--- a/crossplane/xplane-flux-apps/main.k
+++ b/crossplane/xplane-flux-apps/main.k
@@ -69,6 +69,7 @@ _appObject = lambda app: {str:} -> {str:} {
     }
     _sub = app?.substitute or {}
     _subFrom = app?.substituteFrom or []
+
     # ALWAYS EMITTED, even when the XR supplies nothing. This used to be
     # conditional, and the conditional form is a trap: kustomize-controller runs
     # its variable-substitution pass only when spec.postBuild is non-nil, so an

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -79,11 +79,21 @@ test_optional_components_are_marked = lambda {
     assert cm["selfsigned"].optional
 }
 
-# openebs — the first entry with no required substitutions at all, which is the
-# whole reason it went in first: `apps: {openebs: {enabled: true}}` is a
-# complete spec. Asserted so nobody "helpfully" adds a required var and turns a
-# one-line enable into a broken deploy.
-test_openebs_needs_no_substitutions = lambda {
+# openebs declares no REQUIRED substitutions — every variable in its manifests
+# carries a `${VAR:-default}` fallback.
+#
+# THAT IS A STATEMENT ABOUT THE CATALOG, NOT ABOUT USAGE, and the distinction
+# cost a live debug on u26-rke2-1 (2026-08-12). An XR still has to supply a
+# `substitute` block: xplane-flux-apps used to emit `postBuild` only when one
+# was present, and kustomize-controller runs its substitution pass only when
+# spec.postBuild is non-nil — so a bare enable meant NO substitution at all and
+# the fallbacks never applied. `${OPENEBS_NAMESPACE:-openebs}` reached the
+# cluster as a literal string and failed namespace validation.
+#
+# Fixed in xplane-flux-apps 0.2.0, which always emits postBuild. The test name
+# stays about the catalog on purpose — it was previously called
+# `test_openebs_needs_no_substitutions`, which read as a promise about usage.
+test_openebs_declares_no_required_substitutions = lambda {
     _a = c.get("openebs")
     assert len(_a.components) == 1
     assert _a.components[0].requiredSubstitutions == []

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.4.0"
+version = "0.4.1"


### PR DESCRIPTION
## The bug

`kustomize-controller` runs its variable-substitution pass **only when `spec.postBuild` is non-nil**. This module emitted `postBuild` only when the XR supplied `substitute` or `substituteFrom` — so an app with neither got *no substitution at all*, and every `\${VAR:-default}` fallback in its manifests silently stopped being a fallback.

The literal string reached the cluster:

```
Namespace/\${OPENEBS_NAMESPACE:-openebs} dry-run failed (Invalid):
metadata.name: Invalid value: "\${OPENEBS_NAMESPACE:-openebs}"
```

Found on `u26-rke2-1` enabling openebs — whose catalog entry declares **zero required substitutions precisely because every variable has a manifest default**. That is the trap: the app most likely to be enabled bare is the one guaranteed to break.

## The fix

An empty substitute map is enough — `PostBuild != nil` is the whole condition upstream. Verified by rendering an app with no substitute at all:

```yaml
          wait: true
          postBuild:
            substitute: {}
```

`substituteFrom` stays conditional, where an empty list really would mean a source list with no sources.

## Also: a test that made the wrong promise

`test_openebs_needs_no_substitutions` reads as a claim about **usage**. It is a claim about the **catalog**. Renamed to `test_openebs_declares_no_required_substitutions`, with the distinction and what it cost written next to it. Catalog → 0.4.1.

`kcl test` — 11/11 on the catalog.

## Follow-up

The `flux-apps` Configuration pins this module and needs a bump + `task push` before the fix reaches a cluster. Until then, XRs must keep supplying a `substitute` block — which the live `u26-rke2-1` XR now does explicitly ([stuttgart-things#2495](https://github.com/stuttgart-things/stuttgart-things/pull/2495)).