### PR TITLE
feat(xplane-management-plane): install Crossplane and its packages (0.1.0)

### DIFF
--- a/crossplane/xplane-management-plane/README.md
+++ b/crossplane/xplane-management-plane/README.md
@@ -1,0 +1,97 @@
+# xplane-management-plane
+
+`function-kcl` module for the **management-plane** Crossplane Configuration.
+
+Turns a cluster into a *management* cluster: installs Crossplane on it, then the
+packages and provider configs that let it build other clusters.
+
+```
+1. helm.m.crossplane.io Release       the crossplane chart
+2. kubernetes.m.crossplane.io Object  one per Provider / Function / Configuration
+3. kubernetes.m.crossplane.io Object  one per in-cluster ProviderConfig
+```
+
+## What it installs is not in the XR
+
+The package set comes from
+[`xplane-crossplane-catalog`](../xplane-crossplane-catalog/), resolved through
+`spec.profile` (default `machinery`). It is a fleet fact, not a per-cluster
+choice, and it belongs where it can be version-controlled and tested — the
+catalog asserts the naming rule that keeps the
+[#247](https://github.com/stuttgart-things/crossplane-configurations/issues/247)
+Lock collision impossible.
+
+A cluster can still break out, per package:
+
+```yaml
+spec:
+  clusterName: mgmt-1
+  packageOverrides:
+    stuttgart-things-crossplane-configurations-platform:
+      ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.9
+```
+
+The override replaces the **whole reference**, not just the tag — deliberately.
+A tag-only override would silently keep the catalog's registry, and which mirror
+a package comes from is load-bearing here: `function-kcl` sits on
+`xpkg.upbound.io` precisely because our `dependsOn` entries use
+`xpkg.crossplane.io`.
+
+An override naming a package the profile does not carry is **rejected**. Doing
+nothing would leave the caller believing a version was pinned when it was not —
+and the key is the CR name, so `platform` is not the same thing as
+`stuttgart-things-crossplane-configurations-platform`.
+
+## Why not part of `platform`
+
+`platform` answers *what does this cluster offer*. Being a management cluster is
+a **role**, and the two have different lifetimes: a workload cluster's apps
+change weekly, its control plane does not.
+
+## The gates, and why they only open
+
+The install order is forced by CRDs rather than preference — the
+`pkg.crossplane.io` CRDs arrive *with* Crossplane, and each provider's
+`ProviderConfig` CRD arrives with that provider. Emitting everything at once
+still converges, because the Objects retry; what it costs is the ability to
+diagnose a failed bootstrap, since the real errors are buried under minutes of
+expected ones.
+
+So packages wait for the Crossplane Release, and provider configs wait for the
+packages.
+
+**Every gate is one-way.** Not emitting a composed resource is how Crossplane
+deletes it — a gate that closed again would tear the cluster down: a Crossplane
+Deployment briefly NotReady would uninstall the whole fleet's packages. Once a
+resource has been emitted it keeps being emitted, which the tests pin.
+
+## Status
+
+```yaml
+status:
+  ready: true
+  profile: machinery
+  crossplaneVersion: 2.3.3
+  components:
+    crossplane:      {ready: true, version: 2.3.3}
+    packages:        {total: 20, ready: 20}
+    providerConfigs: {total: 3, emitted: 3}
+  transitive: [ansible-run, cni, flux-apps, flux-init, ip-reservation, ...]
+```
+
+`transitive` is there because "which packages are on this cluster" cannot be
+answered from the spec: eleven of them arrive through some other package's
+`dependsOn` without ever being named.
+
+## Not yet covered
+
+Cluster-scoped **RBAC** — the `rbac.yaml` manifests from `remote-cluster` and
+`ip-reservation`, and the `cluster-admin` binding some providers need. The
+machinery play applies them from raw URLs today. Left out of 0.1.0 rather than
+guessed at: binding a provider's ServiceAccount by name is exactly the trap
+[crossplane-configurations#251](https://github.com/stuttgart-things/crossplane-configurations/issues/251)
+fixed (the name carries a generated hash), and the group-based alternative wants
+deciding, not inventing.
+
+Capability charts are also out, and stay out: their values are per-environment,
+which is the line this module and the catalog both hold.

--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,0 +1,7 @@
+[package]
+name = "xplane-management-plane"
+edition = "v0.12.3"
+version = "0.1.0"
+
+[dependencies]
+xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-management-plane/kcl.mod.lock
+++ b/crossplane/xplane-management-plane/kcl.mod.lock
@@ -1,0 +1,9 @@
+[dependencies]
+  [dependencies.xplane-crossplane-catalog]
+    name = "xplane-crossplane-catalog"
+    full_name = "xplane-crossplane-catalog_0.1.0"
+    version = "0.1.0"
+    sum = "u1HuyWz3a7crMSuiYPaRpBQQHyFStfxSxuiEkKHYTk4="
+    reg = "ghcr.io"
+    repo = "stuttgart-things/xplane-crossplane-catalog"
+    oci_tag = "0.1.0"

--- a/crossplane/xplane-management-plane/logic.k
+++ b/crossplane/xplane-management-plane/logic.k
@@ -1,0 +1,118 @@
+"""
+Decision logic for the management-plane Configuration.
+
+Separated from main.k so it can be unit-tested without Crossplane: what the
+profile resolves to, which packages an override moves, and — the part worth
+testing hardest — the gates. A management cluster is built in an order that
+cannot be expressed by Object dependencies, because the CRDs the later objects
+need are installed by the earlier ones.
+"""
+
+import xplane_crossplane_catalog as cat
+import xplane_crossplane_catalog.schema as cs
+
+# --- provider config refs --------------------------------------------------
+# Same derivation as flux-init and cni: {clusterName}-helm / -kubernetes are the
+# names provider-kubeconfig's RemoteCluster creates for a target cluster.
+helmRef = lambda spec: {str:} -> str {
+    _c = spec?.clusterName or ""
+    spec?.helmProviderConfigRef or ("{}-helm".format(_c) if _c else "")
+}
+
+kubernetesRef = lambda spec: {str:} -> str {
+    _c = spec?.clusterName or ""
+    spec?.kubernetesProviderConfigRef or ("{}-kubernetes".format(_c) if _c else "")
+}
+
+# --- profile resolution ----------------------------------------------------
+profileName = lambda spec: {str:} -> str {
+    spec?.profile or "machinery"
+}
+
+profile = lambda spec: {str:} -> cs.Profile {
+    cat.get(profileName(spec))
+}
+
+crossplaneVersion = lambda spec: {str:} -> str {
+    """spec wins over the profile: a cluster may need to sit on an older core
+    while a catalog release moves the fleet forward."""
+    spec?.crossplaneVersion or profile(spec).crossplaneVersion
+}
+
+targetNamespace = lambda spec: {str:} -> str {
+    spec?.namespace or profile(spec).namespace
+}
+
+# --- package overrides -----------------------------------------------------
+# A map of CR name -> full package reference. Deliberately the WHOLE reference
+# and not just a tag: an override that only swapped the tag would silently keep
+# the catalog's registry, and the mirror a package comes from is load-bearing
+# here (see the catalog's README on function-kcl).
+packages = lambda spec: {str:} -> [cs.Package] {
+    _over = spec?.packageOverrides or {}
+    [cs.Package {
+        kind = p.kind
+        name = p.name
+        package = _over[p.name] or p.package
+        apiVersion = p.apiVersion
+        pulls = p.pulls
+        providerCrd = p.providerCrd
+        clusterRole = p.clusterRole
+    } for p in profile(spec).packages]
+}
+
+# An override naming a package the profile does not carry is a typo that would
+# otherwise do nothing at all — the caller believes a version was pinned and it
+# was not.
+unknownOverrides = lambda spec: {str:} -> [str] {
+    _named = {p.name: "" for p in profile(spec).packages}
+    sorted([k for k in (spec?.packageOverrides or {}) if k not in _named])
+}
+
+# The package CR's apiVersion. Functions are split across v1 and v1beta1
+# upstream and it is not guessable from the name, so the catalog states it;
+# everything else is v1.
+packageApiVersion = lambda p: cs.Package -> str {
+    p.apiVersion or "pkg.crossplane.io/v1"
+}
+
+# --- gates -----------------------------------------------------------------
+# The order is forced by CRDs, not by preference: the pkg.crossplane.io CRDs
+# arrive WITH Crossplane, and each provider's ProviderConfig CRD arrives with
+# that provider. Emitting everything at once still converges — the Objects
+# retry — but it buries the real errors of a broken build under minutes of
+# expected ones, which is how a failed bootstrap gets diagnosed as healthy.
+#
+# Every gate is ONE-WAY: once a resource exists it keeps being emitted. Not
+# emitting a composed resource is how Crossplane deletes it, so a gate that
+# closed again would tear down what it just built.
+packagesOpen = lambda coreReady: bool, existing: int -> bool {
+    coreReady or existing > 0
+}
+
+providerConfigsOpen = lambda packagesReady: bool, existing: int -> bool {
+    packagesReady or existing > 0
+}
+
+# --- validation ------------------------------------------------------------
+validate = lambda spec: {str:} -> bool {
+    """Rules that must hold before anything is emitted.
+
+    Vacuously true on an empty spec: that is the module being evaluated with no
+    XR at all (unit tests, bare `kcl run`), not a misconfigured one. Same
+    convention as xplane-cni.
+    """
+    _empty = not spec
+    _unknown = unknownOverrides(spec)
+    assert _empty or helmRef(spec) != "", "clusterName or helmProviderConfigRef must be set"
+    assert _empty or kubernetesRef(spec) != "", "clusterName or kubernetesProviderConfigRef must be set"
+    assert _unknown == [], "packageOverrides name packages this profile does not carry"
+    True
+}
+
+# What arrives on the cluster without being installed by name. Surfaced on the
+# status because "which packages are on this cluster" is not answerable from the
+# spec: two thirds of them come through some other package's dependsOn.
+transitivePackages = lambda spec: {str:} -> [str] {
+    cat.transitive(profile(spec))
+}

--- a/crossplane/xplane-management-plane/logic_test.k
+++ b/crossplane/xplane-management-plane/logic_test.k
@@ -1,0 +1,95 @@
+# Unit tests for the management-plane logic. `kcl test`.
+# These are the rules that would otherwise only be observable on a live cluster.
+import .logic as l
+
+_min = {clusterName = "mgmt-1"}
+
+test_refs_derive_from_cluster_name = lambda {
+    assert l.helmRef(_min) == "mgmt-1-helm"
+    assert l.kubernetesRef(_min) == "mgmt-1-kubernetes"
+}
+
+test_explicit_refs_win = lambda {
+    _s = {clusterName = "mgmt-1", helmProviderConfigRef = "other-helm"}
+    assert l.helmRef(_s) == "other-helm"
+    assert l.kubernetesRef(_s) == "mgmt-1-kubernetes", "the other ref still derives"
+}
+
+test_profile_defaults_to_machinery = lambda {
+    assert l.profileName({}) == "machinery"
+    assert l.profileName({profile = "machinery"}) == "machinery"
+}
+
+# The catalog carries the fleet's version; an XR may sit behind it. A cluster
+# mid-incident must be able to stay on an older core while the catalog moves.
+test_crossplane_version_can_be_overridden = lambda {
+    assert l.crossplaneVersion(_min) == "2.3.3"
+    assert l.crossplaneVersion({clusterName = "c", crossplaneVersion = "2.2.1"}) == "2.2.1"
+}
+
+test_namespace_defaults_from_the_profile = lambda {
+    assert l.targetNamespace(_min) == "crossplane-system"
+    assert l.targetNamespace({clusterName = "c", namespace = "xp"}) == "xp"
+}
+
+# An override replaces the WHOLE reference, not just the tag: the registry a
+# package comes from is load-bearing (function-kcl lives on the other mirror on
+# purpose), so a tag-only override would silently keep the catalog's registry.
+test_package_override_replaces_the_whole_reference = lambda {
+    _s = {clusterName = "c", packageOverrides = {
+        "stuttgart-things-crossplane-configurations-platform" = "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.9"
+    }}
+    _p = [x for x in l.packages(_s) if x.name == "stuttgart-things-crossplane-configurations-platform"][0]
+    assert _p.package.endswith(":v0.3.9")
+    _untouched = [x for x in l.packages(_s) if x.name == "function-kcl"][0]
+    assert _untouched.package.startswith("xpkg.upbound.io/")
+}
+
+# An override naming a package the profile does not carry does nothing at all —
+# the caller believes a version is pinned and it is not. Rejected instead.
+test_unknown_override_is_rejected = lambda {
+    _s = {clusterName = "c", packageOverrides = {"platform" = "ghcr.io/x/platform:v1"}}
+    assert l.unknownOverrides(_s) == ["platform"], "the short name is NOT the CR name here"
+    assert l.unknownOverrides(_min) == []
+}
+
+test_package_api_version_defaults_to_v1 = lambda {
+    _pkgs = l.packages(_min)
+    _cfg = [p for p in _pkgs if p.kind == "Configuration"][0]
+    assert l.packageApiVersion(_cfg) == "pkg.crossplane.io/v1"
+    _ar = [p for p in _pkgs if p.name == "function-auto-ready"][0]
+    assert l.packageApiVersion(_ar) == "pkg.crossplane.io/v1beta1", "functions are split across v1 and v1beta1"
+}
+
+# The gates exist because the CRDs the later objects need are installed by the
+# earlier ones. Emitting everything at once still converges, but buries the real
+# errors of a broken build under minutes of expected ones.
+test_gates_wait_for_the_stage_below = lambda {
+    assert not l.packagesOpen(False, 0), "no packages before Crossplane is up"
+    assert l.packagesOpen(True, 0)
+    assert not l.providerConfigsOpen(False, 0), "no provider configs before the providers exist"
+    assert l.providerConfigsOpen(True, 0)
+}
+
+# EVERY gate is one-way. Not emitting a composed resource is how Crossplane
+# deletes it, so a gate that closed again would tear down what it just built —
+# a Crossplane deployment briefly NotReady would uninstall the whole fleet's
+# packages.
+test_gates_never_close_again = lambda {
+    assert l.packagesOpen(False, 3), "already-emitted packages keep being emitted"
+    assert l.providerConfigsOpen(False, 1)
+}
+
+# Two thirds of what ends up on the cluster is never named. Surfaced so the
+# status can answer "what is actually installed here".
+test_transitive_packages_are_reported = lambda {
+    _t = l.transitivePackages(_min)
+    assert "ansible-run" in _t
+    assert "flux-apps" in _t
+    assert len(_t) >= 6
+}
+
+test_validate_requires_a_target = lambda {
+    assert l.validate(_min)
+    assert l.helmRef({}) == "", "nothing to derive from, so validate would reject it"
+}

--- a/crossplane/xplane-management-plane/main.k
+++ b/crossplane/xplane-management-plane/main.k
@@ -1,0 +1,199 @@
+"""
+xplane-management-plane — function-kcl module for the management-plane Configuration.
+
+Turns a cluster into a MANAGEMENT cluster: installs Crossplane on it, then the
+packages and provider configs that let it build other clusters. What it installs
+comes from xplane-crossplane-catalog, not from this XR — the package set is a
+fleet fact and belongs where it can be version-controlled and tested.
+
+  1. helm.m.crossplane.io Release      — the crossplane chart
+  2. kubernetes.m.crossplane.io Object — one per Provider / Function / Configuration
+  3. kubernetes.m.crossplane.io Object — one per in-cluster ProviderConfig
+
+Render and status happen in a single pass: the module emits the managed
+resources AND patches the XR status from `ocds`. On the first reconcile `ocds`
+is empty, so status.ready starts False and converges.
+
+This is deliberately NOT part of `platform`. platform answers "what does this
+cluster offer"; being a management cluster is a ROLE, and the two have different
+lifetimes — a workload cluster's apps change weekly, its control plane does not.
+
+All decision logic lives in logic.k so it is unit-testable without Crossplane;
+this file only marshals option("params") in and `items` out.
+"""
+
+import .logic as l
+
+_params = option("params") or {}
+_oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
+
+_spec = _oxr?.spec or {}
+_meta = _oxr?.metadata or {}
+_name = _meta?.name or "management-plane"
+_xrNs = _meta?.namespace
+
+_valid = l.validate(_spec)
+
+_helmPcr = l.helmRef(_spec)
+_k8sPcr = l.kubernetesRef(_spec)
+_ns = l.targetNamespace(_spec)
+_packages = l.packages(_spec)
+_profile = l.profile(_spec)
+
+# --- observed children ------------------------------------------------------
+_byName = lambda name: str -> [any] {
+    [v.Resource for _, v in _ocds if v?.Resource?.metadata?.name == name]
+}
+_isReady = lambda res: any -> bool {
+    len([c for c in (res?.status?.conditions or []) if c?.type == "Ready" and c?.status == "True"]) > 0
+}
+
+_coreName = "{}-crossplane".format(_name)
+_coreObs = _byName(_coreName)
+_coreReady = len(_coreObs) > 0 and _isReady(_coreObs[0])
+
+_pkgName = lambda p -> str {
+    "{}-pkg-{}".format(_name, p.name)
+}
+_pkgObs = [x for p in _packages for x in _byName(_pkgName(p))]
+_pkgReady = len(_pkgObs) == len(_packages) and len([x for x in _pkgObs if _isReady(x)]) == len(_packages)
+
+_pcName = lambda i: int, pc -> str {
+    "{}-pc-{}".format(_name, i)
+}
+_pcObs = [x for i, pc in _profile.providerConfigs for x in _byName(_pcName(i, pc))]
+
+# --- gates ------------------------------------------------------------------
+_pkgOpen = l.packagesOpen(_coreReady, len(_pkgObs))
+_pcOpen = l.providerConfigsOpen(_pkgReady, len(_pcObs))
+
+# --- 1) Crossplane core -----------------------------------------------------
+_core = {
+    apiVersion = "helm.m.crossplane.io/v1beta1"
+    kind = "Release"
+    metadata = {
+        name = _coreName
+        namespace = _xrNs
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = _coreName
+        }
+    }
+    spec = {
+        forProvider = {
+            chart = {
+                name = "crossplane"
+                repository = "https://charts.crossplane.io/stable"
+                version = l.crossplaneVersion(_spec)
+            }
+            namespace = _ns
+            skipCreateNamespace = False
+            wait = True
+        }
+        providerConfigRef = {
+            name = _helmPcr
+            kind = "ClusterProviderConfig"
+        }
+    }
+}
+
+# --- 2) packages ------------------------------------------------------------
+# The CR name comes from the catalog, which derives it the way Crossplane does.
+# It is the whole reason this Configuration can be upgraded without the Lock
+# collision that #247 describes.
+_packageObject = lambda p -> any {
+    {
+        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+        kind = "Object"
+        metadata = {
+            name = _pkgName(p)
+            namespace = _xrNs
+            annotations = {
+                "krm.kcl.dev/composition-resource-name" = _pkgName(p)
+                "crossplane.io/uses" = _coreName
+            }
+        }
+        spec = {
+            forProvider = {
+                manifest = {
+                    apiVersion = l.packageApiVersion(p)
+                    kind = p.kind
+                    metadata = {
+                        name = p.name
+                    }
+                    spec = {
+                        package = p.package
+                    }
+                }
+            }
+            providerConfigRef = {
+                name = _k8sPcr
+                kind = "ClusterProviderConfig"
+            }
+        }
+    }
+}
+
+# --- 3) in-cluster provider configs ----------------------------------------
+_providerConfigObject = lambda i: int, pc -> any {
+    {
+        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+        kind = "Object"
+        metadata = {
+            name = _pcName(i, pc)
+            namespace = _xrNs
+            annotations = {
+                "krm.kcl.dev/composition-resource-name" = _pcName(i, pc)
+            }
+        }
+        spec = {
+            forProvider = {
+                manifest = {
+                    apiVersion = pc.apiVersion
+                    kind = pc.kind
+                    metadata = {
+                        name = pc.name
+                    }
+                    spec = pc.spec
+                }
+            }
+            providerConfigRef = {
+                name = _k8sPcr
+                kind = "ClusterProviderConfig"
+            }
+        }
+    }
+}
+
+_status = {
+    apiVersion = _oxr?.apiVersion
+    kind = _oxr?.kind
+    metadata = {
+        name = _name
+        namespace = _xrNs
+    }
+    status = {
+        ready = _coreReady and _pkgReady
+        profile = l.profileName(_spec)
+        crossplaneVersion = l.crossplaneVersion(_spec)
+        components = {
+            crossplane = {
+                ready = _coreReady
+                version = l.crossplaneVersion(_spec)
+            }
+            packages = {
+                total = len(_packages)
+                ready = len([x for x in _pkgObs if _isReady(x)])
+            }
+            providerConfigs = {
+                total = len(_profile.providerConfigs)
+                emitted = len(_pcObs)
+            }
+        }
+        # What arrives without being installed. Stated because "which packages
+        # are on this cluster" cannot be answered from the spec alone.
+        transitive = l.transitivePackages(_spec)
+    }
+}
+
+items = [_core] + ([_packageObject(p) for p in _packages] if _pkgOpen else []) + ([_providerConfigObject(i, pc) for i, pc in _profile.providerConfigs] if _pcOpen else []) + [_status]


### PR DESCRIPTION
Zweiter Hop von stuttgart-things/crossplane-configurations#258. Das Modul emittiert gegen einen Ziel-Cluster, was ihn zum **Management-Cluster** macht:

```
1. helm Release        das crossplane-Chart
2. Object je Paket     Provider / Function / Configuration aus dem Katalog
3. Object je Config    die in-cluster ProviderConfigs
```

## Was installiert wird, steht nicht im XR

Die Paketliste kommt aus `xplane-crossplane-catalog` über `spec.profile` (Default `machinery`). Sie ist ein Fleet-Fakt, kein Cluster-Detail — und der Katalog ist der Ort, an dem die Namensregel **geprüft** statt gehofft wird.

Ausbrechen geht trotzdem, pro Paket:

```yaml
spec:
  clusterName: mgmt-1
  packageOverrides:
    stuttgart-things-crossplane-configurations-platform:
      ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.9
```

Der Override ersetzt die **ganze Referenz**, nicht nur den Tag — absichtlich. Ein Tag-Override behielte still die Registry des Katalogs, und welcher Mirror ein Paket liefert, ist hier tragend: `function-kcl` liegt auf `xpkg.upbound.io`, gerade weil unsere `dependsOn` auf `xpkg.crossplane.io` zeigen.

Ein Override, der ein Paket nennt, das das Profil nicht führt, wird **abgelehnt**. Nichts zu tun ließe den Aufrufer glauben, eine Version sei gepinnt — und der Schlüssel ist der CR-Name, `platform` ist also nicht dasselbe wie `stuttgart-things-crossplane-configurations-platform`.

## Die Gates

Die Reihenfolge erzwingen die CRDs, nicht der Geschmack: die `pkg.crossplane.io`-CRDs kommen **mit** Crossplane, jede `ProviderConfig`-CRD mit ihrem Provider. Alles auf einmal zu emittieren konvergiert zwar — die Objects wiederholen —, kostet aber die Diagnostizierbarkeit: die echten Fehler eines kaputten Bootstraps verschwinden unter minutenlang erwarteten.

**Jedes Gate ist einwegig**, und die Tests halten das fest. Eine komponierte Ressource *nicht* zu emittieren ist die Art, wie Crossplane sie löscht — ein Gate, das wieder zuginge, würde den Cluster abreißen: ein kurz `NotReady` gemeldetes Crossplane-Deployment würde die Pakete der ganzen Fleet deinstallieren.

## Geprüft

Durch Rendern, nicht durch Zusehen:

- erster Durchgang → nur der Release, Gate zu
- mit `Ready` am Release → 20 Paket-Objects unter den abgeleiteten CR-Namen
- 12/12 Unit-Tests

## Bewusst noch nicht drin

**RBAC** — die `rbac.yaml` aus `remote-cluster` und `ip-reservation` sowie die `cluster-admin`-Bindung mancher Provider. Der Play holt sie heute von Roh-URLs. Weggelassen statt geraten: eine Provider-ServiceAccount **beim Namen** zu binden ist genau die Falle, die crossplane-configurations#251 behoben hat (der Name trägt einen generierten Hash), und die Gruppen-Variante will entschieden, nicht erfunden werden.

Capability-Charts bleiben draußen und sollen es bleiben: ihre Werte sind umgebungsspezifisch — die Linie, die Modul und Katalog beide halten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL