### PR TITLE
feat(xplane-platform): a cluster can discover its own Vault mount (0.14.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.10.0" }

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -150,28 +150,44 @@ appSources = lambda spec: {str:} -> [{str:}] {
     } for _n, _a in enabledApps(spec)]
 }
 
+# One step of a dotted path: read `seg` out of `cur`, where seg may carry a
+# `[N]` index. Undefined for anything absent, which is what makes the whole walk
+# collapse to "" rather than to a partial value.
+_step = lambda cur, seg: str -> any {
+    _isIdx = seg.endswith("]") and "[" in seg
+    _field = seg.split("[")[0] if _isIdx else seg
+    _next = cur[_field] if (typeof(cur) == "dict" and _field in cur) else Undefined
+    _i = int(seg.split("[")[1].replace("]", "")) if _isIdx else 0
+    (_next[_i] if (typeof(_next) == "list" and len(_next) > _i) else Undefined) if _isIdx else _next
+}
+
 resolveSource = lambda discovered: {str:}, path: str -> str {
     """Read one catalog `substitutionSources` path out of the discovered facts.
 
-    Supports exactly the two shapes the catalog uses — `group.field` and
-    `group.field[N]` — and nothing else. That is a deliberate floor rather than a
-    parser: a general path language would need its own error semantics, and the
-    failure it would introduce (an unresolvable path silently yielding "") is the
-    very one requiredSubstitutions exists to prevent. A path this cannot read
-    returns "", which leaves the variable unset and lets the existing check
-    reject it by name.
+    Walks a dotted path of up to four segments, each of which may carry a `[N]`
+    index — `ipReservation.domain`, `ipReservation.ipAddresses[0]`,
+    `vaultIssuer.auths.eso.mountPath`.
 
-    Returns "" for anything absent, so callers can treat "" as "not discovered".
+    Four rather than unbounded, and dotted rather than a query language, for the
+    reason the two-segment version gave: a general path language would need its
+    own error semantics, and the failure it would introduce — an unresolvable
+    path silently yielding "" — is the very one requiredSubstitutions exists to
+    prevent. The bound keeps this a lookup. It grew from two to four when the
+    Vault mount a cluster created became discoverable, which is genuinely nested
+    (crossplane-configurations#260); raise it again only for a real path, never
+    in advance.
+
+    Returns "" for anything absent, so callers can treat "" as "not discovered",
+    and a path deeper than four reads as absent rather than as a truncated
+    prefix — the one outcome that would be worse than not resolving at all.
     """
     _seg = path.split(".")
-    _group = _seg[0] if len(_seg) > 0 else ""
-    _rest = _seg[1] if len(_seg) == 2 else ""
-    _obj = discovered[_group] if _group in discovered else {}
-    _isIdx = _rest.endswith("]") and "[" in _rest
-    _field = _rest.split("[")[0] if _isIdx else _rest
-    _val = _obj[_field] if _field != "" and _field in _obj else Undefined
-    _i = int(_rest.split("[")[1].replace("]", "")) if _isIdx else 0
-    str(_val[_i]) if (_isIdx and typeof(_val) == "list" and len(_val) > _i) else ("" if (_isIdx or _val == Undefined or _val == None) else str(_val))
+    _v1 = _step(discovered, _seg[0]) if len(_seg) > 0 else Undefined
+    _v2 = _step(_v1, _seg[1]) if len(_seg) > 1 else _v1
+    _v3 = _step(_v2, _seg[2]) if len(_seg) > 2 else _v2
+    _val = _step(_v3, _seg[3]) if len(_seg) > 3 else _v3
+    _tooDeep = len(_seg) > 4
+    "" if (_tooDeep or _val == Undefined or _val == None or typeof(_val) == "dict" or typeof(_val) == "list") else str(_val)
 }
 
 discoveredSubstitutions = lambda comp: cs.Component, discovered: {str:} -> {str:str} {

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -489,3 +489,63 @@ test_apps_machinery_costs_one_typed_value = lambda {
     assert len(_missing) == 1, "the Gateway choice stays required"
     assert "GATEWAY_NAME" in ", ".join(_missing)
 }
+
+# The resolver grew from two segments to four when the Vault mount a cluster
+# created became discoverable. The old shapes must keep working exactly, and the
+# new depth must fail the same way — absent, never truncated.
+test_resolve_source_walks_four_segments = lambda {
+    _d = {
+        vaultIssuer = {
+            auths = {
+                eso = {mountPath = "mgmt-test1-eso", role = "eso"}
+            }
+        }
+    }
+    assert l.resolveSource(_d, "vaultIssuer.auths.eso.mountPath") == "mgmt-test1-eso"
+    assert l.resolveSource(_d, "vaultIssuer.auths.eso.role") == "eso"
+}
+
+# A path that stops short lands on a dict. Returning str(dict) would substitute
+# a rendered map into a Vault mount path — worse than not resolving, because it
+# looks like a value. Empty is what lets requiredSubstitutions reject it by name.
+test_resolve_source_refuses_a_partial_path = lambda {
+    _d = {
+        vaultIssuer = {
+            auths = {
+                eso = {mountPath = "m"}
+            }
+        }
+    }
+    assert l.resolveSource(_d, "vaultIssuer.auths") == ""
+    assert l.resolveSource(_d, "vaultIssuer.auths.eso") == ""
+}
+
+# Deeper than the bound reads as absent rather than as a truncated prefix. A
+# prefix would be a plausible-looking wrong value, which is the one outcome
+# worse than not resolving.
+test_resolve_source_rejects_beyond_the_bound = lambda {
+    _d = {
+        a = {
+            b = {
+                c = {
+                    d = {e = "too deep"}
+                }
+            }
+        }
+    }
+    assert l.resolveSource(_d, "a.b.c.d.e") == ""
+}
+
+# A missing auth resolves to nothing, not to another auth's mount. This is the
+# case that matters on a cluster whose vaultIssuer has not created the ESO auth
+# yet: the variable stays unset and the app is rejected by name.
+test_resolve_source_missing_auth_is_empty = lambda {
+    _d = {
+        vaultIssuer = {
+            auths = {
+                certmanager = {mountPath = "mgmt-certmanager"}
+            }
+        }
+    }
+    assert l.resolveSource(_d, "vaultIssuer.auths.eso.mountPath") == ""
+}

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -71,6 +71,14 @@ _discovered = {
         ipAddresses = _readStatus(_ipResKey)?.ipAddresses or []
         zone = _readStatus(_ipResKey)?.zone or ""
     }
+    vaultIssuer = {
+        # Keyed by auth name, unlike the VaultK8sAuth's own status, which keeps
+        # the list it was given. Different layers, different jobs: there the
+        # status mirrors what was asked for, here it is ADDRESSED — a catalog
+        # entry says `vaultIssuer.auths.eso.mountPath`, and an index would break
+        # the moment someone reorders spec.vaultIssuer.additionalAuths.
+        auths = {a.name: a for a in ((_readStatus(_vaultAuthKey)?.share or {})?.auths or []) if a?.name}
+    }
 }
 
 # Validated against what was discovered: a variable the platform can supply is
@@ -297,7 +305,22 @@ _vaultK8sAuthXR = {
             # adds the backend_config on a later reconcile.
             if _viReviewerAvailable:
                 backendConfig = {secretName = _viEffReviewerSecret, secretNamespace = _namespace}
-        }]
+        }] + [{
+            # Further auths on the SAME Vault mount machinery — external-secrets
+            # is the reason this exists: it needs its own mount and role, bound
+            # to its own ServiceAccount, with its own policies. Reusing
+            # cert-manager's would hand a secrets reader the right to issue
+            # certificates.
+            name = a?.name or "extra"
+            boundServiceAccountNames = a?.boundServiceAccountNames or ["default"]
+            boundServiceAccountNamespaces = a?.boundServiceAccountNamespaces or ["default"]
+            if a?.tokenPolicies:
+                tokenPolicies = a.tokenPolicies
+            if a?.policies:
+                policies = a.policies
+            if _viReviewerAvailable:
+                backendConfig = {secretName = _viEffReviewerSecret, secretNamespace = _namespace}
+        } for a in (_viSpec?.additionalAuths or [])]
     }
 }
 
@@ -563,6 +586,11 @@ _xrStatus = _oxr | {
                 authReady = _vaultAuthReady
                 caReady = _vaultPkiReady
                 issuerReady = _issuerReady
+                # What Vault actually created, keyed by auth name. This is what
+                # lets external-secrets discover its own cluster's mount instead
+                # of being told the name by hand — the gap that kept it out of
+                # the catalog with substitutionSources.
+                auths = _discovered.vaultIssuer.auths
             }
         }
         componentCount = len(_enabledReady)


### PR DESCRIPTION
Drei Änderungen, die nur zusammen Sinn ergeben — und sie schließen die Lücke, die external-secrets aus dem Katalog gehalten hat (stuttgart-things/crossplane-configurations#260).

## `spec.vaultIssuer.additionalAuths`

Weitere Kubernetes-Auth-Mounts neben dem von cert-manager, je mit eigener gebundener ServiceAccount und **eigenen Policies**:

```yaml
vaultIssuer:
  enabled: true
  additionalAuths:
    - name: eso
      boundServiceAccountNames: ["external-secrets"]
      boundServiceAccountNamespaces: ["external-secrets"]
      policies:
        - name: kv-own
          rules: |
            path "kv/data/mgmt-test1/*" { capabilities = ["read"] }
```

external-secrets ist der Grund: es braucht Mount und Rolle für sich. Den von cert-manager mitzubenutzen hieße, einem Secrets-Leser das Recht zu geben, **Zertifikate auszustellen**.

## `status.components.vaultIssuer.auths`

Was Vault tatsächlich angelegt hat, gehoben aus dem `VaultK8sAuth`-Kind (vault-auth v0.2.0) — **nach Auth-Namen geschlüsselt**:

```yaml
auths:
  certmanager: {mountPath: mgmt-test1-certmanager, role: certmanager}
  eso:         {mountPath: mgmt-test1-eso, role: eso, policies: [mgmt-test1-kv-own]}
```

Bewusst **nicht** die Liste, die das Kind publiziert. Dort spiegelt der Status, was gefragt wurde; hier wird er **adressiert** — und ein Index bräche in dem Moment, in dem jemand `additionalAuths` umsortiert.

## `resolveSource` läuft vier Segmente statt zwei

Damit `vaultIssuer.auths.eso.mountPath` lesbar ist. Weiterhin gepunktet, weiterhin begrenzt, aus dem Grund, den schon die Zwei-Segment-Fassung nannte: eine allgemeine Pfadsprache bräuchte eigene Fehlersemantik, und der Fehler, den sie einführte — ein unauflösbarer Pfad, der still `""` liefert — ist genau der, den `requiredSubstitutions` verhindern soll.

**Die Grenze trägt in einer Richtung, die man leicht übersieht:** ein Pfad *tiefer* als vier löst zu `""` auf, nicht zu seinem Vier-Segment-Präfix. Und ein Pfad, der auf einem Dict endet, ebenfalls zu `""`, nicht zu einer gerenderten Map. Beides wären plausibel aussehende **falsche** Werte in einem Vault-Mount-Pfad — schlimmer als gar nicht aufzulösen. Vier Tests halten genau das fest.

46/46 Tests; die bestehenden Pfade (`ipReservation.domain`, `ipReservation.ipAddresses[0]`) unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL
