### PR TITLE
feat(xplane-platform): pull catalog 0.11.0 (0.15.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.14.0"
+version = "0.15.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.10.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.11.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.10.0"
-    version = "0.10.0"
-    sum = "u2XwRu9FZEifntTh1xOYP9hSSCyDfQrqEcn+2/EDQHc="
+    full_name = "xplane-flux-catalog_0.11.0"
+    version = "0.11.0"
+    sum = "qIrM/Ba8BdqYsaim8HYFYcYiGEa2E1mE26AqGPLoyys="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.10.0"
+    oci_tag = "0.11.0"


### PR DESCRIPTION
`xplane-flux-catalog` **0.10.0 → 0.11.0**.

Der `cluster-store-vault` von external-secrets bezieht Mount-Pfad und Rolle jetzt aus `vaultIssuer.auths.eso` — dem Auth, den der eigene vaultIssuer dieser Platform angelegt hat — statt aus den Artefakt-Defaults, die den Mount **eines bestimmten fremden Clusters** benennen.

Beide Variablen wurden im selben Katalog-Release **required**. Ein Cluster ohne `eso`-Eintrag in `spec.vaultIssuer.additionalAuths` wird damit beim Rendern **beim Namen abgelehnt**, statt still auf einen fremden Vault zu zeigen.

Keine Logikänderung — das Modul konsumiert den Katalog generisch, und sein Resolver läuft seit 0.14.0 die vier Segmente, die das braucht.

46/46 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL