### PR TITLE
feat(xplane-platform): machinery costs one typed value now (0.12.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.11.0"
+version = "0.12.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.8.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.9.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.8.0"
-    version = "0.8.0"
-    sum = "EYkgTJ3t2efga4Dmgt0R+tNOt3GM2VK7RKRSyU+Vp7k="
+    full_name = "xplane-flux-catalog_0.9.0"
+    version = "0.9.0"
+    sum = "DfbXw1vAxIT7xXGZlSKEty9Jwjo/mbwMXEDWxpIhrsQ="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.8.0"
+    oci_tag = "0.9.0"

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -468,18 +468,24 @@ test_apps_machinery_discovers_its_domain = lambda {
     assert _k.substitute["DOMAIN"] == "u26-rke2-1.sthings-vsphere.labul.sva.de"
 }
 
-test_apps_machinery_still_demands_its_version = lambda {
-    # The artifact defaults MACHINERY_VERSION to `1.13.4` while the published
-    # tags carry a `v` — the OCIRepository never resolves. The catalog entry
-    # declares it required so that fails at render time, naming the variable,
-    # instead of silently. Drop this once stuttgart-things/flux#193 lands.
+test_apps_machinery_costs_one_typed_value = lambda {
+    # stuttgart-things/flux#193 fixed the artifact default (it read `1.13.4`
+    # while the published tags read `v1.13.4`, so the OCIRepository never
+    # resolved), and catalog 0.9.0 dropped MACHINERY_VERSION from the required
+    # list. What remains is GATEWAY_NAME — a decision, not a fact, so nothing
+    # can discover it.
     _d = {
         ipReservation = {domain = "u26-rke2-1.sthings-vsphere.labul.sva.de", ipAddresses = [], zone = "z"}
     }
-    _spec = {clusterName = "c", apps = {
+    _withGateway = {clusterName = "c", apps = {
         machinery = {enabled = True, substitute = {GATEWAY_NAME = "cilium-gateway"}}
     }}
-    _missing = l.missingSubstitutions(_spec, _d)
-    assert len(_missing) == 1, "only the version is unsupplied"
-    assert "MACHINERY_VERSION" in ", ".join(_missing)
+    assert len(l.missingSubstitutions(_withGateway, _d)) == 0, "the version is no longer typed by hand"
+
+    _bare = {clusterName = "c", apps = {
+        machinery = {enabled = True}
+    }}
+    _missing = l.missingSubstitutions(_bare, _d)
+    assert len(_missing) == 1, "the Gateway choice stays required"
+    assert "GATEWAY_NAME" in ", ".join(_missing)
 }


### PR DESCRIPTION
Hop 2 der Nachzieh-Kette zu stuttgart-things/flux#193.

`xplane-flux-catalog` **0.8.0 → 0.9.0**: der machinery-Eintrag verlangt `MACHINERY_VERSION` nicht mehr und pinnt Artefakt **v1.19.2**.

Hintergrund: der Default des Artefakts war kaputt (`1.13.4` gegen publizierte Tags `v1.13.4`), deshalb stand die Variable als required im Katalog. flux#193 hat das behoben — und liefert zugleich den Watch-Set als Datei mit, sodass das Aktivieren der App jetzt genügt.

## Der Test wurde umgeschrieben, nicht gelöscht

Die interessante Aussage ist nicht verschwunden, sie hat sich verschoben: **Machinery zu aktivieren muss genau einen getippten Wert kosten** — `GATEWAY_NAME`. `DOMAIN` kommt aus der Reservierung, die Version ist wieder Sache des Artefakts.

Die zweite Hälfte prüft mit einem nackten `machinery: {enabled: true}`, dass die Gateway-Wahl required **bleibt**. An welches Gateway ein Dienst hängt, ist eine Entscheidung — die kann die Platform nicht entdecken.

42/42 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL