### PR TITLE
fix(xplane-flux-catalog): machinery no longer needs a typed version (0.9.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/machinery.k
+++ b/crossplane/xplane-flux-catalog/apps/machinery.k
@@ -14,41 +14,40 @@ import ..schema as s
 # configurable status-field extraction is what makes `status.stage` — "the one
 # field to look at when a build is stuck" — visible without kubectl.
 #
-# TWO GAPS in the artifact, both verified 2026-08-14 — neither blocks the
-# catalog entry, but both bite whoever enables it first:
+# Two gaps used to make this entry awkward; stuttgart-things/flux#193 closed
+# both in artifact v1.19.2, which is why this pins it rather than v1.18.1:
 #
-#  1. MACHINERY_VERSION defaults to `1.13.4`; the published tags are `v1.13.4`.
-#     The default resolves to nothing. Hence it sits in requiredSubstitutions.
-#  2. The artifact patches MACHINERY_CONFIG=/etc/machinery/config.json onto the
-#     deployment and mounts the `machinery-config` ConfigMap — which carries
-#     only LOG_LEVEL. There is no config.json key, so the path dangles. The
-#     service does run (the config is optional; it falls back to built-in
-#     defaults), but the WATCH SET cannot be configured through the app today.
+#  1. MACHINERY_VERSION defaulted to `1.13.4` while the published tags read
+#     `v1.13.4`, so the OCIRepository never resolved and the app never
+#     deployed. The entry carried it in requiredSubstitutions to turn that
+#     silent pull failure into a render-time rejection; no longer needed.
+#  2. MACHINERY_CONFIG pointed at /etc/machinery/config.json while the mounted
+#     ConfigMap held only LOG_LEVEL, so the WATCH SET — which decides the kinds
+#     the dashboard shows — could not be configured through the app at all. The
+#     service still ran, on built-in defaults watching StoragePlatform and
+#     NetworkIntegration: a dashboard, just not this fleet's.
 #
-# That second one matters for this fleet: the watch set decides which kinds the
-# dashboard shows, and no shipped example covers ours. examples/configs/
-# platforms.json watches StoragePlatform / NetworkIntegration /
-# SecurityPlatform / AnsibleRun — not ClusterStack, Platform or XIPReservation.
-# Making those visible needs a config the artifact has no way to supply yet.
+# The artifact now ships the watch set as a file, covering ClusterStack,
+# Platform, XIPReservation and VaultK8sAuth. Enabling this app is therefore
+# enough — no ConfigMap has to be placed on the cluster by hand.
 machinery: s.App = {
     artifact = "oci://ghcr.io/stuttgart-things/flux/apps/machinery"
-    defaultVersion = "v1.18.1"
+    defaultVersion = "v1.19.2"
     components = [
         s.Component {
             name = "app"
             path = "./"
             wrapsHelmRelease = True
             timeout = "15m"
-            # MACHINERY_VERSION is listed even though the artifact gives it a
-            # default, because that default is WRONG: it reads `1.13.4` while
-            # the published tags are `v1.13.4` — the OCIRepository does not
-            # resolve and the app never deploys. Declaring it required turns a
-            # silent pull failure into a render-time rejection that names the
-            # variable. Drop it from this list once flux fixes the default.
+            # MACHINERY_VERSION is no longer listed: stuttgart-things/flux#193
+            # fixed the artifact's default (it read `1.13.4` while the published
+            # tags read `v1.13.4`, so the OCIRepository never resolved) and this
+            # entry pins v1.19.2, which carries that fix. Overriding the version
+            # is still possible, it is just no longer mandatory.
             #
             # MACHINERY_HOSTNAME (machinery), MACHINERY_NAMESPACE (machinery)
-            # and GATEWAY_NAMESPACE (default) carry usable defaults.
-            requiredSubstitutions = ["DOMAIN", "GATEWAY_NAME", "MACHINERY_VERSION"]
+            # and GATEWAY_NAMESPACE (default) carry usable defaults too.
+            requiredSubstitutions = ["DOMAIN", "GATEWAY_NAME"]
             # DOMAIN is the cluster's own — the same value the Gateway listener
             # wildcard and the certificate CN are built from. GATEWAY_NAME stays
             # manual: which Gateway a service attaches to is a decision.

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -200,8 +200,13 @@ test_headlamp_discovers_only_the_domain = lambda {
 # so a later artifact change that adds a required variable is noticed.
 test_machinery_costs_one_typed_value = lambda {
     _c = c.get("machinery").components[0]
-    assert _c.requiredSubstitutions == ["DOMAIN", "GATEWAY_NAME", "MACHINERY_VERSION"]
+    assert _c.requiredSubstitutions == ["DOMAIN", "GATEWAY_NAME"]
     assert _c.substitutionSources == {DOMAIN = "ipReservation.domain"}
     _typed = [v for v in _c.requiredSubstitutions if v not in _c.substitutionSources]
-    assert _typed == ["GATEWAY_NAME", "MACHINERY_VERSION"], "the Gateway choice, plus the version until flux fixes its broken default"
+    assert _typed == ["GATEWAY_NAME"], "only the Gateway choice — which Gateway a service attaches to is a decision, not a fact"
+
+    # MACHINERY_VERSION was required until stuttgart-things/flux#193 fixed the
+    # artifact's `1.13.4` default (published tags read `v1.13.4`). It must stay
+    # out: re-adding it would mean the artifact's default broke again.
+    assert "MACHINERY_VERSION" not in _c.requiredSubstitutions
 }

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.8.0"
+version = "0.9.0"


### PR DESCRIPTION
stuttgart-things/flux#193 ist behoben und als Artefakt **v1.19.2** released — die beiden Krücken in diesem Eintrag können weg.

| | |
|---|---|
| `defaultVersion` | v1.18.1 → **v1.19.2** |
| `requiredSubstitutions` | **`MACHINERY_VERSION` entfällt** |

## Warum die Variable überhaupt drin stand

Das Artefakt hatte einen Default — nur den falschen: `1.13.4`, während die publizierten Tags `v1.13.4` lauten. Die `OCIRepository` löste nie auf, die App deployte nie, und die Fehlermeldung nannte die Version nicht als Ursache. Sie required zu deklarieren machte daraus eine Ablehnung beim Rendern, die die Variable benennt.

v1.19.2 korrigiert den Default. Die Krücke würde den Eintrag jetzt nur noch schwerer benutzbar machen als nötig.

## Und die zweite Lücke ist auch zu

v1.19.2 liefert den Watch-Set als Datei mit. Vorher kam der Dienst auf eingebauten Defaults hoch, die `StoragePlatform` und `NetworkIntegration` beobachten — ein Dashboard, nur nicht das dieser Fleet —, und **keine** XR-Konfiguration konnte daran etwas ändern. Jetzt reicht das Aktivieren der App.

## Ergebnis

Machinery kostet nun genau **einen** getippten Wert: `GATEWAY_NAME`. Und das ist eine Entscheidung, kein Fakt — an welches Gateway ein Dienst hängt, kann die Platform nicht entdecken.

`test_machinery_costs_one_typed_value` hieß schon vorher so und stimmt jetzt erst. Er prüft zusätzlich, dass `MACHINERY_VERSION` **draußen bleibt** — käme sie zurück, hieße das, der Default des Artefakts ist wieder kaputt.

19/19 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL