### PR TITLE
feat(xplane-flux-catalog): external-secrets, nfs-csi and vault (0.10.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/external_secrets.k
+++ b/crossplane/xplane-flux-catalog/apps/external_secrets.k
@@ -1,0 +1,44 @@
+import ..schema as s
+
+# external-secrets — https://github.com/stuttgart-things/flux/tree/main/infra/external-secrets
+#
+# The one entry that is also an ANSWER rather than just an app: once a
+# ClusterSecretStore stands, a catalog app can reference an ExternalSecret
+# instead of carrying a password. Substitutions land in `postBuild.substitute`,
+# i.e. in the XR spec and therefore in git in the clear — which is why harbor,
+# kube-prometheus-stack and argo-cd are not in this catalog yet. This is what
+# unblocks them.
+externalSecrets: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/infra/external-secrets"
+    defaultVersion = "v1.18.1"
+    components = [
+        s.Component {
+            name = "install"
+            path = "./components/install"
+            wrapsHelmRelease = True
+            timeout = "15m"
+        }
+        # The Vault-backed ClusterSecretStore. Optional because a cluster may
+        # want ESO with a different backend, or none yet.
+        #
+        # Every variable it needs carries a default, so it renders without an
+        # XR saying anything — but the defaults describe THIS fleet's usual
+        # Vault (mount `platform-sthings-eso`, role `eso`, CA in cert-manager),
+        # and a cluster whose vaultIssuer created a differently named mount has
+        # to say so.
+        #
+        # NO substitutionSources yet, and that is a gap rather than a choice:
+        # the values are exactly what `vaultIssuer` creates, but Platform's
+        # status.components.vaultIssuer publishes only readiness flags
+        # (authReady/caReady/issuerReady) — the Tofu outputs auth_backend_path
+        # and auth_role_name reach nothing. Wire them here the moment
+        # VaultK8sAuth publishes a status; see
+        # crossplane-configurations#260.
+        s.Component {
+            name = "cluster-store-vault"
+            path = "./components/cluster-store-vault"
+            optional = True
+            dependsOn = ["install"]
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/apps/nfs_csi.k
+++ b/crossplane/xplane-flux-catalog/apps/nfs_csi.k
@@ -1,0 +1,20 @@
+import ..schema as s
+
+# nfs-csi — https://github.com/stuttgart-things/flux/tree/main/infra/nfs-csi
+#
+# A StorageClass backed by an existing NFS export. Two required variables and
+# nothing else: which server, which share. Both are facts about the network the
+# cluster sits in, not about the cluster, so no source can discover them.
+nfsCsi: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/infra/nfs-csi"
+    defaultVersion = "v1.18.1"
+    components = [
+        s.Component {
+            name = "install"
+            path = "./"
+            wrapsHelmRelease = True
+            timeout = "15m"
+            requiredSubstitutions = ["NFS_SERVER_FQDN", "NFS_SHARE_PATH"]
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/apps/vault.k
+++ b/crossplane/xplane-flux-catalog/apps/vault.k
@@ -1,0 +1,60 @@
+import ..schema as s
+
+# vault — https://github.com/stuttgart-things/flux/tree/main/apps/vault
+#
+# NOT the fleet's Vault. This installs a Vault ON the cluster; the fleet's own
+# lives at vault.infra.sthings-vsphere and is consumed, not managed, by
+# `platform.vaultIssuer`. Worth stating because the names collide in
+# conversation more often than in configuration.
+#
+# No admin password among the required variables, unlike harbor or argo-cd:
+# Vault initialises itself and unsealing is the autounseal component's job, not
+# a value someone types into an XR.
+vault: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/apps/vault"
+    defaultVersion = "v1.18.1"
+    components = [
+        s.Component {
+            name = "install"
+            path = "./"
+            wrapsHelmRelease = True
+            timeout = "15m"
+            # ISSUER_* name the cert-manager Issuer the ingress certificate is
+            # requested from — a decision about trust, so no source. The domain
+            # is a fact and is discovered.
+            requiredSubstitutions = [
+                "ISSUER_KIND"
+                "ISSUER_NAME"
+                "VAULT_INGRESS_DOMAIN"
+                "VAULT_INGRESS_HOSTNAME"
+            ]
+            substitutionSources = {
+                VAULT_INGRESS_DOMAIN = "ipReservation.domain"
+            }
+        }
+        # Gateway API route, for clusters that front their services with a
+        # Gateway rather than an Ingress. Optional because the install already
+        # brings an Ingress path.
+        s.Component {
+            name = "httproute"
+            path = "./httproute"
+            optional = True
+            dependsOn = ["install"]
+            requiredSubstitutions = ["VAULT_DOMAIN", "VAULT_HOSTNAME"]
+            substitutionSources = {
+                VAULT_DOMAIN = "ipReservation.domain"
+            }
+        }
+        # Auto-unseal operator. Optional and deliberately so: a Vault that
+        # unseals itself is a convenience with a real trade-off, and a cluster
+        # should have to ask for it.
+        s.Component {
+            name = "autounseal"
+            path = "./autounseal"
+            optional = True
+            dependsOn = ["install"]
+            wrapsHelmRelease = True
+            timeout = "15m"
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -210,3 +210,73 @@ test_machinery_costs_one_typed_value = lambda {
     # out: re-adding it would mean the artifact's default broke again.
     assert "MACHINERY_VERSION" not in _c.requiredSubstitutions
 }
+
+# external-secrets is the entry that unblocks the others: with a
+# ClusterSecretStore standing, an app can reference an ExternalSecret instead of
+# carrying a password. Substitutions land in postBuild.substitute — the XR spec,
+# and therefore git in the clear — which is why harbor, kube-prometheus-stack
+# and argo-cd are not catalogued yet.
+test_external_secrets_has_an_optional_vault_store = lambda {
+    _c = {x.name: x for x in c.get("external-secrets").components}
+    assert not _c["install"].optional, "ESO itself is not optional"
+    assert _c["install"].wrapsHelmRelease
+    assert _c["cluster-store-vault"].optional, "a cluster may want a different backend, or none yet"
+    assert _c["cluster-store-vault"].dependsOn == ["install"]
+    assert _c["cluster-store-vault"].requiredSubstitutions == [], "every variable carries a default"
+}
+
+# The wiring that is MISSING, asserted so its absence stays deliberate: the
+# cluster-store's Vault values are exactly what platform.vaultIssuer creates,
+# but status.components.vaultIssuer publishes only readiness flags today, so
+# there is nothing to read. Adding a source that resolves to nothing would
+# leave the variable unset and rejected — worse than the default.
+test_external_secrets_cannot_discover_its_vault_yet = lambda {
+    _c = {x.name: x for x in c.get("external-secrets").components}
+    assert _c["cluster-store-vault"].substitutionSources == {}, "no source until VaultK8sAuth publishes a status"
+}
+
+# Both nfs-csi variables are facts about the NETWORK the cluster sits in, not
+# about the cluster — nothing in the platform's status can discover them.
+test_nfs_csi_needs_the_export_named = lambda {
+    _c = c.get("nfs-csi").components[0]
+    assert _c.requiredSubstitutions == ["NFS_SERVER_FQDN", "NFS_SHARE_PATH"]
+    assert _c.substitutionSources == {}
+    assert _c.path == "./"
+}
+
+# vault installs a Vault ON the cluster. It is NOT the fleet's Vault at
+# vault.infra.sthings-vsphere, which platform.vaultIssuer consumes rather than
+# manages — the names collide in conversation more than in configuration.
+#
+# Notably it needs no admin password, unlike harbor or argo-cd: Vault
+# initialises itself and unsealing is the autounseal component's job.
+test_vault_needs_no_password = lambda {
+    _a = c.get("vault")
+    assert _a.artifact.endswith("/apps/vault")
+    _all = [v for x in _a.components for v in x.requiredSubstitutions]
+    assert len([v for v in _all if "PASSWORD" in v or "TOKEN" in v]) == 0
+    _c = {x.name: x for x in _a.components}
+    assert _c["autounseal"].optional, "a Vault that unseals itself is a trade-off, not a default"
+    assert _c["httproute"].optional
+}
+
+# The domain is discovered, the issuer is not: which Issuer a certificate comes
+# from is a decision about trust, and no status field can make it.
+test_vault_discovers_the_domain_but_not_the_issuer = lambda {
+    _c = {x.name: x for x in c.get("vault").components}
+    assert _c["install"].substitutionSources["VAULT_INGRESS_DOMAIN"] == "ipReservation.domain"
+    assert "ISSUER_NAME" not in _c["install"].substitutionSources
+    assert "ISSUER_KIND" not in _c["install"].substitutionSources
+    assert _c["httproute"].substitutionSources["VAULT_DOMAIN"] == "ipReservation.domain"
+}
+
+# Every optional component that depends on another must name one that exists —
+# already covered generically, asserted here for the four added at once so a
+# typo in this batch fails loudly rather than as DependencyNotReady on a
+# cluster.
+test_new_entries_are_registered = lambda {
+    _want = ["external-secrets", "nfs-csi", "vault"]
+    _missing = [n for n in _want if n not in c.catalog]
+    assert _missing == [], "entry missing from the registry"
+    assert len(c.names) == 10
+}

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.9.0"
+version = "0.10.0"

--- a/crossplane/xplane-flux-catalog/main.k
+++ b/crossplane/xplane-flux-catalog/main.k
@@ -6,20 +6,26 @@
 import .apps.cert_manager as cert_manager
 import .apps.cilium as cilium
 import .apps.dapr as dapr
+import .apps.external_secrets as external_secrets
 import .apps.headlamp as headlamp
 import .apps.machinery as machinery
+import .apps.nfs_csi as nfs_csi
 import .apps.openebs as openebs
 import .apps.trust_manager as trust_manager
+import .apps.vault as vault
 import schema as s
 
 catalog: {str:s.App} = {
     "cert-manager" = cert_manager.certManager
     cilium = cilium.cilium
     dapr = dapr.dapr
+    "external-secrets" = external_secrets.externalSecrets
     headlamp = headlamp.headlamp
     machinery = machinery.machinery
+    "nfs-csi" = nfs_csi.nfsCsi
     openebs = openebs.openebs
     "trust-manager" = trust_manager.trustManager
+    vault = vault.vault
 }
 
 names = sorted(catalog)


### PR DESCRIPTION
Erste Charge aus stuttgart-things/crossplane-configurations#260, in der dort festgelegten Reihenfolge — **ESO zuerst**, weil es der einzige Eintrag ist, der zugleich eine **Antwort** ist.

Substitutionen landen in `postBuild.substitute`, also im XR-Spec und damit im Klartext im Git. Genau deshalb stehen harbor, kube-prometheus-stack und argo-cd nicht im Katalog: jedes verlangt ein Admin-Passwort. Sobald ein `ClusterSecretStore` steht, kann ein Eintrag stattdessen ein `ExternalSecret` referenzieren — und die drei werden zu gewöhnlichen Einträgen.

| | |
|---|---|
| `external-secrets` | `install` (helm) + `cluster-store-vault` (optional) |
| `nfs-csi` | eine Komponente, zwei Pflichtvariablen |
| `vault` | `install` + `httproute` + `autounseal`, **kein Passwort** |

## Zwei Dinge, die die Prüfung gefangen hat

**`tekton` war in dieser Charge und ist es nicht mehr: `cicd/*` wird nicht publiziert.** Der Release-Workflow im flux-Repo zählt `find apps infra -mindepth 1` auf — alle acht cicd-Komponenten (argo-cd, crossplane, tekton, komoplane, kro …) existieren also im Git **ohne OCI-Artefakt dahinter**. Per API bestätigt: `flux/cicd/tekton` und `flux/cicd/crossplane` liefern beide 404. Ein Eintrag, der auf ein nicht ziehbares Artefakt zeigt, ist schlechter als kein Eintrag.

**`defaultVersion` ist v1.18.1, nicht v1.19.2.** Der Release taggt nur Komponenten, die sich in einem Merge **geändert** haben — v1.19.2 existiert für `apps/machinery` (aus flux#194) und sonst für nichts hier.

## Was bewusst fehlt

`external-secrets/cluster-store-vault` hat **keine** `substitutionSources`, und ein Test hält das fest. Seine Vault-Werte sind exakt das, was `platform.vaultIssuer` erzeugt — aber `status.components.vaultIssuer` publiziert nur Readiness-Flags (`authReady`/`caReady`/`issuerReady`), es gibt also nichts zu lesen. Eine Quelle, die ins Leere auflöst, lässt die Variable **unbelegt und damit abgelehnt** zurück, was schlechter ist als der Default des Artefakts.

Zu verdrahten, sobald `VaultK8sAuth` einen Status publiziert.

25/25 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL