### PR TITLE
feat(xplane-platform): catalog 0.7.0, headlamp's domain is discovered (0.10.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.9.0"
+version = "0.10.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.6.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.7.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.6.0"
-    version = "0.6.0"
-    sum = "YS5LALSzg3ibLw0qP1s8FElVuUUq33Af5Ni8emmW1b4="
+    full_name = "xplane-flux-catalog_0.7.0"
+    version = "0.7.0"
+    sum = "x+IiwLlKcH+fTC1B52GUX6xxVI4yxgWdfjfKEF0zEyA="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.6.0"
+    oci_tag = "0.7.0"

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -433,3 +433,22 @@ test_wildcard_cert_needs_enable_and_domain = lambda {
     }, "u26.example.com"), "not opted in"
     assert not l.wildcardCertEnabled({}, "u26.example.com"), "no vaultIssuer at all"
 }
+
+# headlamp's DOMAIN became discoverable in catalog 0.7.0. Enabling it now needs
+# only the two values that are decisions — which name it answers on, and which
+# Gateway it attaches to.
+test_apps_headlamp_discovers_its_domain = lambda {
+    _d = {
+        ipReservation = {domain = "u26-rke2-1.sthings-vsphere.labul.sva.de", ipAddresses = ["10.31.102.8"], zone = "z"}
+    }
+    _spec = {clusterName = "c", apps = {
+        headlamp = {enabled = True, substitute = {
+            HOSTNAME = "headlamp"
+            GATEWAY_NAME = "cilium-gateway"
+        }}
+    }}
+    assert len(l.missingSubstitutions(_spec, _d)) == 0, "DOMAIN comes from the status"
+    assert len(l.missingSubstitutions(_spec)) == 1, "and is still required when nothing was discovered"
+    _k = [k for k in l.appEntries(_spec, _d) if k.name == "headlamp-app"][0]
+    assert _k.substitute["DOMAIN"] == "u26-rke2-1.sthings-vsphere.labul.sva.de"
+}


### PR DESCRIPTION
Nimmt stuttgart-things/kcl#113 auf. `headlamp`s `DOMAIN` löst jetzt aus `status.components.ipReservation.domain` auf.

## Wirkung am XR

Vorher drei Substitutionen, jetzt zwei:

```yaml
apps:
  headlamp:
    substitute:
      HOSTNAME: headlamp
      GATEWAY_NAME: cilium-gateway
      # DOMAIN kommt aus dem Status
```

Beides Übriggebliebene sind **Entscheidungen** — unter welchem Namen die App antwortet und an welchen Gateway sie sich hängt. Kein Status kann sie beantworten.

## Der Test prüft beide Richtungen

Mit entdeckter Domain fehlt nichts; **ohne** entdeckte Domain wird `DOMAIN` weiterhin namentlich als fehlend gemeldet.

Die zweite Hälfte ist die wichtigere: Entdeckung darf die `requiredSubstitutions`-Prüfung nicht ins Schweigen bringen, sondern nur das erfüllen, was tatsächlich gefunden wurde.

40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL