### PR TITLE
feat(kcl): publish the cluster domain (platform 0.7.0, cluster 0.5.0)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -390,3 +390,20 @@ usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str, r
         }
     }
 }
+
+platformDomain = lambda plat: {str:} -> str {
+    """The cluster's DNS domain, read off an observed Platform child.
+
+    Discovered two levels down: the ipReservation child asks clusterbook, which
+    returns a `*.` wildcard when createDNS is set; platform reduces it to the
+    usable name and republishes it as components.ipReservation.domain. This only
+    lifts it into the stack's own share, for the same reason apiEndpoint is
+    lifted — state it once where it is discovered, read it everywhere else.
+
+    Returns "" when ipReservation is off, has no DNS, or the Platform has not
+    reported yet. Callers omit the field rather than publishing an empty string:
+    a blank domain substituted into a Gateway hostname or a certificate is worse
+    than an absent one, because it renders as a valid-looking empty value.
+    """
+    ((plat?.status?.components or {})?.ipReservation or {})?.domain or ""
+}

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -410,3 +410,36 @@ test_no_endpoint_means_no_injection = lambda {
     _r = l.platformChild("c", "ns", _spec, "")
     assert "kubernetesHost" not in _r.spec.vaultIssuer
 }
+
+test_platform_domain_is_lifted = lambda {
+    _plat = {
+        status = {
+            components = {
+                ipReservation = {domain = "u26-rke2-1.sthings-vsphere.labul.sva.de"}
+            }
+        }
+    }
+    assert l.platformDomain(_plat) == "u26-rke2-1.sthings-vsphere.labul.sva.de"
+}
+
+# Every shape that means "no domain yet" must yield "", so the caller can omit
+# the field. A blank domain substituted into a Gateway hostname or a certificate
+# renders as a valid-looking empty value — worse than an absent one.
+test_platform_domain_absent_is_empty = lambda {
+    assert l.platformDomain({}) == ""
+    assert l.platformDomain({
+        status = {}
+    }) == ""
+    assert l.platformDomain({
+        status = {
+            components = {}
+        }
+    }) == ""
+    assert l.platformDomain({
+        status = {
+            components = {
+                ipReservation = {enabled = False}
+            }
+        }
+    }) == ""
+}

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -87,6 +87,14 @@ _platObs = _byKind("Platform")
 _plat = _platObs[0] if _platObs else {}
 _platReady = len([c for c in (_plat?.status?.conditions or []) if c?.type == "Ready" and c?.status == "True"]) > 0
 
+# The cluster's DNS domain, discovered by the ipReservation child two levels
+# down and republished by platform as components.ipReservation.domain (already
+# reduced from clusterbook's `*.` wildcard). Lifted here for the same reason
+# apiEndpoint is: state it once where it is discovered, read it everywhere else.
+# Empty whenever ipReservation is off or has no DNS — the field is then omitted
+# from share rather than published blank.
+_platDomain = l.platformDomain(_plat)
+
 # --- gates -----------------------------------------------------------------
 _distOpen = (_vmReady and _vmIP != "" and _baseosOk) or len(_distObs) > 0
 _kcOpen = (_distOk and _vmIP != "") or len(_kcObs) > 0
@@ -194,6 +202,8 @@ _dxrPatched = _dxr | {
                 clusterType = _accessShare.clusterType
             if _accessShare?.serverVersion:
                 serverVersion = _accessShare.serverVersion
+            if _platDomain:
+                domain = _platDomain
         }
         stages = {
             vm = {ready = _vmReady, ip = _vmIP}

--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.6.2"
+version = "0.7.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.5.0" }

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -78,6 +78,24 @@ ipReservationEnabled = lambda spec: {str:} -> bool {
     (spec?.ipReservation or {})?.enabled or False
 }
 
+clusterDomain = lambda fqdn: str -> str {
+    """The reservation's wildcard FQDN reduced to the name a consumer can use.
+
+    clusterbook publishes `*.u26-rke2-1.sthings-vsphere.labul.sva.de` when
+    createDNS is set — a wildcard record, so the leading `*.` is part of the DNS
+    name, not of the domain. Everything downstream wants the remainder:
+    CILIUM_GATEWAY_DOMAIN, a Gateway listener hostname, a certificate's common
+    name. Stripping it once here is the point of publishing the value at all —
+    the alternative is every consumer doing the same string surgery, which is
+    the repetition this status field exists to remove.
+
+    Anything that is not a wildcard is passed through untouched: an explicit
+    `spec.ip` reservation carries no DNS name, and a future non-wildcard record
+    would already be the usable form.
+    """
+    fqdn[2::] if fqdn.startswith("*.") else fqdn
+}
+
 vaultIssuerEnabled = lambda spec: {str:} -> bool {
     """Opt-IN. Provisions the TOKENLESS cert-manager -> Vault-PKI path: a Vault
     Kubernetes-auth mount (VaultK8sAuth), the CA bundle on the target

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -346,3 +346,18 @@ test_apps_cilium_bare_enable_is_rejected = lambda {
     assert len(_m) == 4, "all four cilium vars are required"
     assert "cilium-config: CILIUM_GATEWAY_DOMAIN" in _m
 }
+
+# The wildcard the clusterbook reservation publishes is not the domain — the
+# leading `*.` belongs to the DNS record. Stripping it once here is what keeps
+# every consumer from doing the same string surgery.
+test_cluster_domain_strips_the_wildcard = lambda {
+    assert l.clusterDomain("*.u26-rke2-1.sthings-vsphere.labul.sva.de") == "u26-rke2-1.sthings-vsphere.labul.sva.de"
+}
+
+# Not every reservation carries a wildcard: `spec.ip` skips DNS entirely, and a
+# non-wildcard record would already be usable. Both must pass through untouched
+# rather than losing their first two characters.
+test_cluster_domain_passes_through_non_wildcards = lambda {
+    assert l.clusterDomain("") == ""
+    assert l.clusterDomain("gw.example.com") == "gw.example.com"
+}

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -479,6 +479,13 @@ _xrStatus = _oxr | {
                 ready = _ipResReady
                 ipAddresses = _ipResStatus?.ipAddresses or []
                 networkKey = _ipResStatus?.networkKey or ""
+                # fqdn/zone verbatim from the child; domain is the wildcard
+                # reduced to the usable name (see l.clusterDomain). Kept side by
+                # side so a wrong domain can be traced to what clusterbook
+                # actually returned rather than guessed at.
+                fqdn = _ipResStatus?.fqdn or ""
+                zone = _ipResStatus?.zone or ""
+                domain = l.clusterDomain(_ipResStatus?.fqdn or "")
             }
             cilium = {
                 enabled = _ciliumEnabled


### PR DESCRIPTION
Schließt den Abschnitt „Cluster-Domain in den Status des Umbrella-XR" aus stuttgart-things/crossplane-configurations#248.

Die Domain war **auffindbar, aber nicht lesbar**: ein `XIPReservation` publiziert `fqdn` und `zone`, und niemand hob sie an. Ein Gateway-Hostname musste deshalb am XR wiederholt werden — direkt neben der IP, aus der er stammt.

## Der Issue beschreibt einen Hop. Es sind zwei.

```
XIPReservation.status   fqdn "*.u26-rke2-1.sthings-vsphere.labul.sva.de"
  └─ platform   components.ipReservation   hatte nur ipAddresses + networkKey
       └─ cluster   status.share           las Platform überhaupt nicht
```

## xplane-platform 0.7.0

Hebt `fqdn` und `zone` wörtlich an und ergänzt **`domain`** — das Wildcard, reduziert durch `clusterDomain()`.

Das `*.` gehört zum DNS-**Record**, nicht zur Domain. Alles Nachgelagerte — `CILIUM_GATEWAY_DOMAIN`, ein Gateway-Listener-Hostname, ein Zertifikats-CN — will den Rest. Einmal abzuschneiden ist der ganze Zweck, den Wert überhaupt zu publizieren; sonst wiederholt jeder Consumer dieselbe String-Chirurgie.

Nicht-Wildcards laufen unverändert durch: eine Reservierung mit explizitem `spec.ip` trägt gar keinen DNS-Namen.

`fqdn` und `zone` bleiben daneben stehen, damit eine falsche Domain auf das zurückführbar ist, was clusterbook tatsächlich geliefert hat.

## xplane-cluster 0.5.0

Hebt das nach `status.share.domain` — dieselbe Bewegung, die `apiEndpoint` schon macht, und aus demselben Grund: einmal dort feststellen, wo es entdeckt wird, überall sonst lesen.

## Leere Werte werden weggelassen, nicht publiziert

Alle Abwesenheits-Fälle liefern `""`, und das Feld wird dann **aus `share` entfernt** statt leer gesetzt. Ein leerer String in einem Gateway-Hostname oder einem Zertifikat rendert als gültig aussehender Leerwert — schlimmer als ein fehlender. Dasselbe Muster, das cilium's vier Substitutionen required macht.

## Tests

Die Extraktion liegt in `logic.k`, nicht in `main.k` — dort liest die Status-Montage `_params` und hat keinen Test-Hook. 33/33 (platform) und 40/40 (cluster), davon vier neu.

## Nachgelagert

Beide XRD-Status-Schemas müssen die Felder noch bekommen, dann die Configuration-Pins: `platform` (components.ipReservation → fqdn/zone/domain) und `cluster` (share → domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL