### PR TITLE
feat(xplane-platform): a waiting variable is not a broken one (0.17.0)

### DIFF
--- a/crossplane/xplane-platform/README.md
+++ b/crossplane/xplane-platform/README.md
@@ -67,8 +67,48 @@ where it could not be tested at all.
 | a dependency's app is not enabled | rejected, naming what to add: `trust-manager-install depends on cert-manager:install, but app 'cert-manager' is not enabled — add it to spec.apps`. Deliberately **not** auto-enabled: a toggle that silently installs artifacts you did not list gets confusing with transitive chains, and conflicts with disable-prunes |
 | a dependency's component is disabled | rejected the same way |
 | catalog `optional` components | not deployed unless the XR enables them explicitly |
-| required substitution variable not supplied | rejected — Flux substitutes empty strings rather than failing, so this would deploy silently broken. Satisfied by `substitute` keys, or skipped when the component carries a `substituteFrom` (resolved at build time, not statically checkable) |
+| required substitution variable not supplied, and **no** `substitutionSources` entry declares where it could come from | rejected — Flux substitutes empty strings rather than failing, so this would deploy silently broken. Satisfied by `substitute` keys, or skipped when the component carries a `substituteFrom` (resolved at build time, not statically checkable) |
+| required substitution variable not supplied, but a `substitutionSources` entry declares one | **the component is deferred**, not rejected — see below |
 | disabling an app | prunes it — the entry stops being emitted, and flux-apps' Objects use `managementPolicies: ["*"]`, so the Kustomization and its workload are removed |
+
+### Deferring, not aborting
+
+A required variable that nothing supplies is one of two very different things,
+and treating them alike made some apps impossible to enable at all
+([crossplane-configurations#277](https://github.com/stuttgart-things/crossplane-configurations/issues/277)):
+
+- **no source declared** — nothing will ever supply it. A typo or a missing
+  decision. Fatal, by name, at render time.
+- **a source declared** — the platform *can* discover it, just not yet. The
+  status it reads is produced by this same Composition, so on the reconcile that
+  enables both halves it is legitimately absent.
+
+The second used to be fatal too, which deadlocked: enabling
+`vaultIssuer.additionalAuths[eso]` and `apps.external-secrets` in one step
+aborted the render **before** it emitted the `VaultK8sAuth` the app was waiting
+for. Nothing converged, and because a failed render emits nothing, every
+*unrelated* component stopped reconciling with it. Only a second, manual apply
+escaped it.
+
+Now such a component is held back — **alone**, not with its siblings. That
+distinction is the point: `external-secrets/install` deploys the operator on the
+very reconcile that `external-secrets/cluster-store-vault` waits through, and
+the store needs a CRD that operator owns anyway.
+
+Held-back components are listed on the XR:
+
+```yaml
+status:
+  components:
+    fluxApps:
+      pendingSubstitutions:
+        - "external-secrets-cluster-store-vault: VAULT_K8S_AUTH_MOUNT_PATH"
+```
+
+They are absent from `appCount`, so without that list an app enabled on the XR
+would simply not appear anywhere — indistinguishable from being ignored. The
+list is expected to empty out on its own; one that stays put names both the
+variable and the component that wants it.
 
 ## Overrides
 

--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.16.0"
+version = "0.17.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.12.0" }

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -206,6 +206,11 @@ appEntries = lambda spec: {str:}, discovered: {str:} = {} -> [{str:}] {
     An app is not necessarily one Kustomization (dapr ships control-plane +
     template-execution), so components are expanded here and dependsOn is
     rewritten to the emitted '{app}-{component}' names.
+
+    A component still WAITING for a discoverable value is held back rather than
+    emitted blank — see componentIsPending. It is held back alone: its siblings
+    keep deploying, which is what lets external-secrets install the operator on
+    the reconcile before its ClusterSecretStore learns the auth mount path.
     """
     sum([[{
         name = "{}-{}".format(_n, _c.name)
@@ -223,34 +228,83 @@ appEntries = lambda spec: {str:}, discovered: {str:} = {} -> [{str:}] {
             substituteFrom = ((_a?.components or {})[_c.name] or {}).substituteFrom
         if (((_a?.components or {})[_c.name] or {})?.targetNamespace or _a?.targetNamespace):
             targetNamespace = ((_a?.components or {})[_c.name] or {})?.targetNamespace or _a?.targetNamespace
-    } for _c in cat.get(_n).components if compEnabled(_c, (_a?.components or {})[_c.name] or {})] for _n, _a in enabledApps(spec)], [])
+    } for _c in cat.get(_n).components if compEnabled(_c, (_a?.components or {})[_c.name] or {}) and not componentIsPending(_a, _c, discovered)] for _n, _a in enabledApps(spec)], [])
 }
 
 _compOverride = lambda app: {str:}, name: str -> {str:} {
     (app?.components or {})[name] or {}
 }
 
-_appMissing = lambda name: str, app: {str:}, discovered: {str:} = {} -> [str] {
-    """Required vars of one app that nothing supplies. A component carrying
-    substituteFrom is skipped — its values come from a ConfigMap/Secret resolved
-    at build time, which cannot be checked statically."""
-    _supplied = lambda cname: str, comp: cs.Component -> {str:} {
-        # A value the platform can discover counts as supplied — that is the
-        # point of substitutionSources. Only resolvable ones count; an entry
-        # that reads nothing still fails here, by name.
-        discoveredSubstitutions(comp, discovered) | (app?.substitute or {}) | (_compOverride(app, cname)?.substitute or {})
-    }
-    _checked = [c for c in cat.get(name).components if compEnabled(c, _compOverride(app, c.name)) and not _compOverride(app, c.name)?.substituteFrom]
-    sum([[name + "-" + c.name + ": " + v for v in c.requiredSubstitutions if v not in _supplied(c.name, c)] for c in _checked], [])
+_compSupplied = lambda app: {str:}, cname: str, comp: cs.Component, discovered: {str:} -> {str:} {
+    """Everything that supplies a value to one component, discovered included.
+
+    A value the platform can discover counts as supplied — that is the point of
+    substitutionSources. Only RESOLVABLE ones count; an entry that reads nothing
+    is still missing."""
+    discoveredSubstitutions(comp, discovered) | (app?.substitute or {}) | (_compOverride(app, cname)?.substitute or {})
+}
+
+_checkedComps = lambda name: str, app: {str:} -> [cs.Component] {
+    """Enabled components worth checking. One carrying substituteFrom is skipped
+    — its values come from a ConfigMap/Secret resolved at build time, which
+    cannot be checked statically."""
+    [c for c in cat.get(name).components if compEnabled(c, _compOverride(app, c.name)) and not _compOverride(app, c.name)?.substituteFrom]
+}
+
+# A required variable that nothing supplies is one of two very different things,
+# and treating them alike is what made an app impossible to enable
+# (crossplane-configurations#277).
+#
+#   NO source declared    nothing will ever supply it — a typo or missing
+#                         config. Fatal: reject at render time, by name.
+#   source declared       the platform CAN discover it, just not yet — the
+#                         status it reads from is produced by this same
+#                         Composition. A transient state, not an error.
+#
+# The second used to be fatal too, which deadlocked: enabling
+# `vaultIssuer.additionalAuths[eso]` and `apps.external-secrets` in one step
+# aborted the whole Composition BEFORE it emitted the auth the app was waiting
+# for. Nothing converged, and every other component stopped reconciling with it.
+_compMissing = lambda app: {str:}, comp: cs.Component, discovered: {str:} -> [str] {
+    _sup = _compSupplied(app, comp.name, comp, discovered)
+    [v for v in comp.requiredSubstitutions if v not in _sup]
+}
+
+_compPending = lambda app: {str:}, comp: cs.Component, discovered: {str:} -> [str] {
+    """Missing variables the component knows how to discover — waiting, not broken."""
+    [v for v in _compMissing(app, comp, discovered) if v in (comp?.substitutionSources or {})]
+}
+
+_compFatal = lambda app: {str:}, comp: cs.Component, discovered: {str:} -> [str] {
+    """Missing variables nothing can ever supply."""
+    [v for v in _compMissing(app, comp, discovered) if v not in (comp?.substitutionSources or {})]
+}
+
+componentIsPending = lambda app: {str:}, comp: cs.Component, discovered: {str:} -> bool {
+    """Hold this component back this reconcile: it is waiting on a value the
+    platform will produce. Emitting it with the variable unset would deploy
+    something that looks configured and is not."""
+    len(_compPending(app, comp, discovered)) > 0
 }
 
 missingSubstitutions = lambda spec: {str:}, discovered: {str:} = {} -> [str] {
-    """Required substitution variables that nothing supplies.
+    """Required substitution variables that NOTHING can supply — fatal.
 
     Flux replaces an undefined variable with an empty string instead of failing,
-    so a missing one is a silently broken deploy — that is what this catches.
+    so a missing one is a silently broken deploy. Variables the component
+    declares a source for are excluded here and reported by
+    pendingSubstitutions instead; see the note above _compMissing.
     """
-    sum([_appMissing(n, a, discovered) for n, a in enabledApps(spec)], [])
+    sum([[n + "-" + c.name + ": " + v for c in _checkedComps(n, a) for v in _compFatal(a, c, discovered)] for n, a in enabledApps(spec)], [])
+}
+
+pendingSubstitutions = lambda spec: {str:}, discovered: {str:} = {} -> [str] {
+    """Variables a component is WAITING for — discoverable, not yet discovered.
+
+    Published on the status so a held-back component reads as waiting rather
+    than as forgotten. Without that, an app enabled on the XR simply would not
+    appear, which is the second-worst kind of silence."""
+    sum([[n + "-" + c.name + ": " + v for c in _checkedComps(n, a) for v in _compPending(a, c, discovered)] for n, a in enabledApps(spec)], [])
 }
 
 _compEnabled = lambda apps: {str:}, appName: str, compName: str -> bool {

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -151,12 +151,17 @@ test_explicit_substitute_satisfies_required = lambda {
     assert len(l.missingSubstitutions(spec)) == 0
 }
 
+# Three variables, but not three of the same kind. HOSTNAME and GATEWAY_NAME
+# are decisions nothing can look up — fatal. DOMAIN is discoverable, so a bare
+# enable is rejected for two, not three.
 test_headlamp_missing_vars_detected = lambda {
-    assert len(l.missingSubstitutions({
+    _spec = {
         apps = {
             headlamp = {}
         }
-    })) == 3
+    }
+    assert len(l.missingSubstitutions(_spec)) == 2
+    assert l.pendingSubstitutions(_spec) == ["headlamp-app: DOMAIN"]
 }
 
 # --- cross-artifact dependsOn -------------------------------------------------
@@ -344,8 +349,12 @@ test_apps_cilium_bare_enable_is_rejected = lambda {
             cilium = {enabled = True}
         }
     })
-    assert len(_m) == 4, "all four cilium vars are required"
-    assert "cilium-config: CILIUM_GATEWAY_DOMAIN" in _m
+    assert _m == ["cilium-config: CILIUM_GATEWAY_TLS_SECRET"], "the one nothing can look up"
+    assert len(l.pendingSubstitutions({
+        apps = {
+            cilium = {enabled = True}
+        }
+    })) == 3, "the other three wait for the reservation"
 }
 
 # The wildcard the clusterbook reservation publishes is not the domain — the
@@ -399,7 +408,8 @@ test_discovery_satisfies_required_substitutions = lambda {
     _spec = {clusterName = "c", apps = {
         cilium = {enabled = True}
     }}
-    assert len(l.missingSubstitutions(_spec)) == 4, "nothing discovered: all four missing"
+    assert len(l.pendingSubstitutions(_spec)) == 3, "nothing discovered yet: three still waiting"
+    assert len(l.pendingSubstitutions(_spec, _disc)) == 0, "discovery clears all three"
     _m = l.missingSubstitutions(_spec, _disc)
     assert _m == ["cilium-config: CILIUM_GATEWAY_TLS_SECRET"], "only the decision is left"
 }
@@ -448,7 +458,7 @@ test_apps_headlamp_discovers_its_domain = lambda {
         }}
     }}
     assert len(l.missingSubstitutions(_spec, _d)) == 0, "DOMAIN comes from the status"
-    assert len(l.missingSubstitutions(_spec)) == 1, "and is still required when nothing was discovered"
+    assert l.pendingSubstitutions(_spec) == ["headlamp-app: DOMAIN"], "and is still awaited when nothing was discovered"
     _k = [k for k in l.appEntries(_spec, _d) if k.name == "headlamp-app"][0]
     assert _k.substitute["DOMAIN"] == "u26-rke2-1.sthings-vsphere.labul.sva.de"
 }
@@ -548,4 +558,66 @@ test_resolve_source_missing_auth_is_empty = lambda {
         }
     }
     assert l.resolveSource(_d, "vaultIssuer.auths.eso.mountPath") == ""
+}
+
+# --- deferral instead of abort (crossplane-configurations#277) -----------------
+
+# The deadlock this replaced: enabling the eso auth and the app in ONE step made
+# the render abort, so the Composition never emitted the VaultK8sAuth the app
+# was waiting for — and every unrelated component stopped reconciling with it.
+# Nothing about that state converges; only a second, manual apply escaped it.
+_esoSpec = {clusterName = "c", apps = {
+    "external-secrets" = {
+        enabled = True
+        components = {
+            "cluster-store-vault" = {enabled = True, substitute = {
+                VAULT_CSS_NAME = "vault"
+                VAULT_KV_PATH = "clusters"
+                VAULT_K8S_AUTH_SA_NAME = "eso"
+            }}
+        }
+    }
+}}
+
+test_pending_component_does_not_abort_the_render = lambda {
+    assert l.missingSubstitutions(_esoSpec) == [], "nothing here is unsuppliable"
+    assert l.validate(_esoSpec), "so the render proceeds"
+    assert len(l.pendingSubstitutions(_esoSpec)) == 2, "mount path and role are awaited"
+}
+
+# Held back ALONE. The operator must install on this very reconcile — the store
+# it is waiting for is a CRD that operator owns.
+test_pending_component_is_held_back_alone = lambda {
+    _names = [e.name for e in l.appEntries(_esoSpec)]
+    assert "external-secrets-install" in _names, "the operator still deploys"
+    assert "external-secrets-cluster-store-vault" not in _names, "the store waits"
+}
+
+# And released once the auth this same Composition creates lands in the status.
+test_pending_component_is_released_by_discovery = lambda {
+    _d = {
+        vaultIssuer = {
+            auths = {
+                eso = {mountPath = "c-eso", role = "eso"}
+            }
+        }
+    }
+    assert l.pendingSubstitutions(_esoSpec, _d) == []
+    _k = [e for e in l.appEntries(_esoSpec, _d) if e.name == "external-secrets-cluster-store-vault"][0]
+    assert _k.substitute["VAULT_K8S_AUTH_MOUNT_PATH"] == "c-eso", "discovered, not typed"
+}
+
+# A variable nothing declares a source for stays fatal. Deferring THAT would
+# swap a loud failure for a component that silently never appears.
+test_unsuppliable_variable_is_still_fatal = lambda {
+    assert len(l.missingSubstitutions({
+        apps = {
+            "nfs-csi" = {enabled = True}
+        }
+    })) == 2
+    assert l.pendingSubstitutions({
+        apps = {
+            "nfs-csi" = {enabled = True}
+        }
+    }) == []
 }

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -559,6 +559,14 @@ _xrStatus = _oxr | {
                 ready = _appsReady
                 appCount = _appsStatus?.appCount or 0
                 readyCount = _appsStatus?.readyCount or 0
+                # Components held back this reconcile, waiting on a value this
+                # same Composition still has to produce (see
+                # l.pendingSubstitutions). They are absent from appCount, so
+                # without this line an app enabled on the XR would just not
+                # appear anywhere — indistinguishable from being ignored.
+                # Expected to empty out on its own; one that stays put names the
+                # variable and the component that wants it.
+                pendingSubstitutions = l.pendingSubstitutions(_spec, _discovered)
             }
             ipReservation = {
                 enabled = _ipResEnabled


### PR DESCRIPTION
## Was

Ein required Substitution-Variable, die niemand liefert, war bisher **immer** fatal. Es sind aber zwei sehr verschiedene Fälle:

| Situation | bisher | jetzt |
|---|---|---|
| kein Wert, **keine** Quelle deklariert | fatal | fatal |
| kein Wert, Quelle deklariert, Gruppe fehlt im Status | fatal | **zurückgestellt** |
| kein Wert, Quelle deklariert, Gruppe da, Feld fehlt | fatal | zurückgestellt |

## Warum

`vaultIssuer.additionalAuths[eso]` + `apps.external-secrets` in einem Schritt zu aktivieren hat den Render abgebrochen, **bevor** er die `VaultK8sAuth` emittiert hat, auf die die App wartet. Der Wert erschien nie, der nächste Reconcile brach identisch ab. Und weil ein fehlgeschlagener Render gar nichts emittiert, hat es auch jede **unbeteiligte** Komponente mitgerissen. Nur ein zweiter, manueller Apply kam da raus — also kein Zustand, der von allein konvergiert.

## Wie

- `missingSubstitutions` behält die fatale Menge, `pendingSubstitutions` meldet die wartende, `validate` asserted nur noch auf die erste
- eine wartende Komponente wird **zurückgehalten** statt mit leerer Variable emittiert (Flux substituiert `""` statt zu scheitern)
- zurückgehalten wird sie **allein**, nicht mit ihren Geschwistern: `external-secrets/install` deployt den Operator genau in dem Reconcile, den `cluster-store-vault` abwartet — und der Store braucht ohnehin ein CRD aus diesem Operator
- veröffentlicht auf `status.components.fluxApps.pendingSubstitutions`, sonst wäre eine aktivierte App einfach unsichtbar

## Tests

50/50 (4 neue für das Deferral, 4 bestehende auf den Split umgestellt).

Refs: stuttgart-things/crossplane-configurations#277