### PR TITLE
feat(xplane-flux-catalog): add cilium as a config-only app (0.5.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/README.md
+++ b/crossplane/xplane-flux-catalog/README.md
@@ -52,6 +52,19 @@ A consumer must **reject** a reference whose target app or component is not
 enabled — `xplane-platform` does, naming what to add. Flux would otherwise leave
 the Kustomization in `DependencyNotReady` indefinitely.
 
+## Config-only apps
+
+Not every entry installs something. `cilium` reconciles only the artifact's
+`components/lb` + `components/gateway`; the `components/install` that sits
+beside them is **not** part of the root, because every target cluster already
+runs Cilium as its CNI and a second install would put two CNIs on one datapath.
+Its component is therefore named `config`, not `install` — a cluster that needs
+Cilium *installed* is served by the `bootstrap/cilium` Configuration instead.
+
+Its real prerequisite is a **cluster fact rather than a `dependsOn`**: Cilium
+must already run with Gateway API and L2 announcements enabled. The catalog has
+no way to express that, so it stays a comment in `apps/cilium.k`.
+
 ## Optional components
 
 `Component.optional = True` marks an opt-in extra that is **not** deployed unless
@@ -79,6 +92,7 @@ An app is **not** necessarily one Kustomization: dapr ships `control-plane` and
 | `test_dependson_targets_exist` | a typo'd `dependsOn` — otherwise found only as a Kustomization stuck in `DependencyNotReady` on a live cluster |
 | `test_component_names_unique` | duplicates colliding on the emitted `{app}-{component}` name |
 | `test_helmrelease_components_raise_timeout` | a chart-installing component left on the 10m FluxApps default, which is demonstrably too short |
+| `test_cilium_is_config_only` | an `install` component appearing on cilium — i.e. someone wiring a second CNI into the platform |
 
 Each was verified to fail on the mistake it describes, not merely to pass.
 

--- a/crossplane/xplane-flux-catalog/apps/cilium.k
+++ b/crossplane/xplane-flux-catalog/apps/cilium.k
@@ -1,0 +1,50 @@
+import ..schema as s
+
+# cilium — https://github.com/stuttgart-things/flux/tree/main/infra/cilium
+#
+# CONFIGURATION ONLY. This entry does NOT install Cilium: the artifact's root
+# kustomization pulls exactly `components/lb` and `components/gateway`, and the
+# component is named `config` for that reason. `components/install` sits beside
+# them and is deliberately NOT part of the root — on a cluster whose CNI is
+# already Cilium (every rke2 built by the cluster Configuration) a second
+# install would put two CNIs on one datapath.
+#
+# There is consequently no `install` component here to depend on, and none
+# should be added: a cluster that needs Cilium INSTALLED is served by the
+# bootstrap/cilium Configuration instead.
+#
+# Both pieces are kustomize `kind: Component`, not standalone Kustomizations,
+# so they cannot be split into two Flux Kustomizations — lb and gateway arrive
+# together or not at all. Worth knowing because the gateway's TLS listener
+# needs a certificate that a fresh cluster does not have yet: the HTTP listener
+# works immediately, HTTPS stays certificate-less until something issues into
+# CILIUM_GATEWAY_TLS_SECRET.
+#
+# Prerequisite is a cluster fact rather than a catalog dependency: Cilium must
+# already run WITH Gateway API and L2 announcements enabled
+# (`enable-gateway-api=true`, `enable-l2-announcements=true`, the
+# `ciliumloadbalancerippools` CRD registered). The rke2 role brings that; a
+# cluster without it gets Kustomizations that apply CRs whose CRDs do not
+# exist.
+cilium: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/infra/cilium"
+    defaultVersion = "v1.18.1"
+    components = [
+        s.Component {
+            name = "config"
+            path = "./"
+            # All four are used without a `:=` default, so Flux would silently
+            # substitute an empty string: an IP pool with blank bounds and a
+            # Gateway with a blank hostname both apply cleanly and do nothing
+            # useful. START/STOP and DOMAIN come from a clusterbook reservation
+            # (the ip-reservation Configuration publishes both on its XR
+            # status); TLS_SECRET from whatever issues the wildcard cert.
+            requiredSubstitutions = [
+                "CILIUM_LB_IP_START"
+                "CILIUM_LB_IP_STOP"
+                "CILIUM_GATEWAY_DOMAIN"
+                "CILIUM_GATEWAY_TLS_SECRET"
+            ]
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -113,3 +113,41 @@ test_openebs_pins_a_release_that_can_say_no_to_loki = lambda {
     assert _v != "v4.2.0"
     assert _v == "v1.19.1"
 }
+
+test_cilium_is_registered = lambda {
+    _c = c.get("cilium")
+    assert _c.artifact == "oci://ghcr.io/stuttgart-things/flux/infra/cilium"
+    assert len(_c.components) == 1
+    assert _c.components[0].path == "./", "the artifact root is lb + gateway"
+}
+
+# The four variables the lb and gateway manifests use WITHOUT a `:=` default.
+# Flux substitutes an empty string for a missing one, and both offenders apply
+# cleanly: an IP pool with blank bounds and a Gateway with a blank hostname are
+# valid objects that do nothing. Declared so a consumer can reject the app
+# before it deploys something that merely looks healthy.
+test_cilium_declares_required_substitutions = lambda {
+    assert c.get("cilium").components[0].requiredSubstitutions == [
+        "CILIUM_LB_IP_START"
+        "CILIUM_LB_IP_STOP"
+        "CILIUM_GATEWAY_DOMAIN"
+        "CILIUM_GATEWAY_TLS_SECRET"
+    ]
+}
+
+# cilium is CONFIG-ONLY and must stay that way. The artifact ships a
+# `components/install` beside lb and gateway which the root does not reference,
+# because every target cluster already runs Cilium as its CNI — a second
+# install would be two CNIs on one datapath. An `install` component appearing
+# here would mean someone wired that path into the platform.
+#
+# It also has no dependsOn: its real prerequisite (Cilium running with Gateway
+# API and L2 announcements enabled) is a cluster fact the rke2 role provides,
+# not another catalog app.
+test_cilium_is_config_only = lambda {
+    _c = c.get("cilium")
+    assert "install" not in [x.name for x in _c.components], "cilium must not install a second CNI"
+    assert _c.components[0].name == "config"
+    assert _c.components[0].dependsOn == []
+    assert not _c.components[0].wrapsHelmRelease
+}

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.4.1"
+version = "0.5.0"

--- a/crossplane/xplane-flux-catalog/main.k
+++ b/crossplane/xplane-flux-catalog/main.k
@@ -4,6 +4,7 @@
 # apps/<name>.k, then one import and one entry here. Keeping it manual is the
 # point — adding an app to the platform is a reviewable two-line diff.
 import .apps.cert_manager as cert_manager
+import .apps.cilium as cilium
 import .apps.dapr as dapr
 import .apps.headlamp as headlamp
 import .apps.openebs as openebs
@@ -12,6 +13,7 @@ import schema as s
 
 catalog: {str:s.App} = {
     "cert-manager" = cert_manager.certManager
+    cilium = cilium.cilium
     dapr = dapr.dapr
     headlamp = headlamp.headlamp
     openebs = openebs.openebs


### PR DESCRIPTION
Entsperrt Schritt 4 des Gateway-Pfads (stuttgart-things/crossplane-configurations#248). Auf einem rke2-Cluster, dessen CNI bereits Gateway API mitbringt, fehlen nur noch ein `CiliumLoadBalancerIPPool` und ein `Gateway` — genau das, was der Root des Artefakts `flux/infra/cilium` liefert.

## Config-only, und das ist tragend

Die Komponente heißt **`config`, nicht `install`**. Das Artefakt liefert neben `components/lb` und `components/gateway` auch ein `components/install`, das der Root **nicht** referenziert: jeder Zielcluster fährt Cilium schon als CNI, ein zweites Install wären zwei CNIs auf einem Datapath. Ein Cluster, der Cilium *installiert* bekommen soll, wird von der `bootstrap/cilium`-Configuration bedient.

`test_cilium_is_config_only` hält das fest — taucht hier je eine `install`-Komponente auf, hat jemand diesen Pfad in die Platform verdrahtet.

## Warum ein Eintrag und nicht zwei

`lb` und `gateway` sind kustomize `kind: Component`, keine eigenständigen Kustomizations. Sie lassen sich also nicht in zwei Flux-Kustomizations aufteilen — sie kommen zusammen oder gar nicht.

Das ist relevant, weil der TLS-Listener des Gateways ein Zertifikat braucht, das ein frischer Cluster noch nicht hat: **HTTP funktioniert sofort, HTTPS bleibt ohne gültiges Zertifikat**, bis etwas in `CILIUM_GATEWAY_TLS_SECRET` ausstellt.

## Substitutionen — geprüft, nicht angenommen

Alle vier sind als required deklariert. Gegen das Artefakt verifiziert: keine von `CILIUM_LB_IP_START`, `CILIUM_LB_IP_STOP`, `CILIUM_GATEWAY_DOMAIN`, `CILIUM_GATEWAY_TLS_SECRET` trägt einen `:=`-Default.

Das ist hier besonders heikel, weil beide Betroffenen bei leerem String **sauber applyen**: ein IP-Pool mit leeren Grenzen und ein Gateway mit leerem Hostname sind gültige Objekte, die nichts tun. Ein Consumer kann die App so ablehnen, bevor etwas deployt wird, das bloß gesund aussieht.

## Kein `dependsOn`

Die echte Voraussetzung ist ein **Cluster-Fakt**, keine Katalog-Abhängigkeit: Cilium muss bereits mit `enable-gateway-api=true` und `enable-l2-announcements=true` laufen. Die rke2-Rolle bringt das mit; der Katalog kann es nicht ausdrücken, also steht es als Kommentar in `apps/cilium.k` und im README-Abschnitt „Config-only apps".

## Tests

14/14 grün, drei davon neu (`test_cilium_is_registered`, `test_cilium_declares_required_substitutions`, `test_cilium_is_config_only`).

## Nachgelagert

Damit der Eintrag auf einem Cluster ankommt, sind noch zwei Hops nötig: `xplane-platform` pinnt den Katalog derzeit auf `0.4.0` (lokal stand schon `0.4.1`), und die `platform`-Configuration pinnt `xplane-platform`. Beide Bumps kommen nach dem Publish dieses Moduls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL