### PR TITLE
feat(xplane-flux-catalog): substitutionSources, and cilium's three (0.6.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/README.md
+++ b/crossplane/xplane-flux-catalog/README.md
@@ -65,6 +65,34 @@ Its real prerequisite is a **cluster fact rather than a `dependsOn`**: Cilium
 must already run with Gateway API and L2 announcements enabled. The catalog has
 no way to express that, so it stays a comment in `apps/cilium.k`.
 
+## Discoverable substitutions
+
+`Component.substitutionSources` maps a variable to a dotted path into the
+**consumer's** status, for variables whose value is a fact about the cluster
+rather than a choice:
+
+```kcl
+substitutionSources = {
+    CILIUM_GATEWAY_DOMAIN = "ipReservation.domain"
+    CILIUM_LB_IP_START    = "ipReservation.ipAddresses[0]"
+}
+```
+
+A consumer resolves an entry **only when the XR does not supply the variable** —
+an explicit value always wins.
+
+The mapping lives here rather than in the consumer because this is where the app
+is described; the consumer only knows how to read its own status. And it is a
+mapping rather than a template dialect in the value, because a template would
+add a second way to fail — an unresolvable path rendering as an empty string,
+which is exactly what `requiredSubstitutions` exists to prevent. A path that
+resolves to nothing leaves the variable **unset**, so it falls through that
+check and is rejected by name.
+
+Not every required variable belongs here. cilium's `CILIUM_GATEWAY_TLS_SECRET`
+stays manual: it is a decision about where a certificate gets issued, not a fact
+any status can answer.
+
 ## Optional components
 
 `Component.optional = True` marks an opt-in extra that is **not** deployed unless
@@ -93,6 +121,7 @@ An app is **not** necessarily one Kustomization: dapr ships `control-plane` and
 | `test_component_names_unique` | duplicates colliding on the emitted `{app}-{component}` name |
 | `test_helmrelease_components_raise_timeout` | a chart-installing component left on the 10m FluxApps default, which is demonstrably too short |
 | `test_cilium_is_config_only` | an `install` component appearing on cilium — i.e. someone wiring a second CNI into the platform |
+| `test_substitution_sources_name_declared_variables` | a `substitutionSources` key that names no declared variable — it would resolve nothing and stay invisible until deploy |
 
 Each was verified to fail on the mistake it describes, not merely to pass.
 

--- a/crossplane/xplane-flux-catalog/apps/cilium.k
+++ b/crossplane/xplane-flux-catalog/apps/cilium.k
@@ -45,6 +45,23 @@ cilium: s.App = {
                 "CILIUM_GATEWAY_DOMAIN"
                 "CILIUM_GATEWAY_TLS_SECRET"
             ]
+            # Three of the four are FACTS the platform already discovered, and
+            # repeating them on the XR is how they drift: when the reservation
+            # moved from a standalone XR to a platform child on u26-rke2-1 the
+            # IP changed .5 -> .8, DNS followed immediately and the Gateway did
+            # not, because its bounds were typed in by hand.
+            #
+            # Start and stop both take the single reserved address: `count: 1`
+            # reserves one IP and the pool is that one address, not a range.
+            #
+            # TLS_SECRET is NOT listed on purpose. It is not a discovered fact
+            # but a decision about where a certificate gets issued, and nothing
+            # in the platform's status can answer it.
+            substitutionSources = {
+                CILIUM_LB_IP_START = "ipReservation.ipAddresses[0]"
+                CILIUM_LB_IP_STOP = "ipReservation.ipAddresses[0]"
+                CILIUM_GATEWAY_DOMAIN = "ipReservation.domain"
+            }
         }
     ]
 }

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -151,3 +151,35 @@ test_cilium_is_config_only = lambda {
     assert _c.components[0].dependsOn == []
     assert not _c.components[0].wrapsHelmRelease
 }
+
+# The three cilium variables that are FACTS the platform discovers, mapped to
+# where it can read them. Repeating them on the XR is how they drift: when the
+# reservation moved to a platform child on u26-rke2-1 the IP changed .5 -> .8,
+# DNS followed and the Gateway did not.
+test_cilium_declares_substitution_sources = lambda {
+    _src = c.get("cilium").components[0].substitutionSources
+    assert _src["CILIUM_GATEWAY_DOMAIN"] == "ipReservation.domain"
+    # count: 1 reserves ONE address; the pool is that address, not a range.
+    assert _src["CILIUM_LB_IP_START"] == "ipReservation.ipAddresses[0]"
+    assert _src["CILIUM_LB_IP_STOP"] == _src["CILIUM_LB_IP_START"]
+}
+
+# TLS_SECRET must never gain a source: it is a decision about where a
+# certificate is issued, not a fact the platform can discover.
+test_cilium_tls_secret_stays_manual = lambda {
+    _c = c.get("cilium").components[0]
+    assert "CILIUM_GATEWAY_TLS_SECRET" in _c.requiredSubstitutions
+    assert "CILIUM_GATEWAY_TLS_SECRET" not in _c.substitutionSources
+}
+
+# Every source must belong to a variable the component actually declares —
+# a typo would otherwise resolve nothing and be invisible until deploy.
+test_substitution_sources_name_declared_variables = lambda {
+    assert all _n, app in c.catalog {
+        all comp in app.components {
+            all v in comp.substitutionSources {
+                v in comp.requiredSubstitutions
+            }
+        }
+    }, "a substitutionSources key names a variable the component does not declare"
+}

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.5.0"
+version = "0.6.0"

--- a/crossplane/xplane-flux-catalog/schema.k
+++ b/crossplane/xplane-flux-catalog/schema.k
@@ -49,6 +49,26 @@ schema Component:
     whose required vars are neither in `substitute` nor plausibly supplied by a
     `substituteFrom` source."""
 
+    substitutionSources?: {str:str} = {}
+    """Where a substitution variable's value can be DISCOVERED, for variables
+    whose value is a fact about the cluster rather than a choice.
+
+    Maps a variable name to a dotted path into the consumer's own status, e.g.
+    `{CILIUM_GATEWAY_DOMAIN = "ipReservation.domain"}`. A consumer resolves an
+    entry ONLY when the XR does not supply the variable — an explicit value
+    always wins, so a cluster can still break out.
+
+    This is deliberately a MAPPING here rather than logic: the catalog knows
+    which of an app's variables are discoverable facts, because it is where the
+    app is described. The consumer knows how to read its own status. Putting the
+    variable names in the consumer instead would make it grow a special case per
+    app; putting a template dialect in the value would introduce a second way to
+    fail (an unresolvable path rendering as an empty string), which is precisely
+    what requiredSubstitutions exists to prevent.
+
+    A path that resolves to nothing leaves the variable UNSET, so it falls
+    through requiredSubstitutions and is rejected — never substituted blank."""
+
     optional?: bool = False
     """Opt-in extra: NOT deployed unless the XR enables it explicitly.
 


### PR DESCRIPTION
Erste Hälfte des letzten offenen Punkts aus stuttgart-things/crossplane-configurations#248 — der [dort entschiedene Entwurf](https://github.com/stuttgart-things/crossplane-configurations/issues/248#issuecomment-5286175786).

## Das Problem ist nicht hypothetisch

Domain und LB-IP werden von der Platform **entdeckt** und dann am XR **abgetippt**. Als die Reservierung auf u26-rke2-1 vom eigenständigen XR auf ein Platform-Kind umgestellt wurde, vergab clusterbook `.8` statt `.5` — DNS zog binnen Sekunden mit, der Gateway nicht, weil seine Pool-Grenzen ein Literal im XR waren.

## Das neue Feld

`Component.substitutionSources` bildet eine Variable auf einen Pfad in den Status des **Consumers** ab:

```kcl
substitutionSources = {
    CILIUM_LB_IP_START    = "ipReservation.ipAddresses[0]"
    CILIUM_LB_IP_STOP     = "ipReservation.ipAddresses[0]"
    CILIUM_GATEWAY_DOMAIN = "ipReservation.domain"
}
```

Aufgelöst wird **nur, wenn das XR die Variable nicht liefert** — ein expliziter Wert gewinnt immer.

`start` und `stop` nehmen dieselbe einzelne Adresse: `count: 1` reserviert eine IP, der Pool ist diese Adresse, kein Bereich.

**`CILIUM_GATEWAY_TLS_SECRET` fehlt bewusst** — das ist eine Entscheidung darüber, wohin ein Zertifikat ausgestellt wird, kein Fakt, den ein Status beantworten kann.

## Zwei Designpunkte

**Das Mapping liegt im Katalog, nicht im Consumer.** Hier wird die App beschrieben, hier stehen ihre Variablen ohnehin; der Consumer weiß nur, wie er seinen eigenen Status liest. Die Alternative — die Platform kennt Cilium-Variablennamen — wächst pro App um einen Sonderfall.

**Es ist ein Mapping, keine Template-Sprache im Wert.** Ein Template brächte eine zweite Fehlerart mit: ein nicht auflösbarer Pfad, der als leerer String rendert — genau das, wogegen `requiredSubstitutions` existiert. Ein Pfad, der nichts liefert, lässt die Variable stattdessen **ungesetzt**, und die bestehende Prüfung lehnt sie namentlich ab.

## Tests

17/17, drei neu. `test_substitution_sources_name_declared_variables` fängt einen Schlüssel, der keine deklarierte Variable benennt — der würde nichts auflösen und bliebe bis zum Deploy unsichtbar.

## Nachgelagert

`xplane-platform` bekommt die Auflösung, sobald dieses Modul publiziert ist — es zieht den Katalog per OCI-Pin, `substitutionSources` existiert dort also erst nach dem Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL