### PR TITLE
feat(xplane-platform): pull the machinery catalog entry (0.11.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.7.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.8.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.7.0"
-    version = "0.7.0"
-    sum = "x+IiwLlKcH+fTC1B52GUX6xxVI4yxgWdfjfKEF0zEyA="
+    full_name = "xplane-flux-catalog_0.8.0"
+    version = "0.8.0"
+    sum = "EYkgTJ3t2efga4Dmgt0R+tNOt3GM2VK7RKRSyU+Vp7k="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.7.0"
+    oci_tag = "0.8.0"

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -452,3 +452,34 @@ test_apps_headlamp_discovers_its_domain = lambda {
     _k = [k for k in l.appEntries(_spec, _d) if k.name == "headlamp-app"][0]
     assert _k.substitute["DOMAIN"] == "u26-rke2-1.sthings-vsphere.labul.sva.de"
 }
+
+test_apps_machinery_discovers_its_domain = lambda {
+    _d = {
+        ipReservation = {domain = "u26-rke2-1.sthings-vsphere.labul.sva.de", ipAddresses = ["10.31.102.8"], zone = "z"}
+    }
+    _spec = {clusterName = "c", apps = {
+        machinery = {enabled = True, substitute = {
+            GATEWAY_NAME = "cilium-gateway"
+            MACHINERY_VERSION = "v1.18.1"
+        }}
+    }}
+    assert len(l.missingSubstitutions(_spec, _d)) == 0, "DOMAIN comes from the status"
+    _k = [k for k in l.appEntries(_spec, _d) if k.name == "machinery-app"][0]
+    assert _k.substitute["DOMAIN"] == "u26-rke2-1.sthings-vsphere.labul.sva.de"
+}
+
+test_apps_machinery_still_demands_its_version = lambda {
+    # The artifact defaults MACHINERY_VERSION to `1.13.4` while the published
+    # tags carry a `v` — the OCIRepository never resolves. The catalog entry
+    # declares it required so that fails at render time, naming the variable,
+    # instead of silently. Drop this once stuttgart-things/flux#193 lands.
+    _d = {
+        ipReservation = {domain = "u26-rke2-1.sthings-vsphere.labul.sva.de", ipAddresses = [], zone = "z"}
+    }
+    _spec = {clusterName = "c", apps = {
+        machinery = {enabled = True, substitute = {GATEWAY_NAME = "cilium-gateway"}}
+    }}
+    _missing = l.missingSubstitutions(_spec, _d)
+    assert len(_missing) == 1, "only the version is unsupplied"
+    assert "MACHINERY_VERSION" in ", ".join(_missing)
+}


### PR DESCRIPTION
Hop 2 der Kette aus stuttgart-things/crossplane-configurations#259.

`xplane-flux-catalog` **0.7.0 → 0.8.0** — der Katalog trägt seit kcl#115 `apps/machinery`, den gRPC/HTMX-Dienst zum Beobachten Crossplane-verwalteter Ressourcen (nicht den gleichnamigen Bootstrap-Play).

**Keine Logikänderung.** Das Modul konsumiert den Katalog generisch, ein neuer Eintrag kostet einen Pin-Bump.

## Zwei Tests, weil dieser Eintrag beide Hälften des Substitutionspfads berührt

- `test_apps_machinery_discovers_its_domain` — `DOMAIN` kommt über `substitutionSources` aus `ipReservation.domain`, wie bei headlamp
- `test_apps_machinery_still_demands_its_version` — `MACHINERY_VERSION` bleibt required und **fehlt erwartungsgemäß**, wenn niemand ihn liefert

Der zweite Test hält fest, warum der Katalog-Eintrag überspezifiziert aussieht: der Default im Artefakt lautet `1.13.4`, die publizierten Tags tragen aber ein `v`. Die `OCIRepository` löst nie auf, und der Fehler nennt nicht den Default als Ursache. Required zu deklarieren macht daraus eine Ablehnung beim Rendern, die die Variable benennt.

Der Test verschwindet mit stuttgart-things/flux#193.

## Nächster Hop

`platform`-Composition-Pin auf 0.11.0, dann `task push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL