### PR TITLE
feat(xplane-flux-catalog): headlamp discovers its DOMAIN (0.7.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/headlamp.k
+++ b/crossplane/xplane-flux-catalog/apps/headlamp.k
@@ -20,6 +20,15 @@ headlamp: s.App = {
             wrapsHelmRelease = True
             timeout = "15m"
             requiredSubstitutions = ["DOMAIN", "HOSTNAME", "GATEWAY_NAME"]
+            # DOMAIN is the cluster's own domain — the same value the Gateway
+            # listener's wildcard and the certificate CN are built from. Typing
+            # it on the XR is how those three drift apart; the platform already
+            # discovered it. HOSTNAME and GATEWAY_NAME stay manual: which name
+            # this app answers on, and which Gateway it attaches to, are
+            # decisions no status can answer.
+            substitutionSources = {
+                DOMAIN = "ipReservation.domain"
+            }
         }
     ]
 }

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -183,3 +183,13 @@ test_substitution_sources_name_declared_variables = lambda {
         }
     }, "a substitutionSources key names a variable the component does not declare"
 }
+
+# headlamp's DOMAIN is the cluster domain — discoverable, and the same value the
+# Gateway listener wildcard and the certificate CN come from. HOSTNAME and
+# GATEWAY_NAME are decisions and must stay manual.
+test_headlamp_discovers_only_the_domain = lambda {
+    _c = c.get("headlamp").components[0]
+    assert _c.substitutionSources == {DOMAIN = "ipReservation.domain"}
+    assert "HOSTNAME" not in _c.substitutionSources
+    assert "GATEWAY_NAME" not in _c.substitutionSources
+}

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.6.0"
+version = "0.7.0"


### PR DESCRIPTION
`DOMAIN` ist die Cluster-Domain — **derselbe Wert**, aus dem der Wildcard-Hostname des Gateway-Listeners und der CN des Zertifikats gebaut werden. Ihn am XR abzutippen ist genau der Weg, auf dem diese drei auseinanderlaufen; die Platform hat ihn längst entdeckt.

## Belegt, unmittelbar davor

Headlamp auf u26-rke2-1 deployt, mit allen drei Substitutionen ausgeschrieben:

```
https://headlamp.u26-rke2-1.sthings-vsphere.labul.sva.de → HTTP 200, TLS-Verify 0
HTTPRoute  headlamp/headlamp → default/cilium-gateway   Accepted=True
```

Das `DOMAIN` in diesem XR war eine wörtliche Kopie dessen, was `status.components.ipReservation.domain` ohnehin sagte.

## Was manuell bleibt, und warum

`HOSTNAME` und `GATEWAY_NAME` bekommen **keine** Quelle. Unter welchem Namen eine App antwortet und an welchen Gateway sie sich hängt, sind Entscheidungen — kein Status kann sie beantworten. Dieselbe Linie wie bei cilium's `CILIUM_GATEWAY_TLS_SECRET`.

Der Test prüft **beide Hälften**: dass `DOMAIN` eine Quelle hat und dass die anderen zwei keine. Ein späteres „wenn wir schon dabei sind" kann eine Entscheidung damit nicht stillschweigend in einen entdeckten Wert verwandeln.

18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL