### PR TITLE
feat(xplane-crossplane-catalog): a management cluster can build one (0.2.0)

### DIFF
--- a/crossplane/xplane-crossplane-catalog/catalog_test.k
+++ b/crossplane/xplane-crossplane-catalog/catalog_test.k
@@ -126,3 +126,14 @@ test_get_rejects_an_unknown_profile = lambda {
     assert "machinery" in c.names
     assert len(c.names) == len(c.catalog)
 }
+
+# A management cluster must be able to build FURTHER management clusters — that
+# is what makes the seed disposable rather than load-bearing forever. It needs
+# cluster >=v0.4.0 (spec.managementPlaneEnabled) and management-plane behind it.
+test_the_profile_can_build_control_planes = lambda {
+    _p = c.get("machinery")
+    _cl = [x for x in _p.packages if x.name.endswith("-cluster")][0]
+    assert _cl.package.endswith(":v0.4.0")
+    assert "management-plane" in _cl.pulls
+    assert "management-plane" in c.transitive(_p)
+}

--- a/crossplane/xplane-crossplane-catalog/kcl.mod
+++ b/crossplane/xplane-crossplane-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-crossplane-catalog"
 edition = "v0.12.3"
-version = "0.1.0"
+version = "0.2.0"

--- a/crossplane/xplane-crossplane-catalog/profiles/machinery.k
+++ b/crossplane/xplane-crossplane-catalog/profiles/machinery.k
@@ -102,8 +102,11 @@ machinery: s.Profile = {
         s.Package {
             kind = "Configuration"
             name = "stuttgart-things-crossplane-configurations-cluster"
-            package = "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.3.3"
-            pulls = ["platform", "remote-cluster", "vspherevm", "proxmoxvm", "ansible-run"]
+            # >=v0.4.0 carries spec.managementPlaneEnabled — without it a
+            # management cluster built from this profile cannot build further
+            # management clusters, only workload ones.
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.4.0"
+            pulls = ["platform", "remote-cluster", "vspherevm", "proxmoxvm", "ansible-run", "management-plane"]
         }
         s.Package {
             kind = "Configuration"


### PR DESCRIPTION
`cluster` **v0.3.3 → v0.4.0** im Profil `machinery`.

v0.4.0 ist das Release mit `spec.managementPlaneEnabled` (stuttgart-things/crossplane-configurations#268). Ohne das kann ein aus diesem Profil gebautes Management-Cluster **Workload-Cluster bauen und sonst nichts** — der Seed bliebe damit dauerhaft tragend statt ersetzbar, und genau das ist der Punkt von crossplane-configurations#258.

`management-plane` kommt in `cluster`s `pulls`: es arrivert über dessen `dependsOn`, wird also nicht namentlich installiert und gehört in die transitive Menge. `status.transitive` an einem `ManagementPlane`-XR liest das von hier — und dieses Feld ist die einzige ehrliche Antwort auf „was ist auf diesem Cluster eigentlich installiert".

14/14 Tests, darunter ein neuer, der genau diese Fähigkeit festhält.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL