### PR TITLE
feat(xplane-vault-auth): publish what the auth created (0.6.0)

### DIFF
--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
-xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.8.0" }
+xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.9.0" }

--- a/crossplane/xplane-vault-auth/kcl.mod.lock
+++ b/crossplane/xplane-vault-auth/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-vault-auth-base]
     name = "xplane-vault-auth-base"
-    full_name = "xplane-vault-auth-base_0.8.0"
-    version = "0.8.0"
-    sum = "b6J3QyDtnx6klXa0BOJxD/aczJPR6PBVf9T1NnkYe6I="
+    full_name = "xplane-vault-auth-base_0.9.0"
+    version = "0.9.0"
+    sum = "tuiEOI4H8BtjDD4ou9uh4Mq1EwF1RVmjX0ZwSRqAyhg="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-vault-auth-base"
-    oci_tag = "0.8.0"
+    oci_tag = "0.9.0"

--- a/crossplane/xplane-vault-auth/logic.k
+++ b/crossplane/xplane-vault-auth/logic.k
@@ -1,0 +1,47 @@
+"""
+Status shaping for the vault-auth Composition.
+
+Separated from main.k so it can be unit-tested without Crossplane. What is
+worth testing here is not the marshalling but the rule: a value that the
+Workspace has not produced yet must be OMITTED, never published empty.
+"""
+
+# The Workspace the base module builds for one auth. Derived rather than passed,
+# because the two must agree and a second source of truth is how they drift.
+workspaceName = lambda clusterName: str, authName: str -> str {
+    "{}-{}-vault-auth".format(clusterName, authName)
+}
+
+isReady = lambda res: any -> bool {
+    len([c for c in (res?.status?.conditions or []) if c?.type == "Ready" and c?.status == "True"]) > 0
+}
+
+authStatus = lambda clusterName: str, authName: str, ws: any -> {str:} {
+    """One entry of status.share.auths.
+
+    mountPath, role and policies are OMITTED while the Workspace is still
+    applying, rather than published as empty strings. A consumer resolving a
+    substitution source to "" would send a blank mount path to Vault, and Vault
+    answers that with a 403 that names nothing — the value looks supplied and is
+    not. Absent is a state a consumer can act on; empty is not.
+    """
+    _out = ((ws?.status?.atProvider or {})?.outputs or {})
+    {
+        name = authName
+        workspace = workspaceName(clusterName, authName)
+        ready = isReady(ws)
+        if _out?.auth_backend_path:
+            mountPath = _out.auth_backend_path
+        if _out?.auth_role_name:
+            role = _out.auth_role_name
+        if _out?.policy_names:
+            policies = _out.policy_names
+    }
+}
+
+allReady = lambda auths: [{str:}] -> bool {
+    """False on an empty list: a VaultK8sAuth with no auths has created nothing,
+    and reporting it ready would let a consumer proceed against a Vault that
+    knows nothing about this cluster."""
+    len(auths) > 0 and len([a for a in auths if a.ready]) == len(auths)
+}

--- a/crossplane/xplane-vault-auth/logic_test.k
+++ b/crossplane/xplane-vault-auth/logic_test.k
@@ -1,0 +1,72 @@
+# Unit tests for the status shaping. `kcl test`.
+import .logic as l
+
+_ws = lambda ready: bool, outputs: {str:} -> any {
+    {
+        metadata = {name = "mgmt-test1-eso-vault-auth"}
+        status = {
+            conditions = [{type = "Ready", status = "True" if ready else "False"}]
+            atProvider = {outputs = outputs}
+        }
+    }
+}
+
+_full = {
+    auth_backend_path = "mgmt-test1-eso"
+    auth_role_name = "eso"
+    policy_names = ["mgmt-test1-kv-own", "mgmt-test1-kv-cicd"]
+}
+
+# Derived on both sides so the two cannot drift: the base module names the
+# Workspace the same way.
+test_workspace_name_is_derived = lambda {
+    assert l.workspaceName("mgmt-test1", "eso") == "mgmt-test1-eso-vault-auth"
+}
+
+test_outputs_are_lifted = lambda {
+    _a = l.authStatus("mgmt-test1", "eso", _ws(True, _full))
+    assert _a.ready
+    assert _a.mountPath == "mgmt-test1-eso"
+    assert _a.role == "eso"
+    assert _a.policies == ["mgmt-test1-kv-own", "mgmt-test1-kv-cicd"]
+    assert _a.workspace == "mgmt-test1-eso-vault-auth"
+}
+
+# THE rule. While the Workspace is still applying there are no outputs, and the
+# fields must be ABSENT rather than empty: a consumer resolving a substitution
+# source to "" would send a blank mount path to Vault, which answers with a 403
+# that names nothing. The value looks supplied and is not.
+test_missing_outputs_are_omitted_not_blank = lambda {
+    _a = l.authStatus("mgmt-test1", "eso", _ws(False, {}))
+    assert not _a.ready
+    assert "mountPath" not in _a, "absent is a state a consumer can act on; empty is not"
+    assert "role" not in _a
+    assert "policies" not in _a
+    assert _a.name == "eso", "identity is known before the Workspace produces anything"
+}
+
+# A Workspace that has not been observed at all — first reconcile, ocds empty.
+test_unobserved_workspace_yields_identity_only = lambda {
+    _a = l.authStatus("mgmt-test1", "eso", {})
+    assert not _a.ready
+    assert "mountPath" not in _a
+}
+
+# Partial outputs happen: tofu can publish one before the other.
+test_partial_outputs_are_partial = lambda {
+    _a = l.authStatus("mgmt-test1", "eso", _ws(False, {auth_backend_path = "mgmt-test1-eso"}))
+    assert _a.mountPath == "mgmt-test1-eso"
+    assert "role" not in _a
+}
+
+# Aggregate readiness. False on empty deliberately: a VaultK8sAuth with no auths
+# has created nothing, and reporting it ready would let a consumer proceed
+# against a Vault that knows nothing about this cluster.
+test_all_ready_needs_every_auth = lambda {
+    _r = {name = "a", ready = True}
+    _n = {name = "b", ready = False}
+    assert l.allReady([_r])
+    assert l.allReady([_r, _r])
+    assert not l.allReady([_r, _n])
+    assert not l.allReady([]), "nothing created is not the same as everything ready"
+}

--- a/crossplane/xplane-vault-auth/main.k
+++ b/crossplane/xplane-vault-auth/main.k
@@ -1,7 +1,9 @@
+import .logic as l
 import xplane_vault_auth_base as vault_auth
 
 _params = option("params") or {}
 _oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
 _spec = _oxr?.spec or {}
 _meta = _oxr?.metadata or {}
 
@@ -35,6 +37,13 @@ _k8sAuths = [vault_auth.K8sAuth {
     tokenTtl = auth?.tokenTtl or 3600
     boundServiceAccountNames = auth?.boundServiceAccountNames or ["default"]
     boundServiceAccountNamespaces = auth?.boundServiceAccountNamespaces or ["default"]
+    # Policies to CREATE for this auth, each named {clusterName}-{name} and
+    # appended to tokenPolicies. A cluster usually wants more than one: its own
+    # KV subtree, plus whatever the role it plays grants it.
+    policies = [vault_auth.VaultPolicy {
+        name = p?.name or "default"
+        rules = p?.rules or ""
+    } for p in (auth?.policies or [])]
     backendConfig = _buildBackendConfig(auth?.backendConfig)
 } for auth in (_spec?.k8sAuths or [
     {"name": "frontend", "tokenPolicies": ["read-secrets"], "tokenTtl": 7200}
@@ -54,4 +63,44 @@ _config = vault_auth.VaultConfig {
     kubernetesHost = _kubernetesHost
 }
 
-items = vault_auth.vaultK8sAuth(_config)
+# --- status ----------------------------------------------------------------
+# The OpenTofu Workspace publishes what a consumer needs — the mount path Vault
+# created, the role name, and now the policies created for it. Nothing lifted
+# them, so a VaultK8sAuth reported readiness and nothing else, and anything
+# wanting to USE the mount had to be told its name by hand.
+#
+# Not cosmetic: external-secrets needs exactly these values, and without them a
+# catalog entry cannot discover its own cluster's Vault mount
+# (crossplane-configurations#260).
+#
+# A LIST rather than a map keyed by name: `k8sAuths` is a list, one auth per
+# Workspace, and the status mirrors what was asked for rather than reshaping it.
+#
+# Matched by the Workspace's metadata.name rather than the ocds key, because the
+# base module fills composition-resource-name from `auth.annotations` and an XR
+# that passes none would otherwise be unmatchable.
+_wsNamed = lambda n: str -> any {
+    _m = [v.Resource for _, v in _ocds if v?.Resource?.metadata?.name == n]
+    _m[0] if _m else {}
+}
+
+_auths = [l.authStatus(a.clusterName, a.name, _wsNamed(l.workspaceName(a.clusterName, a.name))) for a in _k8sAuths]
+
+_statusPatch = {
+    apiVersion = _oxr?.apiVersion
+    kind = _oxr?.kind
+    metadata = {
+        name = _meta?.name
+        namespace = _meta?.namespace
+    }
+    status = {
+        share = {
+            clusterName = _clusterName
+            vaultAddr = _vaultAddr
+            auths = _auths
+            ready = l.allReady(_auths)
+        }
+    }
+}
+
+items = vault_auth.vaultK8sAuth(_config) + [_statusPatch]


### PR DESCRIPTION
`xplane-vault-auth-base` **0.8.0 → 0.9.0**, und daraus folgen zwei Dinge.

## Policies werden durchgereicht

`spec.k8sAuths[].policies` erreicht das Basis-Modul, das jede als `{clusterName}-{name}` **im selben tofu-Plan** anlegt wie die Rolle, die sie nennt. Eine Liste, weil ein Cluster meist mehr als eine will: seinen eigenen KV-Teilbaum, plus das, was ihm die gespielte Rolle gewährt.

## Die Outputs landen im Status

Der Workspace publiziert seit jeher `auth_backend_path` und `auth_role_name` — und jetzt `policy_names` — und **niemand hat sie gelesen**. Ein `VaultK8sAuth` meldete Readiness und sonst nichts, wer den Mount *benutzen* wollte, musste seinen Namen von Hand erfahren.

Genau das blockiert external-secrets: dessen `ClusterSecretStore` braucht exakt diese Werte, und ein Katalog-Eintrag kann den Vault-Mount seines eigenen Clusters nicht aus Readiness-Flags ableiten (stuttgart-things/crossplane-configurations#260).

```yaml
status:
  share:
    auths:
      - name: eso
        workspace: mgmt-test1-eso-vault-auth
        ready: true
        mountPath: mgmt-test1-eso
        role: eso
        policies: [mgmt-test1-kv-own, mgmt-test1-kv-cicd]
```

Eine **Liste**, keine Map nach Namen: `k8sAuths` ist eine Liste, und der Status spiegelt, was gefragt wurde, statt es umzuformen.

## Abwesend, nicht leer

Die drei aus Outputs abgeleiteten Felder werden **weggelassen**, solange der Workspace noch appliziert. Ein Konsument, der eine Substitutionsquelle auf `""` auflöst, schickt einen leeren Mount-Pfad an Vault — und Vault antwortet mit einem 403, das nichts benennt. Der Wert *sieht* geliefert aus und ist es nicht.

**Abwesend ist ein Zustand, auf den ein Konsument reagieren kann; leer nicht.** Aus demselben Grund ist `allReady` bei leerer Liste `false`: nichts erzeugt zu haben ist nicht dasselbe wie fertig zu sein.

Die Formung ist nach `logic.k` gewandert, damit diese Regeln ohne Crossplane prüfbar sind — wie in `xplane-cni` und `xplane-platform`. Sechs Tests; das Modul hatte keine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL
