### PR TITLE
feat(xplane-cluster): compose a ManagementPlane child (0.6.0)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -360,6 +360,33 @@ platformChild = lambda name: str, ns: str, spec: {str:any}, apiEndpoint: str -> 
     }
 }
 
+# A ManagementPlane child, for a cluster that is meant to BUILD clusters rather
+# than run workloads. Same passthrough shape as platformChild: whatever the user
+# puts under spec.managementPlane reaches the child verbatim, and this
+# Composition supplies only clusterName — which it knows and the user should not
+# have to repeat.
+#
+# NOT filtered for `enabled`: that lives on spec.managementPlaneEnabled, a
+# sibling, for the same reason platformEnabled is one. A preserve-unknown-fields
+# block that also declares known properties makes schema converters emit
+# additionalProperties:false and reject every passthrough key.
+managementPlaneChild = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
+    _cluster = spec?.clusterName or name
+    _passthrough = {k: v for k, v in (spec?.managementPlane or {}) if k != "clusterName"}
+    {
+        apiVersion = "config.stuttgart-things.com/v1alpha1"
+        kind = "ManagementPlane"
+        metadata = {
+            name = "{}-management-plane".format(name)
+            namespace = ns
+            annotations = {"krm.kcl.dev/composition-resource-name" = "management-plane"}
+        }
+        spec = _passthrough | {
+            clusterName = _cluster
+        }
+    }
+}
+
 # --- teardown ordering -----------------------------------------------------
 
 # `of` is what must die LAST, `by` is the user. replayDeletion re-issues the

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -443,3 +443,31 @@ test_platform_domain_absent_is_empty = lambda {
         }
     }) == ""
 }
+
+# The ManagementPlane child passes through verbatim and gets only clusterName
+# added — the one thing this Composition knows and the user should not repeat.
+test_management_plane_child_passes_through = lambda {
+    _spec = {clusterName = "mgmt-1", managementPlane = {profile = "machinery", clusterAdminRbac = True}}
+    _c = l.managementPlaneChild("stack-1", "default", _spec)
+    assert _c.kind == "ManagementPlane"
+    assert _c.metadata.name == "stack-1-management-plane"
+    assert _c.metadata.namespace == "default"
+    assert _c.spec.profile == "machinery", "arbitrary keys reach the child untouched"
+    assert _c.spec.clusterAdminRbac
+    assert _c.spec.clusterName == "mgmt-1"
+}
+
+# clusterName falls back to the stack's own name, matching platformChild.
+test_management_plane_child_defaults_cluster_name = lambda {
+    _c = l.managementPlaneChild("stack-1", "default", {})
+    assert _c.spec.clusterName == "stack-1"
+}
+
+# A clusterName inside the passthrough block must not win over the Composition's
+# — it is the one field this layer owns, and two sources would let a child point
+# at a different cluster than the stack that built it.
+test_management_plane_child_ignores_a_passed_cluster_name = lambda {
+    _spec = {clusterName = "right", managementPlane = {clusterName = "wrong"}}
+    _c = l.managementPlaneChild("stack-1", "default", _spec)
+    assert _c.spec.clusterName == "right"
+}

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -49,6 +49,12 @@ _supported = cat.assertSizeSupported(_spec?.distribution or "k3s", _spec?.size o
 # additionalProperties:false and reject every passthrough key.
 _platformEnabled = _spec?.platformEnabled if "platformEnabled" in _spec else True
 
+# Default OFF, unlike platformEnabled. Most ClusterStacks build WORKLOAD
+# clusters; a control plane is the exception, and installing Crossplane plus the
+# fleet's twenty packages on a machine that did not ask for it is not a default
+# anyone wants to discover.
+_mgmtEnabled = _spec?.managementPlaneEnabled if "managementPlaneEnabled" in _spec else False
+
 # --- observed children -----------------------------------------------------
 _byKind = lambda kind: str -> [any] {
     [v.Resource for _, v in _ocds if v?.Resource?.kind == kind]
@@ -83,6 +89,10 @@ _access = _accessObs[0] if _accessObs else {}
 _accessReady = _access?.status?.ready or False
 _accessShare = _access?.status?.share or {}
 
+_mgmtObs = _byKind("ManagementPlane")
+_mgmt = _mgmtObs[0] if _mgmtObs else {}
+_mgmtReady = len([c for c in (_mgmt?.status?.conditions or []) if c?.type == "Ready" and c?.status == "True"]) > 0
+
 _platObs = _byKind("Platform")
 _plat = _platObs[0] if _platObs else {}
 _platReady = len([c for c in (_plat?.status?.conditions or []) if c?.type == "Ready" and c?.status == "True"]) > 0
@@ -100,6 +110,11 @@ _distOpen = (_vmReady and _vmIP != "" and _baseosOk) or len(_distObs) > 0
 _kcOpen = (_distOk and _vmIP != "") or len(_kcObs) > 0
 _accessOpen = _kcOk or len(_accessObs) > 0
 _platOpen = _platformEnabled and (_accessReady or len(_platObs) > 0)
+
+# Gated on ClusterAccess, the same as the Platform child and for the same
+# reason: both need only the ClusterProviderConfigs, and neither needs the
+# other. They install in parallel — Crossplane and Flux do not contend.
+_mgmtOpen = _mgmtEnabled and (_accessReady or len(_mgmtObs) > 0)
 
 # Verbatim re-emission for the ansible children (see the module docstring).
 _reemit = lambda prev: any, stage: str -> {str:any} {
@@ -178,13 +193,25 @@ _usageGroups = [
     [l.usage("ClusterAccess", "{}-access".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-access", True)] if (_platOpen and _accessOpen) else []
     [l.usage(_vmKind, "{}-vm".format(_name), "ClusterAccess", "{}-access".format(_name), "access-uses-vm", True)] if _accessOpen else []
     [l.usage("ClusterStack", _name, "Platform", "{}-platform".format(_name), "stack-uses-platform", False)] if _platOpen else []
+    # The ManagementPlane needs the same three guards as the Platform, and for
+    # the same reasons: it applies everything it owns THROUGH the VM and the
+    # ClusterAccess, so losing either first leaves its Objects hanging against a
+    # cluster that is gone.
+    [l.usage(_vmKind, "{}-vm".format(_name), "ManagementPlane", "{}-management-plane".format(_name), "mgmt-uses-vm", True)] if _mgmtOpen else []
+    [l.usage("ClusterAccess", "{}-access".format(_name), "ManagementPlane", "{}-management-plane".format(_name), "mgmt-uses-access", True)] if (_mgmtOpen and _accessOpen) else []
+    [l.usage("ClusterStack", _name, "ManagementPlane", "{}-management-plane".format(_name), "stack-uses-mgmt", False)] if _mgmtOpen else []
 ]
 _usages = sum(_usageGroups, [])
 
 # --- status ----------------------------------------------------------------
 
 # The one field to look at when a build is stuck.
-_stage = "ready" if (_platReady or (not _platformEnabled and _accessReady)) else ("platform" if _platOpen else ("access" if _accessOpen else ("kubeconfig" if _kcOpen else ("distribution" if _distOpen else ("baseos" if (_vmReady and _vmIP != "") else "vm")))))
+# A disabled component is DONE, not pending — otherwise a stack that only wants
+# a reachable machine would never report ready.
+_platDone = _platReady or (not _platformEnabled and _accessReady)
+_mgmtDone = _mgmtReady or not _mgmtEnabled
+
+_stage = "ready" if (_platDone and _mgmtDone) else ("platform" if (_platOpen and not _platDone) else ("management-plane" if _mgmtOpen else ("access" if _accessOpen else ("kubeconfig" if _kcOpen else ("distribution" if _distOpen else ("baseos" if (_vmReady and _vmIP != "") else "vm"))))))
 
 _dxr = _params?.dxr or {}
 _dxrPatched = _dxr | {
@@ -212,6 +239,7 @@ _dxrPatched = _dxr | {
             kubeconfig = {succeeded = _kcOk, emitted = _kcOpen}
             access = {ready = _accessReady, emitted = _accessOpen}
             platform = {ready = _platReady, emitted = _platOpen}
+            managementPlane = {ready = _mgmtReady, emitted = _mgmtOpen}
         }
     }
 }
@@ -225,6 +253,7 @@ _groups = [
     [_kcChild] if _kcOpen else []
     [l.clusterAccess(_name, _ns, _spec)] if _accessOpen else []
     [l.platformChild(_name, _ns, _spec, _accessShare?.apiEndpoint or "")] if _platOpen else []
+    [l.managementPlaneChild(_name, _ns, _spec)] if _mgmtOpen else []
     _usages
     [_dxrPatched]
 ]


### PR DESCRIPTION
Schließt die Form, die stuttgart-things/crossplane-configurations#258 beschreibt: **ein** XR im Seed baut die VM, das rke2-Cluster **und** die Control Plane darauf.

Bisher konnte ein `ClusterStack` nur einen Workload-Cluster erzeugen; ihn zum Management-Cluster zu machen hieß, ein zweites XR zu schreiben und daran zu denken.

```yaml
spec:
  provider: proxmox
  distribution: rke2
  managementPlaneEnabled: true
  managementPlane:
    profile: machinery
```

## Default AUS, anders als `platformEnabled`

Die meisten `ClusterStack`s bauen **Workload**-Cluster. Eine Control Plane ist die Ausnahme — und Crossplane samt der zwanzig Fleet-Pakete auf einer Maschine zu installieren, die nicht danach gefragt hat, ist kein Default, den man entdecken möchte.

**Geschwister von `spec.managementPlane`, kein Schlüssel darin** — derselbe Grund wie bei `platformEnabled`: ein `preserve-unknown-fields`-Block, der zusätzlich bekannte Properties deklariert, lässt Schema-Konverter `additionalProperties: false` emittieren und jeden Passthrough-Key ablehnen.

## Gate und Reihenfolge

Gegated auf `ClusterAccess`, exakt wie das Platform-Kind: beide brauchen nur die ClusterProviderConfigs, keines das andere. Sie installieren parallel — Crossplane und Flux konkurrieren nicht.

`status.stage` bekommt `management-plane`, und `ready` heißt jetzt: **beide** Komponenten fertig. Eine abgeschaltete Komponente zählt als fertig, nicht als ausstehend — sonst würde ein Stack, der nur eine erreichbare Maschine will, nie `ready` melden.

## Teardown

Drei `Usage`s spiegeln die des Platform-Kinds, aus demselben Grund: das Kind wendet alles, was es besitzt, **durch** die VM und den ClusterAccess an. Stirbt eines davon zuerst, hängen seine Objects gegen ein Cluster, das es nicht mehr gibt.

## Geprüft

- 43/43 Tests, darunter: ein durchgereichter `clusterName` **kann nicht gewinnen** — es ist das eine Feld, das diese Schicht besitzt, und zwei Quellen ließen ein Kind auf einen anderen Cluster zeigen als den, der es gebaut hat
- beide neuen `stage`-Verzweigungen gerendert (Platform fertig → `management-plane`, umgekehrt → `platform`)
- alle drei `Usage`s tatsächlich emittiert, nicht von der Subskript-Falle verschluckt, vor der die Datei warnt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL