### PR TITLE
feat(xplane-flux-catalog): external-secrets discovers its own Vault (0.11.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/external_secrets.k
+++ b/crossplane/xplane-flux-catalog/apps/external_secrets.k
@@ -27,18 +27,36 @@ externalSecrets: s.App = {
         # and a cluster whose vaultIssuer created a differently named mount has
         # to say so.
         #
-        # NO substitutionSources yet, and that is a gap rather than a choice:
-        # the values are exactly what `vaultIssuer` creates, but Platform's
-        # status.components.vaultIssuer publishes only readiness flags
-        # (authReady/caReady/issuerReady) — the Tofu outputs auth_backend_path
-        # and auth_role_name reach nothing. Wire them here the moment
-        # VaultK8sAuth publishes a status; see
-        # crossplane-configurations#260.
+        # The mount path and role are DISCOVERED from this cluster's own
+        # vaultIssuer, which created them. Before xplane-platform 0.14.0 the
+        # status published only readiness flags, so the artifact's defaults —
+        # mount `platform-sthings-eso`, role `eso` — were the only option, and
+        # they describe one specific cluster. A second cluster silently
+        # authenticated against the wrong mount, or against nothing.
+        #
+        # Requires spec.vaultIssuer.additionalAuths to declare an auth named
+        # `eso`. Where it does not, the paths resolve to nothing, the variables
+        # stay at the artifact's defaults, and the store points wherever those
+        # point — which is why this component is opt-in.
         s.Component {
             name = "cluster-store-vault"
             path = "./components/cluster-store-vault"
             optional = True
             dependsOn = ["install"]
+            # REQUIRED even though the artifact defaults them, and that is the
+            # point: the defaults are `platform-sthings-eso` / `eso`, i.e. one
+            # specific cluster's mount. On any other cluster they authenticate
+            # against the wrong mount or against nothing, and the store looks
+            # configured either way.
+            #
+            # Declared required, they are either DISCOVERED from this cluster's
+            # own vaultIssuer or rejected by name at render time. Never silently
+            # someone else's.
+            requiredSubstitutions = ["VAULT_K8S_AUTH_MOUNT_PATH", "VAULT_K8S_AUTH_ROLE"]
+            substitutionSources = {
+                VAULT_K8S_AUTH_MOUNT_PATH = "vaultIssuer.auths.eso.mountPath"
+                VAULT_K8S_AUTH_ROLE = "vaultIssuer.auths.eso.role"
+            }
         }
     ]
 }

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -222,17 +222,31 @@ test_external_secrets_has_an_optional_vault_store = lambda {
     assert _c["install"].wrapsHelmRelease
     assert _c["cluster-store-vault"].optional, "a cluster may want a different backend, or none yet"
     assert _c["cluster-store-vault"].dependsOn == ["install"]
-    assert _c["cluster-store-vault"].requiredSubstitutions == [], "every variable carries a default"
+    # Two are required despite carrying artifact defaults — see below.
+    assert _c["cluster-store-vault"].requiredSubstitutions == ["VAULT_K8S_AUTH_MOUNT_PATH", "VAULT_K8S_AUTH_ROLE"]
 }
 
-# The wiring that is MISSING, asserted so its absence stays deliberate: the
-# cluster-store's Vault values are exactly what platform.vaultIssuer creates,
-# but status.components.vaultIssuer publishes only readiness flags today, so
-# there is nothing to read. Adding a source that resolves to nothing would
-# leave the variable unset and rejected — worse than the default.
-test_external_secrets_cannot_discover_its_vault_yet = lambda {
+# The wiring that was missing until xplane-platform 0.14.0: the mount path and
+# role come from the vaultIssuer that CREATED them, not from the artifact's
+# defaults — which describe one specific cluster (mount `platform-sthings-eso`,
+# role `eso`) and would have a second cluster authenticate against the wrong
+# mount, or against nothing.
+test_external_secrets_discovers_its_vault = lambda {
     _c = {x.name: x for x in c.get("external-secrets").components}
-    assert _c["cluster-store-vault"].substitutionSources == {}, "no source until VaultK8sAuth publishes a status"
+    _src = _c["cluster-store-vault"].substitutionSources
+    assert _src["VAULT_K8S_AUTH_MOUNT_PATH"] == "vaultIssuer.auths.eso.mountPath"
+    assert _src["VAULT_K8S_AUTH_ROLE"] == "vaultIssuer.auths.eso.role"
+}
+
+# Keyed by auth NAME, never by index. spec.vaultIssuer.additionalAuths is a
+# list, and an indexed path would silently point at cert-manager's mount the
+# moment someone reorders it — handing a secrets reader a certificate-issuing
+# role, which is exactly the mix-up the separate auth exists to prevent.
+test_external_secrets_addresses_the_auth_by_name = lambda {
+    _c = {x.name: x for x in c.get("external-secrets").components}
+    _paths = [v for _, v in _c["cluster-store-vault"].substitutionSources]
+    assert len([p for p in _paths if "[" in p]) == 0, "an index would break on reorder"
+    assert len([p for p in _paths if ".eso." in p]) == len(_paths)
 }
 
 # Both nfs-csi variables are facts about the NETWORK the cluster sits in, not
@@ -279,4 +293,20 @@ test_new_entries_are_registered = lambda {
     _missing = [n for n in _want if n not in c.catalog]
     assert _missing == [], "entry missing from the registry"
     assert len(c.names) == 10
+}
+
+# The two sourced variables are REQUIRED although the artifact defaults them,
+# and that is deliberate. The defaults are `platform-sthings-eso` / `eso` — one
+# specific cluster's mount. On any other cluster they authenticate against the
+# wrong mount or against nothing, and the ClusterSecretStore looks configured
+# either way, which is the failure mode this catalog exists to prevent.
+#
+# Required, they are either discovered from the cluster's own vaultIssuer or
+# rejected at render time by name. Never silently someone else's.
+test_external_secrets_never_falls_back_to_another_clusters_mount = lambda {
+    _c = {x.name: x for x in c.get("external-secrets").components}
+    _req = _c["cluster-store-vault"].requiredSubstitutions
+    _src = _c["cluster-store-vault"].substitutionSources
+    _unguarded = [k for k, _ in _src if k not in _req]
+    assert _unguarded == [], "a source with no required declaration falls back to the artifact default when it resolves to nothing"
 }

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.10.0"
+version = "0.11.0"


### PR DESCRIPTION
Die Verdrahtung, auf die stuttgart-things/crossplane-configurations#260 gewartet hat. `xplane-platform` 0.14.0 publiziert `status.components.vaultIssuer.auths` nach Auth-Namen geschlüsselt, also kann der `ClusterSecretStore` Mount-Pfad und Rolle lesen, die **der eigene vaultIssuer dieses Clusters** angelegt hat:

```
VAULT_K8S_AUTH_MOUNT_PATH -> vaultIssuer.auths.eso.mountPath
VAULT_K8S_AUTH_ROLE       -> vaultIssuer.auths.eso.role
```

## Beide sind jetzt **required**, obwohl das Artefakt sie defaultet

Das ist der eigentliche Inhalt dieser Änderung, kein Nebeneffekt. Die Defaults lauten `platform-sthings-eso` / `eso` — der Mount **eines bestimmten** Clusters. Auf jedem anderen authentifiziert sich der Store gegen den falschen Mount oder gegen gar nichts, und **sieht dabei konfiguriert aus**.

Als required deklariert werden sie entweder aus dem eigenen `vaultIssuer` **entdeckt** oder beim Rendern **beim Namen abgelehnt**. Nie still die eines fremden Clusters.

## Eine bestehende Invariante hat das gefangen

`test_substitution_sources_name_declared_variables` verlangt, dass jede Quelle eine Variable benennt, die die Komponente auch als Pflicht deklariert. Genau deshalb: eine Quelle, deren Pfad ins Leere läuft, muss in eine `requiredSubstitutions`-Ablehnung fallen — nicht in einen Artefakt-Default.

Die Quellen zu verdrahten, ohne die Variablen zu deklarieren, hätte den Fehler still gemacht. Dafür gibt es die Invariante, und sie hat sich bezahlt gemacht.

## Nach Namen adressiert, nie nach Index

`spec.vaultIssuer.additionalAuths` ist eine Liste. Ein indizierter Pfad zeigte in dem Moment auf **cert-managers** Mount, in dem jemand sie umsortiert — und gäbe einem Secrets-Leser eine Rolle zum Ausstellen von Zertifikaten. Genau die Verwechslung, für deren Vermeidung der eigene Auth existiert. Ein Test hält es fest.

27/27 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL
