### PR TITLE
feat(xplane-platform): pull catalog 0.10.0 (0.13.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.12.0"
+version = "0.13.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.9.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.10.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.9.0"
-    version = "0.9.0"
-    sum = "DfbXw1vAxIT7xXGZlSKEty9Jwjo/mbwMXEDWxpIhrsQ="
+    full_name = "xplane-flux-catalog_0.10.0"
+    version = "0.10.0"
+    sum = "u2XwRu9FZEifntTh1xOYP9hSSCyDfQrqEcn+2/EDQHc="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.9.0"
+    oci_tag = "0.10.0"


### PR DESCRIPTION
Drei neue Apps, die eine Platform benennen kann: **external-secrets**, **nfs-csi**, **vault** (kcl#125, stuttgart-things/crossplane-configurations#260).

`external-secrets` zählt über sich hinaus: Substitutionen landen in `postBuild.substitute`, also im XR-Spec und damit im Klartext im Git. Genau deshalb fehlen harbor, kube-prometheus-stack und argo-cd weiterhin im Katalog — jedes verlangt ein Admin-Passwort. Sobald ein `ClusterSecretStore` steht, kann ein Eintrag stattdessen ein `ExternalSecret` referenzieren.

Keine Logikänderung — das Modul konsumiert den Katalog generisch. 42/42 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL