### PR TITLE
feat(xplane-flux-catalog): every misleading ESO default is now required (0.12.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/external_secrets.k
+++ b/crossplane/xplane-flux-catalog/apps/external_secrets.k
@@ -43,16 +43,38 @@ externalSecrets: s.App = {
             path = "./components/cluster-store-vault"
             optional = True
             dependsOn = ["install"]
-            # REQUIRED even though the artifact defaults them, and that is the
-            # point: the defaults are `platform-sthings-eso` / `eso`, i.e. one
-            # specific cluster's mount. On any other cluster they authenticate
-            # against the wrong mount or against nothing, and the store looks
-            # configured either way.
+            # ALL FIVE are required even though the artifact defaults every
+            # one of them, and that is the point: each default names a
+            # different deployment. Live on u26-rke2-1, 2026-08-16, the store
+            # came up as `vault-homerun2-cd`, reading KV path `homerun2-cd`,
+            # authenticating as a ServiceAccount `eso` that the chart does not
+            # create — and reported no error at all until it tried to reach
+            # Vault.
             #
-            # Declared required, they are either DISCOVERED from this cluster's
-            # own vaultIssuer or rejected by name at render time. Never silently
-            # someone else's.
-            requiredSubstitutions = ["VAULT_K8S_AUTH_MOUNT_PATH", "VAULT_K8S_AUTH_ROLE"]
+            #   VAULT_K8S_AUTH_MOUNT_PATH  platform-sthings-eso   another cluster
+            #   VAULT_K8S_AUTH_ROLE        eso                    another cluster
+            #   VAULT_CSS_NAME             vault-homerun2-cd      another workload
+            #   VAULT_KV_PATH              homerun2-cd            another mount
+            #   VAULT_K8S_AUTH_SA_NAME     eso                    no such SA
+            #
+            # A store pointed at the wrong Vault LOOKS configured, which is the
+            # failure class requiredSubstitutions exists for. Required, each is
+            # either discovered from this cluster's own vaultIssuer or rejected
+            # at render time by name.
+            #
+            # VAULT_K8S_AUTH_SA_NAME is the odd one out: the SA name is a fact
+            # about the artifact's own chart, not a per-cluster decision, so
+            # every XR will type the same value. The real fix is the artifact
+            # defaulting to the SA it actually creates (`external-secrets`);
+            # drop it from this list once that lands — the same way
+            # MACHINERY_VERSION left it after stuttgart-things/flux#193.
+            requiredSubstitutions = [
+                "VAULT_K8S_AUTH_MOUNT_PATH"
+                "VAULT_K8S_AUTH_ROLE"
+                "VAULT_CSS_NAME"
+                "VAULT_KV_PATH"
+                "VAULT_K8S_AUTH_SA_NAME"
+            ]
             substitutionSources = {
                 VAULT_K8S_AUTH_MOUNT_PATH = "vaultIssuer.auths.eso.mountPath"
                 VAULT_K8S_AUTH_ROLE = "vaultIssuer.auths.eso.role"

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -222,8 +222,14 @@ test_external_secrets_has_an_optional_vault_store = lambda {
     assert _c["install"].wrapsHelmRelease
     assert _c["cluster-store-vault"].optional, "a cluster may want a different backend, or none yet"
     assert _c["cluster-store-vault"].dependsOn == ["install"]
-    # Two are required despite carrying artifact defaults — see below.
-    assert _c["cluster-store-vault"].requiredSubstitutions == ["VAULT_K8S_AUTH_MOUNT_PATH", "VAULT_K8S_AUTH_ROLE"]
+    # Five are required despite the artifact defaulting every one — see below.
+    assert _c["cluster-store-vault"].requiredSubstitutions == [
+        "VAULT_K8S_AUTH_MOUNT_PATH"
+        "VAULT_K8S_AUTH_ROLE"
+        "VAULT_CSS_NAME"
+        "VAULT_KV_PATH"
+        "VAULT_K8S_AUTH_SA_NAME"
+    ]
 }
 
 # The wiring that was missing until xplane-platform 0.14.0: the mount path and
@@ -295,18 +301,31 @@ test_new_entries_are_registered = lambda {
     assert len(c.names) == 10
 }
 
-# The two sourced variables are REQUIRED although the artifact defaults them,
-# and that is deliberate. The defaults are `platform-sthings-eso` / `eso` — one
-# specific cluster's mount. On any other cluster they authenticate against the
-# wrong mount or against nothing, and the ClusterSecretStore looks configured
-# either way, which is the failure mode this catalog exists to prevent.
+# Every one of the five is REQUIRED although the artifact defaults it, and each
+# default names a DIFFERENT deployment. Live on u26-rke2-1, 2026-08-16: the
+# store came up as `vault-homerun2-cd`, reading KV path `homerun2-cd`,
+# authenticating as a ServiceAccount `eso` that the chart does not create — and
+# reported nothing wrong until it tried to reach Vault.
 #
-# Required, they are either discovered from the cluster's own vaultIssuer or
-# rejected at render time by name. Never silently someone else's.
+# A store pointed at the wrong Vault LOOKS configured. That is the failure class
+# requiredSubstitutions exists for: required, each value is either discovered
+# from this cluster's own vaultIssuer or rejected at render time by name.
 test_external_secrets_never_falls_back_to_another_clusters_mount = lambda {
     _c = {x.name: x for x in c.get("external-secrets").components}
     _req = _c["cluster-store-vault"].requiredSubstitutions
     _src = _c["cluster-store-vault"].substitutionSources
     _unguarded = [k for k, _ in _src if k not in _req]
     assert _unguarded == [], "a source with no required declaration falls back to the artifact default when it resolves to nothing"
+}
+
+# The two that are DECISIONS keep no source, and must not gain one: which Vault
+# mount a cluster reads and what its store is called are choices, and a status
+# field cannot make them. Only the mount path and role are facts the vaultIssuer
+# produced.
+test_external_secrets_sources_only_the_facts = lambda {
+    _c = {x.name: x for x in c.get("external-secrets").components}
+    _src = _c["cluster-store-vault"].substitutionSources
+    assert sorted(_src) == ["VAULT_K8S_AUTH_MOUNT_PATH", "VAULT_K8S_AUTH_ROLE"]
+    assert "VAULT_KV_PATH" not in _src, "which mount to read is a decision"
+    assert "VAULT_CSS_NAME" not in _src, "what to call the store is a decision"
 }

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.11.0"
+version = "0.12.0"


### PR DESCRIPTION
Drei weitere Variablen an `cluster-store-vault` kommen zu den zweien aus 0.11.0. **Alle fünf** werden vom Artefakt gedefaultet, und **jeder Default benennt ein anderes Deployment**:

| Variable | Default | zeigt auf |
|---|---|---|
| `VAULT_K8S_AUTH_MOUNT_PATH` | `platform-sthings-eso` | einen anderen Cluster |
| `VAULT_K8S_AUTH_ROLE` | `eso` | einen anderen Cluster |
| `VAULT_CSS_NAME` | `vault-homerun2-cd` | einen anderen Workload |
| `VAULT_KV_PATH` | `homerun2-cd` | einen anderen Mount |
| `VAULT_K8S_AUTH_SA_NAME` | `eso` | eine ServiceAccount, die es nicht gibt |

## Keine Theorie

Auf `u26-rke2-1` am 2026-08-16 erzeugte der erste Render einen `ClusterSecretStore` namens `vault-homerun2-cd`, der den KV-Pfad `homerun2-cd` las und sich als ServiceAccount `eso` authentifizieren wollte — die das Chart gar nicht anlegt (sie heißt `external-secrets`).

**Nichts meldete ein Problem, bis er Vault erreichen wollte.** Ein Store, der auf den falschen Vault zeigt, *sieht konfiguriert aus* — genau die Fehlerklasse, für die `requiredSubstitutions` existiert.

## Entdeckt bleibt entdeckt, entschieden bleibt entschieden

Die beiden **Fakten** behalten ihre `substitutionSources`. Die drei neuen bekommen **keine**, und ein Test hält das fest: welchen Mount ein Cluster liest und wie sein Store heißt, sind **Entscheidungen** — kein Statusfeld kann sie liefern.

## Ein Ausreißer, benannt statt versteckt

`VAULT_K8S_AUTH_SA_NAME` ist eine Eigenschaft des Charts, keine Cluster-Entscheidung — jedes XR wird denselben Wert tippen. Der eigentliche Fix gehört ins Artefakt: der Default sollte die SA benennen, die das Chart wirklich anlegt.

Bis dahin ist `required` die sichere Seite, und der Kommentar sagt, wann die Zeile wieder verschwindet — so wie `MACHINERY_VERSION` nach stuttgart-things/flux#193.

28/28 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL
