### PR TITLE
feat(xplane-platform): compose the wildcard certificate (0.9.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.6.0" }

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -284,3 +284,19 @@ validate = lambda spec: {str:}, discovered: {str:} = {} -> bool {
     assert len(_missing) == 0, "required substitution variables are not supplied (Flux substitutes empty strings rather than failing, so this would deploy silently broken): " + ", ".join(_missing)
     True
 }
+
+wildcardCertEnabled = lambda spec: {str:}, domain: str -> bool {
+    """Whether to compose the wildcard Certificate for this cluster.
+
+    Opt-IN, and gated on a domain having been DISCOVERED — a Certificate whose
+    only dnsName is "*." is rejected by cert-manager, and one that is silently
+    never issued is worse than one that was never composed. The domain arrives
+    from the ipReservation child (status.components.ipReservation.domain), so
+    this is False until that reports, and stays False when ipReservation is off.
+
+    The Secret it fills is the one a Gateway listener names in certificateRefs:
+    cert-manager writes it, the Gateway picks it up and the HTTPS listener goes
+    Programmed on its own.
+    """
+    (((spec?.vaultIssuer or {})?.wildcardCertificate or {})?.enabled or False) and domain != ""
+}

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -416,3 +416,20 @@ test_explicit_substitute_beats_discovery = lambda {
     assert _k.substitute["CILIUM_GATEWAY_DOMAIN"] == "override.example.com"
     assert _k.substitute["CILIUM_LB_IP_START"] == "10.31.102.8", "undisputed values still come from discovery"
 }
+
+# Opt-in AND a discovered domain. Both halves matter, and the second is easy to
+# lose to operator precedence: `enabled or False and domain != ""` parses as
+# `enabled or (False and ...)`, which drops the domain check entirely.
+test_wildcard_cert_needs_enable_and_domain = lambda {
+    _on = {
+        vaultIssuer = {
+            wildcardCertificate = {enabled = True}
+        }
+    }
+    assert l.wildcardCertEnabled(_on, "u26.example.com")
+    assert not l.wildcardCertEnabled(_on, ""), "no domain discovered yet"
+    assert not l.wildcardCertEnabled({
+        vaultIssuer = {}
+    }, "u26.example.com"), "not opted in"
+    assert not l.wildcardCertEnabled({}, "u26.example.com"), "no vaultIssuer at all"
+}

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -446,7 +446,50 @@ _viRevMgmtObj = {
 }
 _viReviewerObjects = ([_viRevSAObj, _viRevCRBObj, _viRevTokenObj, _viRevObserveObj] if _viAutoReviewer else []) + ([_viRevMgmtObj] if (_viAutoReviewer and _viRevToken != "") else [])
 
-_vaultIssuerChildren = ([_vaultK8sAuthXR, _vaultPkiSecretXR, _issuerObj, _tokenReqRoleObj, _tokenReqBindingObj] + _viReviewerObjects) if _vaultIssuerEnabled else []
+# --- Wildcard certificate for the cluster domain (opt-in) ---
+# The last hand-made object of the Gateway path: cert-manager issues
+# `*.{domain}` through the ClusterIssuer above into the Secret a Gateway
+# listener names in certificateRefs. Nothing else composed it, so it survived
+# no teardown and was reconciled by nothing.
+#
+# The domain comes from the ipReservation child, not the XR — the same value
+# the cilium substitutions read, so the certificate and the listener hostname
+# cannot disagree. Gated on it being discovered: a Certificate whose only
+# dnsName is "*." is rejected, and one that never issues is worse than one that
+# was never composed.
+_viCertSpec = (_viSpec?.wildcardCertificate or {})
+_viCertDomain = _discovered.ipReservation.domain
+_viCertEnabled = l.wildcardCertEnabled(_spec, _viCertDomain)
+_viCertSecret = _viCertSpec?.secretName or "wildcard-tls"
+_viCertNs = _viCertSpec?.namespace or "default"
+_viCertKey = "{}-wildcard-cert".format(_name)
+
+_viCertObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {name = _viCertKey, namespace = _namespace, annotations = {"krm.kcl.dev/composition-resource-name" = _viCertKey}}
+    spec = {
+        forProvider.manifest = {
+            apiVersion = "cert-manager.io/v1"
+            kind = "Certificate"
+            metadata = {name = _viCertSecret, namespace = _viCertNs}
+            spec = {
+                secretName = _viCertSecret
+                commonName = "*.{}".format(_viCertDomain)
+                dnsNames = ["*.{}".format(_viCertDomain)]
+                # 90 days, renewed at 15 — well inside the PKI role's one-year
+                # max_ttl, and short enough that a broken renewal surfaces while
+                # the current certificate is still valid.
+                duration = "2160h"
+                renewBefore = "360h"
+                issuerRef = {name = _viIssuerName, kind = "ClusterIssuer", group = "cert-manager.io"}
+            }
+        }
+        providerConfigRef = {name = _viTargetRef, kind = "ClusterProviderConfig"}
+    }
+}
+
+_vaultIssuerChildren = ([_vaultK8sAuthXR, _vaultPkiSecretXR, _issuerObj, _tokenReqRoleObj, _tokenReqBindingObj] + _viReviewerObjects + ([_viCertObj] if _viCertEnabled else [])) if _vaultIssuerEnabled else []
 
 _children = ([_cniXR] if _cniEnabled else []) + ([_ipReservationXR] if _ipResEnabled else []) + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else []) + ([_ciliumXR] if (_ciliumEnabled and l.gateOpen(_networkReady, _ciliumKey in _ocds)) else []) + _vaultIssuerChildren
 


### PR DESCRIPTION
Das letzte von Hand angelegte Objekt des Gateway-Pfads (stuttgart-things/crossplane-configurations#248) bekommt einen Besitzer.

## Es gab keinen

`xplane-platform` erwähnte `Certificate` **null mal**, das Platform-XRD hatte kein Feld dafür, und das Cilium-Artefakt *referenziert* das Secret nur (`certificateRefs`). Der Checkbox-Punkt „Wildcard-Zertifikat" hatte nie eine Zuständigkeit — das auf u26-rke2-1 wurde von Hand appliziert, überlebt keinen Teardown und wird von nichts rekonziliert.

## Was jetzt passiert

cert-manager stellt `*.{domain}` über den ClusterIssuer aus, den `vaultIssuer` ohnehin anlegt, in das Secret, das ein Gateway-Listener in `certificateRefs` nennt. Der Listener wird von selbst `Programmed`, sobald es auftaucht.

**Die Domain kommt aus dem `ipReservation`-Kind, nicht aus dem XR** — derselbe Wert, den auch die Cilium-Substitutionen lesen. Zertifikat und Listener-Hostname können also nicht auseinanderlaufen.

## Das Gate hat zwei Hälften

Opt-in **und** eine entdeckte Domain. Ein `Certificate`, dessen einziger `dnsName` `"*."` ist, wird von cert-manager abgelehnt — und eines, das nie ausgestellt wird, ist schlimmer als eines, das nie komponiert wurde: der Gateway wartet dann auf ein Secret, das kommt und nie ankommt.

Beide Hälften sind getestet. Die zweite verliert man leicht an Operator-Präzedenz:

```kcl
enabled or False and domain != ""      # parst als: enabled or (False and ...)
```

Genau das tat der erste Entwurf — die Domain-Prüfung war tot. Der Test fängt es.

## Laufzeit

`duration 90d` / `renewBefore 15d`: innerhalb der `max_ttl` von einem Jahr der PKI-Rolle, und kurz genug, dass eine fehlgeschlagene Erneuerung auffällt, solange das aktuelle Zertifikat noch gilt. Gegen die Live-Rolle geprüft — sie erlaubt Subdomains und Wildcards unter `sthings-vsphere.labul.sva.de`.

39/39.

## Nachgelagert

Platform-XRD braucht das Feld `vaultIssuer.wildcardCertificate` (`enabled`, `secretName`, `namespace`), dann der Configuration-Pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL