### PR TITLE
feat(xplane-management-plane): pull catalog 0.2.0 (0.3.0)

### DIFF
--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-management-plane"
 edition = "v0.12.3"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
-xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.1.0" }
+xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-management-plane/kcl.mod.lock
+++ b/crossplane/xplane-management-plane/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-crossplane-catalog]
     name = "xplane-crossplane-catalog"
-    full_name = "xplane-crossplane-catalog_0.1.0"
-    version = "0.1.0"
-    sum = "u1HuyWz3a7crMSuiYPaRpBQQHyFStfxSxuiEkKHYTk4="
+    full_name = "xplane-crossplane-catalog_0.2.0"
+    version = "0.2.0"
+    sum = "m3nTr7+8Gk3KYoTzMlmL+zZitNgdkuoDChpoYfYz5YI="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-crossplane-catalog"
-    oci_tag = "0.1.0"
+    oci_tag = "0.2.0"


### PR DESCRIPTION
`xplane-crossplane-catalog` **0.1.0 → 0.2.0**.

Das Profil installiert jetzt `cluster` **v0.4.0** — das Release mit `spec.managementPlaneEnabled`. Ein von diesem Modul gebautes Cluster kann damit **weitere Management-Cluster** bauen statt nur Workload-Cluster. Das ist es, was den Seed ersetzbar macht, statt ihn dauerhaft tragend zu lassen.

`status.transitive` bekommt `management-plane` dazu, das über `cluster`s `dependsOn` ankommt.

14/14 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL