### PR TITLE
fix(xplane-flux-apps): postBuild must be non-empty, not merely present (0.3.0)

### DIFF
--- a/crossplane/xplane-flux-apps/kcl.mod
+++ b/crossplane/xplane-flux-apps/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-apps"
 edition = "v0.11.2"
-version = "0.2.0"
+version = "0.3.0"

--- a/crossplane/xplane-flux-apps/main.k
+++ b/crossplane/xplane-flux-apps/main.k
@@ -70,27 +70,38 @@ _appObject = lambda app: {str:} -> {str:} {
     _sub = app?.substitute or {}
     _subFrom = app?.substituteFrom or []
 
-    # ALWAYS EMITTED, even when the XR supplies nothing. This used to be
-    # conditional, and the conditional form is a trap: kustomize-controller runs
-    # its variable-substitution pass only when spec.postBuild is non-nil, so an
-    # app with no substitute block got NO substitution at all — and every
-    # `${VAR:-default}` fallback in its manifests silently stopped being a
-    # fallback. What reaches the cluster is the literal string:
+    # ALWAYS EMITTED AND NEVER EMPTY. Both halves are load-bearing, and the
+    # second was learned the hard way twice.
+    #
+    # kustomize-controller skips its variable-substitution pass unless there is
+    # something to substitute, so an app with no substitute block gets NO
+    # substitution — and every `${VAR:-default}` fallback in its manifests
+    # silently stops being a fallback. What reaches the cluster is the literal
+    # string:
     #
     #   Namespace/${OPENEBS_NAMESPACE:-openebs} dry-run failed (Invalid):
     #   metadata.name: Invalid value: "${OPENEBS_NAMESPACE:-openebs}"
     #
-    # Found on u26-rke2-1 (2026-08-12) enabling openebs, whose catalog entry
-    # declares zero required substitutions precisely because every variable has
-    # a manifest default. "No REQUIRED substitutions" and "needs no substitute
-    # block" are different claims, and the conditional made the second one false
-    # for every app in the catalog.
+    # 0.2.0 fixed the first half — postBuild is emitted unconditionally — on the
+    # belief that `PostBuild != nil` was the whole condition upstream. IT IS
+    # NOT. Measured on u26-rke2-1, 2026-08-16, with before/after on a running
+    # cluster: with `substitute: {}` the Kustomization stayed
+    # ReconciliationFailed on exactly that error, through a forced reconcile;
+    # adding one real entry made it Ready. It bit openebs first and
+    # external-secrets second, so it is not one app's quirk — it is every app
+    # enabled bare, which is the case the catalog advertises as the easy one.
     #
-    # An empty substitute map is enough: PostBuild != nil is the whole condition
-    # upstream. substituteFrom stays conditional because an empty list is
-    # meaningful there — it would be a source list with no sources.
+    # Hence the marker: one inert entry, whose only job is to be non-empty. It
+    # names its author so nobody deletes it as noise. A user-supplied key of the
+    # same name would win, which is harmless.
+    #
+    # NO LEADING UNDERSCORE in the key. KCL treats an underscore-prefixed
+    # attribute as private and drops it from the emitted output — a marker named
+    # `_XPLANE_FLUX_APPS` renders as `substitute: {}`, i.e. exactly the bug it
+    # exists to prevent, and silently.
+    _marker = {XPLANE_FLUX_APPS = "substitution-marker"}
     _postBuild = {
-        substitute = _sub
+        substitute = _marker | _sub
         **({substituteFrom = _subFrom} if _subFrom else {})
     }
     _appCommon = app?.commonMetadata or _commonMeta
@@ -135,7 +146,8 @@ _appObject = lambda app: {str:} -> {str:} {
                         **({patches = app.patches} if app?.patches else {})
                         **({images = app.images} if app?.images else {})
                         **({decryption = app.decryption} if app?.decryption else {})
-                        # Unconditional, deliberately — see _postBuild above.
+                        # Unconditional AND never empty, deliberately — see
+                        # _postBuild above.
                         postBuild = _postBuild
                     }
                 }

--- a/crossplane/xplane-flux-apps/marker_test.k
+++ b/crossplane/xplane-flux-apps/marker_test.k
@@ -1,0 +1,32 @@
+# Unit tests for the substitution marker. `kcl test`.
+#
+# The marker is one inert entry in postBuild.substitute whose only job is to be
+# non-empty: kustomize-controller skips its substitution pass when there is
+# nothing to substitute, and every `${VAR:-default}` fallback then reaches the
+# cluster as a literal string.
+_marker = {XPLANE_FLUX_APPS = "substitution-marker"}
+
+# THE trap this file exists for. KCL treats an underscore-prefixed attribute as
+# private and DROPS it from the emitted output, so a marker named
+# `_XPLANE_FLUX_APPS` renders as `substitute: {}` — exactly the bug it was added
+# to prevent, and without a word of complaint. Cost a debugging round on
+# 2026-08-16.
+test_marker_key_has_no_leading_underscore = lambda {
+    _keys = [k for k, _ in _marker]
+    assert len([k for k in _keys if k.startswith("_")]) == 0, "KCL drops underscore-prefixed keys from output"
+    assert len(_keys) > 0
+}
+
+# Merging with an empty user map must leave the marker standing — that is the
+# bare-enable case, the one that broke.
+test_marker_survives_an_empty_substitute = lambda {
+    _merged = _marker | {}
+    assert len([k for k, _ in _merged]) == 1, "an app with no substitute still gets a non-empty map"
+}
+
+# And a user's own values must survive beside it.
+test_user_values_are_kept = lambda {
+    _merged = _marker | {DAPR_NAMESPACE = "dapr-system"}
+    assert _merged["DAPR_NAMESPACE"] == "dapr-system"
+    assert _merged["XPLANE_FLUX_APPS"] == "substitution-marker"
+}


### PR DESCRIPTION
0.2.0 machte `postBuild` unbedingt — in der Annahme, `PostBuild != nil` sei die ganze Bedingung, damit kustomize-controller seinen Substitutionsdurchlauf fährt. **Ist es nicht.**

Eine **leere** `substitute`-Map verhält sich exakt wie gar kein `postBuild`, und jeder `${VAR:-default}`-Fallback erreicht den Cluster als literaler String:

```
Namespace/${OPENEBS_NAMESPACE:-openebs} dry-run failed (Invalid)
```

## Gemessen, nicht geschlossen

Auf `u26-rke2-1` am 2026-08-16, Vorher/Nachher am laufenden Cluster: mit `substitute: {}` blieb die Kustomization `ReconciliationFailed` — auch durch eine erzwungene Reconciliation hindurch. **Ein** echter Eintrag machte sie binnen einer Minute `Ready`.

Es ist keine Eigenart einer App. openebs traf es zuerst, external-secrets als zweites — es trifft **jede blank aktivierte App**, also genau den Fall, den der Katalog als den bequemen bewirbt.

## Der Marker

Ein inerter Eintrag, dessen einzige Aufgabe es ist, nicht leer zu sein. Er nennt seinen Urheber, damit ihn niemand als Rauschen entfernt. Ein gleichnamiger Nutzerwert gewinnt, harmlos.

## Kein führender Unterstrich — und ein Test hält das fest

KCL behandelt ein unterstrich-präfigiertes Attribut als **privat** und lässt es aus der Ausgabe fallen. Die erste Fassung dieses Fixes hieß `_XPLANE_FLUX_APPS` und renderte als `substitute: {}` — sie reproduzierte **genau den Fehler, gegen den sie geschrieben war**, lautlos, und kostete eine Debugging-Runde.

3/3 Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL
