### PR TITLE
feat(xplane-management-plane): grant the provider group cluster-admin (0.2.0)

### DIFF
--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-management-plane"
 edition = "v0.12.3"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-management-plane/logic.k
+++ b/crossplane/xplane-management-plane/logic.k
@@ -116,3 +116,24 @@ validate = lambda spec: {str:} -> bool {
 transitivePackages = lambda spec: {str:} -> [str] {
     cat.transitive(profile(spec))
 }
+
+# --- RBAC -------------------------------------------------------------------
+# Crossplane's providers run as ServiceAccounts in crossplane-system with
+# per-revision generated names, so binding one BY NAME is the trap #251 fixed:
+# the name carries a hash and the binding silently applies to nothing. The
+# group `system:serviceaccounts:crossplane-system` is the stable subject.
+#
+# cluster-admin, and on purpose. On a MANAGEMENT cluster the providers create
+# arbitrary cluster content by definition — that is the job. The narrower
+# ClusterRoles the machinery play fetches from raw URLs
+# (provider-kubernetes-remote-cluster, provider-kubernetes-ip-reservation) bind
+# the SAME group, so this subsumes both and they stop being a precondition.
+#
+# Default on: a management cluster without it has every XRD and can reconcile
+# none of them, which presents as a hang rather than an error. Turn it off only
+# if something else grants the equivalent.
+clusterAdminEnabled = lambda spec: {str:} -> bool {
+    spec?.clusterAdminRbac if "clusterAdminRbac" in spec else True
+}
+
+rbacSubjectGroup = "system:serviceaccounts:crossplane-system"

--- a/crossplane/xplane-management-plane/logic_test.k
+++ b/crossplane/xplane-management-plane/logic_test.k
@@ -93,3 +93,18 @@ test_validate_requires_a_target = lambda {
     assert l.validate(_min)
     assert l.helmRef({}) == "", "nothing to derive from, so validate would reject it"
 }
+
+# Binding a provider ServiceAccount BY NAME is the trap #251 fixed — the name
+# carries a per-revision hash, so the binding silently applies to nothing. The
+# group is the stable subject.
+test_rbac_binds_the_group_not_a_service_account = lambda {
+    assert l.rbacSubjectGroup == "system:serviceaccounts:crossplane-system"
+}
+
+# On by default: a management cluster without it has every XRD and can
+# reconcile none of them, which presents as a hang rather than an error.
+test_cluster_admin_rbac_defaults_on = lambda {
+    assert l.clusterAdminEnabled({})
+    assert l.clusterAdminEnabled({clusterName = "c"})
+    assert not l.clusterAdminEnabled({clusterName = "c", clusterAdminRbac = False})
+}

--- a/crossplane/xplane-management-plane/main.k
+++ b/crossplane/xplane-management-plane/main.k
@@ -165,6 +165,50 @@ _providerConfigObject = lambda i: int, pc -> any {
     }
 }
 
+# --- RBAC -------------------------------------------------------------------
+# Emitted alongside the Release, not behind a gate: rbac.authorization.k8s.io is
+# a built-in group, so unlike everything else here it needs no CRD to exist
+# first. Emitting it early also means the providers have their permissions
+# before their first reconcile rather than after a failed one.
+_rbacName = "{}-rbac".format(_name)
+
+_rbac = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {
+        name = _rbacName
+        namespace = _xrNs
+        annotations = {
+            "krm.kcl.dev/composition-resource-name" = _rbacName
+        }
+    }
+    spec = {
+        forProvider = {
+            manifest = {
+                apiVersion = "rbac.authorization.k8s.io/v1"
+                kind = "ClusterRoleBinding"
+                metadata = {
+                    name = "crossplane-providers-cluster-admin"
+                }
+                roleRef = {
+                    apiGroup = "rbac.authorization.k8s.io"
+                    kind = "ClusterRole"
+                    name = "cluster-admin"
+                }
+                subjects = [{
+                    kind = "Group"
+                    apiGroup = "rbac.authorization.k8s.io"
+                    name = l.rbacSubjectGroup
+                }]
+            }
+        }
+        providerConfigRef = {
+            name = _k8sPcr
+            kind = "ClusterProviderConfig"
+        }
+    }
+}
+
 _status = {
     apiVersion = _oxr?.apiVersion
     kind = _oxr?.kind
@@ -189,6 +233,9 @@ _status = {
                 total = len(_profile.providerConfigs)
                 emitted = len(_pcObs)
             }
+            rbac = {
+                clusterAdmin = l.clusterAdminEnabled(_spec)
+            }
         }
         # What arrives without being installed. Stated because "which packages
         # are on this cluster" cannot be answered from the spec alone.
@@ -196,4 +243,4 @@ _status = {
     }
 }
 
-items = [_core] + ([_packageObject(p) for p in _packages] if _pkgOpen else []) + ([_providerConfigObject(i, pc) for i, pc in _profile.providerConfigs] if _pcOpen else []) + [_status]
+items = [_core] + ([_rbac] if l.clusterAdminEnabled(_spec) else []) + ([_packageObject(p) for p in _packages] if _pkgOpen else []) + ([_providerConfigObject(i, pc) for i, pc in _profile.providerConfigs] if _pcOpen else []) + [_status]


### PR DESCRIPTION
Die Lücke, die der erste Live-Lauf offengelassen hat: der Zielcluster hatte **alle XRDs und konnte keines davon reconcilen**, weil Crossplanes Provider keine Rechte über ihr eigenes Paket hinaus hatten. Das äußert sich als Hänger, nicht als Fehler.

Emittiert wird **ein** ClusterRoleBinding: Gruppe `system:serviceaccounts:crossplane-system` → `cluster-admin`.

## Die Gruppe, nicht eine ServiceAccount

Crossplanes Provider-SAs tragen einen pro Revision generierten Namen. Eine davon **beim Namen** zu binden ist genau die Falle, die crossplane-configurations#251 behoben hat: die Bindung greift still ins Leere, und da RBAC Subjects nicht validiert, sieht es aus, als hätte es funktioniert.

## cluster-admin, mit Absicht

Auf einem Management-Cluster erzeugen die Provider beliebige Cluster-Inhalte — das *ist* die Aufgabe. Die beiden engeren ClusterRoles, die der Machinery-Play von Roh-URLs holt (`provider-kubernetes-remote-cluster`, `provider-kubernetes-ip-reservation`), binden **dieselbe Gruppe**. Diese eine Bindung subsumiert also beide: sie sind keine Voraussetzung mehr, und das Nachladen von Roh-URLs entfällt.

## Ohne Gate

`rbac.authorization.k8s.io` ist eingebaut — anders als alles andere hier braucht es keine CRD. Deshalb wird die Bindung **neben** dem Release emittiert, und die Provider haben ihre Rechte vor dem ersten Reconcile statt nach einem gescheiterten.

## Abschaltbar, aber kein Härtungsknopf

`spec.clusterAdminRbac: false` lässt sie weg. Das ist für einen Cluster gedacht, auf dem etwas anderes das Äquivalent gewährt — nicht zum Härten: was es entfernt, ist die Funktionsfähigkeit.

14/14 Tests, Rauchtest gerendert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL