### PR TITLE
feat(xplane-crossplane-catalog): the package set of a management cluster (0.1.0)

### DIFF
--- a/crossplane/xplane-crossplane-catalog/README.md
+++ b/crossplane/xplane-crossplane-catalog/README.md
@@ -1,0 +1,102 @@
+# xplane-crossplane-catalog
+
+The package set that makes a cluster a **management** cluster: Crossplane itself,
+its providers, functions and configurations.
+
+Sibling of [`xplane-flux-catalog`](../xplane-flux-catalog/), one layer down. That
+one describes what a cluster *offers*; this one describes what it *is*.
+
+```kcl
+import xplane_crossplane_catalog as cat
+
+_p = cat.get("machinery")
+_p.crossplaneVersion              # "2.3.3"
+cat.byKind(_p, "Configuration")   # apply these last
+cat.transitive(_p)                # what arrives without being named
+```
+
+## Scope
+
+**Structural facts only**, the same discipline the flux catalog keeps. Package
+identity and version live here because they are identical on every management
+cluster in this fleet. Capability-chart values, credentials and per-datacentre
+placement do not — they are environment-specific and belong in the XR or an
+`EnvironmentConfig`. Duplicating them here would guarantee drift.
+
+## The naming rule, and why it is the whole point
+
+Providers and Configurations carry the name **Crossplane itself derives** from
+the package path — registry dropped, segments joined with `-`, tag stripped:
+
+```
+xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.3.0
+  -> crossplane-contrib-provider-helm
+
+ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.11
+  -> stuttgart-things-crossplane-configurations-platform
+```
+
+This is not cosmetic. The package resolver keys on the **source**, so an
+existing node satisfies a `dependsOn` no matter what its CR is called — which is
+why a fleet cluster looks healthy with short names most of the time. The window
+opens during an **upgrade**: the CR's Lock entry briefly disappears, the resolver
+sees an unsatisfied dependency and auto-installs it under the derived name, and
+when the short-named CR returns there are two names for one source. That is
+[crossplane-configurations#247](https://github.com/stuttgart-things/crossplane-configurations/issues/247):
+on u26-kind3 it took **all 20 Configurations** to `Healthy=False`, and unpicking
+it is whack-a-mole, because deleting one duplicate makes the resolver create the
+next.
+
+With the derived name, the CR the resolver would create and the CR that already
+exists are the same object. There is no window.
+
+### Functions are the exception
+
+They keep **short** names (`function-kcl`, never
+`crossplane-contrib-function-kcl`) because Compositions name them in
+`functionRef` — renaming one breaks every Composition that uses it. Functions
+therefore retain a narrow exposure to the upgrade window above. There is no way
+around it that does not break `functionRef`, so it is documented rather than
+fixed.
+
+`function-kcl` additionally lives on **xpkg.upbound.io** while our `dependsOn`
+entries use `xpkg.crossplane.io`. Two sources, two Lock nodes, healthy —
+verified on kind1. Aligning the mirrors gives two nodes with an *identical*
+source and freezes the resolver for every package on the cluster. The split is
+load-bearing.
+
+## Absences that are deliberate
+
+| not listed | why |
+|---|---|
+| `provider-kubernetes` | every Configuration pulls it |
+| `ansible-run` | pulled by both VM Configurations |
+| `cni`, `flux-init`, `flux-apps`, `ip-reservation`, `vault-auth`, `vault-pki-secrets` | pulled by `platform` |
+
+They are recorded in each package's `pulls`, which is documentation rather than
+an exclusion list — with derived names an entry may legitimately be both
+installed and pulled, because the two are one node. `cat.transitive(profile)`
+returns the whole set: the honest answer to what is actually on the cluster.
+
+## Invariants
+
+`kcl test` asserts the rules rather than trusting the next reader to know them:
+
+- every Provider and Configuration uses the derived name
+- the derivation matches Crossplane's, for both the upstream and the ghcr path shape
+- Function CR names stay short
+- `function-kcl` stays on the other mirror
+- `function-auto-ready` stays below v0.7.0 — v0.7.0 makes Configurations report
+  Unhealthy and times out the install wait
+- every package pins an explicit tag; no floating tags
+- `provider-kubernetes` is never installed explicitly
+- `ProviderConfig`s are `in-cluster` only, carrying no credentials
+
+## Profiles
+
+| name | for |
+|---|---|
+| `machinery` | the full management cluster this fleet runs today — VM building, image building, backup, scheduling |
+
+A seed profile will follow: a seed exists to produce exactly one cluster and
+needs far less than this.

--- a/crossplane/xplane-crossplane-catalog/catalog_test.k
+++ b/crossplane/xplane-crossplane-catalog/catalog_test.k
@@ -1,0 +1,128 @@
+# Unit tests for the package catalog. Run with `kcl test`.
+# These validate the catalog's own invariants — no Crossplane, no cluster.
+import .main as c
+
+test_machinery_is_registered = lambda {
+    assert "machinery" in c.catalog
+    assert c.get("machinery").crossplaneVersion == "2.3.3"
+    assert c.get("machinery").namespace == "crossplane-system"
+}
+
+# THE rule this catalog exists for, in its sharper form.
+#
+# Providers and Configurations carry the name Crossplane derives from their
+# package path. That makes the Lock collision from
+# crossplane-configurations#247 impossible rather than merely unlikely: the
+# resolver keys on the SOURCE, so an existing node satisfies a dependency
+# whatever it is called — but during an UPGRADE the entry is briefly gone, the
+# resolver auto-installs the dependency under the derived name, and a
+# short-named CR then collides with it. On u26-kind3 that took all 20
+# Configurations to Healthy=False, and unpicking it is whack-a-mole because
+# deleting one duplicate makes the resolver create the next.
+test_providers_and_configurations_use_derived_names = lambda {
+    _p = c.get("machinery")
+    _named = c.byKind(_p, "Provider") + c.byKind(_p, "Configuration")
+    _wrong = [x.name for x in _named if x.name != c.derivedName(x.package)]
+    assert _wrong == [], "not the package-manager-derived name"
+}
+
+# The derivation itself, against the two shapes in use — a two-segment upstream
+# path and our four-segment ghcr one. Pinned because everything above rests on
+# it matching what Crossplane actually does.
+test_derived_name_matches_crossplane = lambda {
+    assert c.derivedName("xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.3.0") == "crossplane-contrib-provider-helm"
+    assert c.derivedName("ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.11") == "stuttgart-things-crossplane-configurations-platform"
+    assert c.derivedName("ghcr.io/stuttgart-things/provider-clusterbook-xpkg:v0.4.2") == "stuttgart-things-provider-clusterbook-xpkg"
+}
+
+# The transitive set is not empty — if it were, someone flattened the dependsOn
+# declarations and the graph documentation would be silently worthless.
+test_transitive_set_is_populated = lambda {
+    _t = c.transitive(c.get("machinery"))
+    assert len(_t) >= 6, "the dependsOn graph should carry most of the fleet"
+    assert "flux-apps" in _t, "platform has pulled flux-apps since v0.3.1"
+    assert "ansible-run" in _t, "both VM Configurations pull ansible-run"
+}
+
+# Every reference pins a tag. Enforced by the schema too; asserted here so the
+# intent is visible where the rules are read.
+test_every_package_is_pinned = lambda {
+    _pkgs = c.get("machinery").packages
+    assert all p in _pkgs {
+        ":" in p.package and not p.package.endswith(":latest")
+    }, "a floating tag would move a management cluster forward unattended"
+}
+
+# Function CR names stay SHORT (root CLAUDE.md). A long-named Function CR on the
+# same registry as a dependsOn-derived one adds a duplicate Lock node and
+# freezes the resolver for every package on the cluster.
+test_function_names_are_short = lambda {
+    _f = c.byKind(c.get("machinery"), "Function")
+    assert len(_f) > 0
+    assert all p in _f {
+        not p.name.startswith("crossplane-contrib-")
+    }, "Function CRs use the short name"
+}
+
+# Providers are the EXCEPTION and it is not an oversight: provider-helm carries
+# the long, package-manager-derived name so the explicit CR and any
+# dependsOn-derived one are the same Lock node. Providers own CRDs, and two of
+# them fighting over ownership is worse than the duplication a Function pair
+# causes.
+test_provider_helm_keeps_the_long_name = lambda {
+    _h = [p for p in c.byKind(c.get("machinery"), "Provider") if "provider-helm" in p.package]
+    assert len(_h) == 1
+    assert _h[0].name == "crossplane-contrib-provider-helm"
+}
+
+# function-kcl must stay on the upbound mirror. Our dependsOn entries use
+# xpkg.crossplane.io and the package manager derives a long-named CR from that
+# path; the differing mirror is what keeps the two Lock nodes distinct. Aligning
+# them yields two nodes with an IDENTICAL source and every Function on the
+# cluster goes Healthy=False (verified on kind1, 2026-07-18).
+test_function_kcl_stays_on_the_other_mirror = lambda {
+    _k = [p for p in c.byKind(c.get("machinery"), "Function") if p.name == "function-kcl"]
+    assert len(_k) == 1
+    assert _k[0].package.startswith("xpkg.upbound.io/")
+}
+
+# function-auto-ready v0.7.0 makes Configurations report Unhealthy, which times
+# out the install wait. The ceiling is a fleet fact, not a preference.
+test_function_auto_ready_stays_below_070 = lambda {
+    _a = [p for p in c.byKind(c.get("machinery"), "Function") if p.name == "function-auto-ready"]
+    assert len(_a) == 1
+    assert _a[0].package.endswith(":v0.6.5")
+}
+
+# provider-kubernetes must NOT be an entry: every Configuration pulls it, so
+# naming it would be the duplicate this catalog prevents. Asserted separately
+# because it is the one absence a reader is most likely to mistake for an
+# omission.
+test_provider_kubernetes_is_not_installed_explicitly = lambda {
+    _pkgs = c.get("machinery").packages
+    assert all p in _pkgs {
+        p.name != "provider-kubernetes"
+    }, "provider-kubernetes arrives through every Configuration's dependsOn"
+}
+
+# Each provider gets one in-cluster ProviderConfig, and they carry no
+# credentials — the ServiceAccount is the identity. Per-datacentre configs
+# (vSphere, Proxmox, Vault) are environment-specific and stay out of the catalog.
+test_provider_configs_are_in_cluster_only = lambda {
+    _pc = c.get("machinery").providerConfigs
+    assert len(_pc) == 3
+    assert all x in _pc {
+        x.name == "in-cluster" and x.kind == "ClusterProviderConfig"
+    }
+}
+
+test_byKind_partitions_the_packages = lambda {
+    _p = c.get("machinery")
+    _sum = len(c.byKind(_p, "Provider")) + len(c.byKind(_p, "Function")) + len(c.byKind(_p, "Configuration"))
+    assert _sum == len(_p.packages), "every package has one of the three kinds"
+}
+
+test_get_rejects_an_unknown_profile = lambda {
+    assert "machinery" in c.names
+    assert len(c.names) == len(c.catalog)
+}

--- a/crossplane/xplane-crossplane-catalog/kcl.mod
+++ b/crossplane/xplane-crossplane-catalog/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "xplane-crossplane-catalog"
+edition = "v0.12.3"
+version = "0.1.0"

--- a/crossplane/xplane-crossplane-catalog/main.k
+++ b/crossplane/xplane-crossplane-catalog/main.k
@@ -1,0 +1,55 @@
+# The profile registry.
+#
+# Mirrors xplane-flux-catalog: no file globbing in KCL, so every profile is
+# registered explicitly. One profile today; the shape exists because a seed and
+# a full machinery cluster will not want the same package set.
+import .profiles.machinery as machinery
+import schema as s
+
+catalog: {str:s.Profile} = {
+    machinery = machinery.machinery
+}
+
+names = sorted(catalog)
+
+_known = ", ".join(names)
+
+# Look up a profile by name. Fails loudly rather than returning an empty profile
+# that would render a Crossplane install with no packages — which looks like a
+# working cluster until the first XR finds no XRD.
+get = lambda name: str -> s.Profile {
+    # KCL does NOT interpolate ${} inside assert messages.
+    assert name in catalog, "unknown profile '" + name + "' — known: " + _known
+    catalog[name]
+}
+
+# Packages of one kind, in declaration order. Consumers apply Providers before
+# Functions before Configurations: a Configuration whose functions are missing
+# reconciles into an error rather than waiting.
+byKind = lambda profile: s.Profile, kind: str -> [s.Package] {
+    [p for p in profile.packages if p.kind == kind]
+}
+
+# Everything the profile's packages bring in without being named. Not applied by
+# anyone — this is the deny-list the roots-only rule is checked against, and the
+# honest answer to "what is actually on this cluster".
+transitive = lambda profile: s.Profile -> [str] {
+    sorted({d: "" for p in profile.packages for d in p.pulls})
+}
+
+# The CR name Crossplane itself derives from a package path: registry dropped,
+# path segments joined with "-", tag stripped. `provider-helm` has always been
+# installed as `crossplane-contrib-provider-helm` for this reason.
+#
+# Using it for everything a dependsOn can also name is what makes the #247 Lock
+# collision impossible rather than merely unlikely. The resolver keys on the
+# SOURCE, so an existing node satisfies a dependency no matter what it is
+# called — but during an UPGRADE the entry is briefly gone, the resolver
+# auto-installs the dependency under this derived name, and a short-named CR
+# then collides with it. If the CR already carries this name, the two are the
+# same object and there is no window.
+derivedName = lambda package: str -> str {
+    _rest = package.split("/")[1::]
+    _last = _rest[-1].split(":")[0]
+    "-".join(_rest[:-1:] + [_last])
+}

--- a/crossplane/xplane-crossplane-catalog/profiles/machinery.k
+++ b/crossplane/xplane-crossplane-catalog/profiles/machinery.k
@@ -1,0 +1,191 @@
+import ..schema as s
+
+# machinery — the profile every management cluster in this fleet runs today.
+#
+# Transcribed from the three places that hold it now, each of which knows part
+# of the answer and none of which knows all of it:
+#   - stuttgart-things/helm cicd/crossplane*.yaml.gotmpl  (core, providers,
+#     functions, provider-configs, two base configurations)
+#   - stuttgart-things/ansible kind_machinery.yaml         (the platform and
+#     machinery Configuration lists, plus provider-clusterbook)
+#   - stuttgart-things/flux cicd/crossplane                (an older generation
+#     of the same list, pointing at ghcr.io/stuttgart-things/crossplane/*)
+#
+# Versions are as of 2026-08-15 and were read from those files, not remembered.
+
+machinery: s.Profile = {
+    crossplaneVersion = "2.3.3"
+    packages = [
+        # --- providers ------------------------------------------------------
+        # The long name is deliberate: it is what the package manager derives
+        # from the xpkg.crossplane.io path, so an explicit CR and a
+        # dependsOn-derived one collapse into one Lock node instead of two
+        # providers fighting over the same CRDs.
+        s.Package {
+            kind = "Provider"
+            name = "crossplane-contrib-provider-helm"
+            package = "xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.3.0"
+            clusterRole = "cluster-admin"
+        }
+        s.Package {
+            kind = "Provider"
+            name = "upbound-provider-opentofu"
+            package = "xpkg.upbound.io/upbound/provider-opentofu:v1.1.4"
+            clusterRole = "cluster-admin"
+        }
+        s.Package {
+            kind = "Provider"
+            name = "stuttgart-things-provider-kubeconfig-xpkg"
+            package = "ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:v0.13.1"
+        }
+        # Not pulled by anything: ip-reservation classes clusterbook as a
+        # cluster precondition rather than a package dependency, so without this
+        # entry `spec.ipReservation.enabled: true` has no controller behind it.
+        s.Package {
+            kind = "Provider"
+            name = "stuttgart-things-provider-clusterbook-xpkg"
+            package = "ghcr.io/stuttgart-things/provider-clusterbook-xpkg:v0.4.2"
+            providerCrd = "clusterproviderconfigs.clusterbook.stuttgart-things.com"
+        }
+        # provider-kubernetes is absent ON PURPOSE — every Configuration below
+        # pulls it, and naming it here would create the duplicate this catalog
+        # exists to prevent.
+
+        # --- functions ------------------------------------------------------
+        # SHORT names, always (root CLAUDE.md). apiVersion is not guessable from
+        # the name, hence stated.
+        s.Package {
+            kind = "Function"
+            name = "function-kcl"
+            # xpkg.upbound.io, NOT crossplane.io: our dependsOn entries use the
+            # crossplane.io path, and the package manager derives a long-named
+            # CR from it. Two nodes, two distinct sources — healthy. Aligning
+            # the mirrors gives two nodes with an IDENTICAL source and freezes
+            # the resolver for every package on the cluster.
+            package = "xpkg.upbound.io/crossplane-contrib/function-kcl:v0.12.1"
+            apiVersion = "pkg.crossplane.io/v1"
+        }
+        s.Package {
+            kind = "Function"
+            name = "function-auto-ready"
+            # <v0.7.0 is a hard ceiling: v0.7.0 makes Configurations report
+            # Unhealthy and the deploy-crossplane wait times out.
+            package = "xpkg.crossplane.io/crossplane-contrib/function-auto-ready:v0.6.5"
+            apiVersion = "pkg.crossplane.io/v1beta1"
+        }
+        s.Package {
+            kind = "Function"
+            name = "function-go-templating"
+            package = "xpkg.crossplane.io/crossplane-contrib/function-go-templating:v0.12.2"
+            apiVersion = "pkg.crossplane.io/v1beta1"
+        }
+        s.Package {
+            kind = "Function"
+            name = "function-environment-configs"
+            package = "xpkg.crossplane.io/crossplane-contrib/function-environment-configs:v0.7.2"
+            apiVersion = "pkg.crossplane.io/v1"
+        }
+        s.Package {
+            kind = "Function"
+            name = "function-patch-and-transform"
+            package = "xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.10.7"
+            apiVersion = "pkg.crossplane.io/v1beta1"
+        }
+
+        # --- configurations: ROOTS ONLY --------------------------------------
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-platform"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.11"
+            pulls = ["cni", "flux-init", "flux-apps", "ip-reservation", "vault-auth", "vault-pki-secrets"]
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-cluster"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.3"
+            pulls = ["platform", "remote-cluster", "vspherevm", "proxmoxvm", "ansible-run"]
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-vspherevm"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/vspherevm:v0.9.0"
+            providerCrd = "clusterproviderconfigs.vspherevm.m.stuttgart-things.com"
+            pulls = ["ansible-run"]
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-proxmoxvm"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/proxmoxvm:v0.11.0"
+            pulls = ["ansible-run"]
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-packer-build"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/packer-build:v0.4.1"
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-packer-release"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/packer-release:v0.4.2"
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-cluster-backup"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/cluster-backup:v0.1.0"
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-scheduled-run"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/scheduled-run:v0.1.1"
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-tofu-run"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/tofu-run:v0.1.0"
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-namespace"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/namespace:v0.1.2"
+        }
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-volume-claim"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/volume-claim:v0.1.0"
+        }
+    ]
+    # Point each provider at the cluster it runs on. No credentials: the
+    # provider's own ServiceAccount is the identity.
+    providerConfigs = [
+        s.ProviderConfig {
+            name = "in-cluster"
+            apiVersion = "helm.m.crossplane.io/v1beta1"
+            kind = "ClusterProviderConfig"
+            spec = {credentials = {source = "InjectedIdentity"}}
+        }
+        s.ProviderConfig {
+            name = "in-cluster"
+            apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+            kind = "ClusterProviderConfig"
+            spec = {credentials = {source = "InjectedIdentity"}}
+        }
+        # OpenTofu keeps its state in Secrets on this cluster, so a rebuilt
+        # control plane does not orphan what it provisioned.
+        s.ProviderConfig {
+            name = "in-cluster"
+            apiVersion = "opentofu.m.upbound.io/v1beta1"
+            kind = "ClusterProviderConfig"
+            spec = {
+                credentials = []
+                configuration = """terraform {
+  backend "kubernetes" {
+    secret_suffix     = "clusterproviderconfig-in-cluster"
+    namespace         = "crossplane-system"
+    in_cluster_config = true
+  }
+}
+"""
+            }
+        }
+    ]
+}

--- a/crossplane/xplane-crossplane-catalog/schema.k
+++ b/crossplane/xplane-crossplane-catalog/schema.k
@@ -1,0 +1,91 @@
+"""
+Structural definitions for the stuttgart-things Crossplane package catalog.
+
+The sibling of xplane-flux-catalog, for the layer below it: that one describes
+what a cluster OFFERS, this one describes what makes a cluster a MANAGEMENT
+cluster — Crossplane itself, its providers, functions and configurations.
+
+Same discipline, deliberately: STRUCTURAL facts only. Package identity and
+version live here because they are the same on every management cluster in this
+fleet. Anything environment-specific — capability chart values, credentials,
+per-datacentre placement — stays out, in the XR or an EnvironmentConfig, for the
+reason the flux catalog states: duplicating it here would guarantee drift.
+"""
+
+schema Package:
+    """One Crossplane package CR: a Provider, Function or Configuration."""
+    kind: "Provider" | "Function" | "Configuration"
+
+    name: str
+    """The CR's metadata.name. NOT cosmetic.
+
+    Providers and Configurations use the name Crossplane DERIVES from the
+    package path (see main.derivedName) — `crossplane-contrib-provider-helm`,
+    `stuttgart-things-crossplane-configurations-platform`. That is what makes an
+    explicit CR and a dependsOn-derived one the same Lock node instead of two.
+
+    Functions are the exception and must stay SHORT (`function-kcl`, never
+    `crossplane-contrib-function-kcl`), because Compositions name them in
+    `functionRef` — renaming one breaks every Composition that uses it. Functions
+    therefore keep a narrow exposure to the upgrade window described in
+    main.derivedName; there is no way around it that does not break functionRef.
+    """
+
+    package: str
+    """Full OCI reference INCLUDING the tag. Floating tags are rejected: a
+    management cluster that silently moves a provider forward is how a fleet
+    breaks overnight."""
+
+    apiVersion?: str
+    """Package API version, when it is not the default `pkg.crossplane.io/v1`.
+    Functions are split across v1 and v1beta1 upstream and it is not guessable
+    from the name — function-kcl and function-environment-configs are v1,
+    function-auto-ready and function-go-templating are v1beta1."""
+
+    pulls?: [str] = []
+    """Packages this one brings in transitively through its own dependsOn.
+
+    Documentation, not an exclusion list — with derived names an entry may be
+    both installed explicitly and pulled by another package, because the two
+    are the same Lock node. What it buys is an honest answer to "what is
+    actually on this cluster", and a check that a package named here really is
+    reachable, so the graph cannot rot unnoticed.
+
+    Declared rather than inferred because the catalog cannot read OCI metadata.
+    """
+
+    providerCrd?: str
+    """A CRD this package registers, worth waiting for before anything that
+    references it. Omit when the package registers nothing new."""
+
+    clusterRole?: str
+    """ClusterRole to bind the provider's ServiceAccount to. Only providers that
+    manage arbitrary cluster content need one."""
+
+    check:
+        ":" in package, "package must carry an explicit tag"
+        not package.endswith(":latest"), "package must not use a floating tag"
+
+schema ProviderConfig:
+    """A cluster-scoped ProviderConfig pointing a provider at its OWN cluster.
+
+    Every management cluster needs these and they carry no environment-specific
+    values — which is why they belong here and the per-datacentre ones (vSphere,
+    Proxmox, Vault) do not."""
+    name: str
+    apiVersion: str
+    kind: str
+    spec: {str:any}
+
+schema Profile:
+    """One kind of management cluster."""
+    crossplaneVersion: str
+    """Chart version of crossplane-stable/crossplane."""
+
+    namespace?: str = "crossplane-system"
+    packages: [Package]
+    providerConfigs?: [ProviderConfig] = []
+
+    check:
+        len(packages) > 0, "a profile installs at least one package"
+


### PR DESCRIPTION
Erster Hop von stuttgart-things/crossplane-configurations#258. Geschwister-Modul zu `xplane-flux-catalog`, eine Ebene tiefer: jenes beschreibt, was ein Cluster **anbietet**, dieses, was es **ist** — Crossplane, seine Provider, Functions und Configurations.

## Woher die Liste kommt

Sie existiert heute an drei Stellen, von denen keine sie ganz kennt:

| Repo | Datei | Anteil |
|---|---|---|
| `stuttgart-things/helm` | `cicd/crossplane*.gotmpl` | Core, Provider, Functions, Provider-Configs, 2 Configurations |
| `stuttgart-things/ansible` | `kind_machinery.yaml` | die platform- und machinery-Listen, provider-clusterbook |
| `stuttgart-things/flux` | `cicd/crossplane` | dieselbe Liste, eine Generation alt |

Abgeschrieben aus diesen Dateien, nicht aus dem Gedächtnis: **Crossplane 2.3.3, 4 Provider, 5 Functions, 11 Configurations, 3 in-cluster ProviderConfigs.**

## Was sich ändert — und warum es der Kern ist

Provider und Configurations tragen jetzt den Namen, den **Crossplane selbst ableitet** (`crossplane-contrib-provider-helm`, `stuttgart-things-crossplane-configurations-platform`), statt des kurzen aus dem Machinery-Play.

Der Resolver schlüsselt auf die **Quelle**, nicht den Namen — ein vorhandener Knoten erfüllt ein `dependsOn` also unabhängig davon, wie die CR heißt. Deshalb sehen Fleet-Cluster mit Kurznamen die meiste Zeit gesund aus. Gegen kind3 geprüft: 36 Pakete, **0 doppelte Quellen**, und `platform`s `dependsOn` auf `function-auto-ready` hat keine zweite CR erzeugt.

Das Fenster öffnet sich beim **Upgrade**: der Lock-Eintrag verschwindet kurz, der Resolver installiert die Abhängigkeit unter dem abgeleiteten Namen nach, und die zurückkehrende kurznamige CR kollidiert damit. Das ist crossplane-configurations#247 — auf u26-kind3 alle 20 Configurations auf `Healthy=False`, und das Aufräumen ist Whack-a-Mole.

**Mit dem abgeleiteten Namen gibt es kein Fenster**: die CR, die der Resolver anlegen würde, und die vorhandene sind dasselbe Objekt.

### Functions bleiben die Ausnahme

Sie behalten kurze Namen, weil Compositions sie über `functionRef` nennen — eine Umbenennung bräche jede Composition. Damit bleiben sie dem Fenster schmal ausgesetzt. Das ist dokumentiert statt behoben; eine Alternative, die `functionRef` nicht bricht, gibt es nicht.

## Der Test hat beim ersten Lauf einen echten Fehler gefunden

Nicht in diesem Modul: der Play installiert `platform`, `vspherevm` und `proxmoxvm` explizit, während `cluster` auf alle drei ein `dependsOn` deklariert. **Diese Konstellation ist auf jedem Machinery-Cluster heute scharf** und wartet auf das nächste Upgrade.

Bestehende Cluster umzubenennen ist nicht die Lösung — eine Configuration zu löschen nimmt ihre XRDs und damit ihre XRs mit. Die Umstellung gehört an das neue Management-Cluster aus #258, nicht an eine Migration.

## Invarianten

`kcl test` prüft die Regeln, statt dem nächsten Leser zu vertrauen, dass er sie kennt — 13/13 grün:

- jeder Provider und jede Configuration trägt den abgeleiteten Namen
- die Ableitung entspricht Crossplanes, für beide Pfadformen
- Function-Namen bleiben kurz; `function-kcl` bleibt auf dem anderen Mirror
- `function-auto-ready` bleibt unter v0.7.0
- jedes Paket pinnt einen Tag, keine floating tags
- `provider-kubernetes` wird nie explizit installiert
- ProviderConfigs sind ausschließlich `in-cluster`, ohne Credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL