### PR TITLE
feat(xplane-platform): catalog 0.5.0, so cilium reaches a Platform (0.6.2)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.6.1"
+version = "0.6.2"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.4.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.5.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.4.0"
-    version = "0.4.0"
-    sum = "wvUbz0bKPg8fFGd/onZ0T/YcBvka3SINQu8nfCmTXNA="
+    full_name = "xplane-flux-catalog_0.5.0"
+    version = "0.5.0"
+    sum = "lbjY6t5LFoW1N7rxkcld/RhtAhHvuXavSySqh0shKIg="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.4.0"
+    oci_tag = "0.5.0"

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -309,3 +309,40 @@ test_openebs_renders_from_a_bare_enable = lambda {
     # The floor that can say no to Loki/MinIO/Alloy — see the catalog entry.
     assert _named[0].ref == "v1.19.1"
 }
+
+# The catalog's cilium entry, reached through spec.apps — NOT spec.cilium.
+#
+# The two are different paths to Cilium and only this one is used by the
+# Gateway work (crossplane-configurations#248): spec.cilium composes a Cilium
+# XR from the bootstrap/cilium Configuration, which was never published;
+# apps.cilium reconciles the flux/infra/cilium artifact's lb + gateway. Naming
+# them apart here so the next reader does not assume one test covers both.
+test_apps_cilium_renders_from_the_catalog = lambda {
+    _spec = {clusterName = "c", apps = {
+        cilium = {enabled = True, substitute = {
+            CILIUM_LB_IP_START = "10.31.102.5"
+            CILIUM_LB_IP_STOP = "10.31.102.5"
+            CILIUM_GATEWAY_DOMAIN = "u26-rke2-1.sthings-vsphere.labul.sva.de"
+            CILIUM_GATEWAY_TLS_SECRET = "gateway-tls"
+        }}
+    }}
+    _named = [s for s in l.appSources(_spec) if s.name == "cilium"]
+    assert len(_named) == 1
+    assert _named[0].url == "oci://ghcr.io/stuttgart-things/flux/infra/cilium"
+    assert _named[0].ref == "v1.18.1"
+    assert len(l.missingSubstitutions(_spec)) == 0
+}
+
+# A bare enable must be REJECTED, unlike openebs above. All four of cilium's
+# variables lack a manifest default, and Flux substitutes an empty string
+# instead of failing — an IP pool with blank bounds and a Gateway with a blank
+# hostname both apply cleanly and do nothing, so the cluster would look healthy.
+test_apps_cilium_bare_enable_is_rejected = lambda {
+    _m = l.missingSubstitutions({
+        apps = {
+            cilium = {enabled = True}
+        }
+    })
+    assert len(_m) == 4, "all four cilium vars are required"
+    assert "cilium-config: CILIUM_GATEWAY_DOMAIN" in _m
+}


### PR DESCRIPTION
Zweiter Hop der Kette für Schritt 4 des Gateway-Pfads (stuttgart-things/crossplane-configurations#248). Nimmt den config-only-Eintrag aus #107 auf — damit wird `spec.apps.cilium` überhaupt auflösbar.

Funktional ist der Katalog-Pin der ganze Diff; an der Logik ändert sich nichts.

## Zwei Tests, bewusst benannt

`spec.apps.cilium` und `spec.cilium` sind **verschiedene Wege zu Cilium**, und nur der erste wird hier benutzt:

| | |
|---|---|
| `spec.cilium` | komponiert ein `Cilium`-XR aus der `bootstrap/cilium`-Configuration — **nie publiziert** |
| `spec.apps.cilium` | reconciled das Flux-Artefakt (`lb` + `gateway`) |

`test_cilium_and_ipreservation_are_opt_in` deckt bereits den ersten ab, deshalb tragen die neuen ein `apps_`-Präfix statt als zweite Meinung zum selben Thema zu lesen.

## Der Ablehnungs-Test ist der wichtigere

Anders als bei openebs muss ein bloßes `enabled: true` bei cilium **fehlschlagen**. Alle vier Variablen haben keinen Manifest-Default, und Flux ersetzt eine fehlende durch einen **leeren String** statt zu scheitern — ein IP-Pool mit leeren Grenzen und ein Gateway mit leerem Hostname applyen beide sauber und tun nichts.

Ohne die Prüfung meldet der Cluster `Ready` und serviert nichts. Genau die Sorte Fehler, die man erst beim Debuggen eines nicht erreichbaren Service findet.

## Zur Version

Katalog 0.4.0 → 0.5.0 überspringt 0.4.1: dort wurde nur `catalog_test.k` geändert, funktional identisch zu 0.4.0.

31/31 Tests grün.

## Nächster Hop

`bootstrap/platform/apis/composition.yaml` pinnt `xplane-platform:0.6.1` → nach dem Publish auf `0.6.2`, dann die `platform`-Configuration als v0.3.4 pushen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL