### PR TITLE
feat(xplane-platform): pull catalog 0.12.0 (0.16.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.15.0"
+version = "0.16.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.11.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.12.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.11.0"
-    version = "0.11.0"
-    sum = "qIrM/Ba8BdqYsaim8HYFYcYiGEa2E1mE26AqGPLoyys="
+    full_name = "xplane-flux-catalog_0.12.0"
+    version = "0.12.0"
+    sum = "6To7Sub66tRGhgKcNWqua4IcbyIuQ5t6MIgCyc6brRg="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.11.0"
+    oci_tag = "0.12.0"


### PR DESCRIPTION
`xplane-flux-catalog` **0.11.0 → 0.12.0**.

Der `cluster-store-vault` von external-secrets verlangt jetzt **alle fünf** Variablen, die das Artefakt defaultet — weil jeder Default ein anderes Deployment benennt. Live auf `u26-rke2-1` bestätigt: der erste Render erzeugte einen Store, der auf den Vault-Mount eines fremden Workloads zeigte und **nichts meldete**, bis er sich verbinden wollte.

Keine Logikänderung — das Modul konsumiert den Katalog generisch. 46/46 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL