### PR TITLE
feat(xplane-vault-auth-base): build the policy body, stop accepting it (0.10.0)

### DIFF
--- a/crossplane/xplane-vault-auth-base/kcl.mod
+++ b/crossplane/xplane-vault-auth-base/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth-base"
 edition = "v0.11.0"
-version = "0.9.0"
+version = "0.10.0"
 description = "KCL library for creating Vault Kubernetes authentication backends as Crossplane v2 namespaced OpenTofu Workspaces"
 
 [dependencies]

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -300,8 +300,8 @@ _policyBody = lambda clusterName: str, policy: VaultPolicy -> str {
         clusterName if scope == "own" else scope
     }
     "\n".join(sum([[
-        'path "' + policy.kvMount + '/data/' + _subtree(s) + '/*" { capabilities = ["read"] }',
-        'path "' + policy.kvMount + '/metadata/' + _subtree(s) + '/*" { capabilities = ["read", "list"] }',
+        'path "' + policy.kvMount + '/data/' + _subtree(s) + '/*" { capabilities = ["read"] }'
+        'path "' + policy.kvMount + '/metadata/' + _subtree(s) + '/*" { capabilities = ["read", "list"] }'
     ] for s in policy.read], [])) + "\n"
 }
 

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -1,6 +1,7 @@
 # Library module — not runnable standalone.
 # Generates Crossplane v2 namespaced OpenTofu Workspaces that configure
 # Vault Kubernetes auth backends (optionally with backend_config).
+import regex
 import json
 import v1beta1 as otf
 
@@ -18,23 +19,44 @@ schema K8sAuthBackendConfig:
     disableLocalCaJwt?: bool = True
 
 schema VaultPolicy:
-    """One Vault ACL policy, created for the auth that declares it."""
+    """One Vault ACL policy, created for the auth that declares it.
+
+    The body is BUILT here, from a bounded description — it is deliberately not
+    accepted as HCL. A free-form body plus the ability to bind it to your own
+    role is the right to grant yourself anything: a cluster could write
+    `path "clusters/*" { capabilities = ["read"] }` and read every other
+    cluster's secrets. Restricting the policy NAME does not help, because Vault
+    cannot restrict what a policy body contains — so the body has to come from
+    here. See crossplane-configurations#285.
+
+    What remains configurable is the part that is safe to configure: which KV
+    mount, and which subtrees of it. Not the paths, not the capabilities, not
+    the mount type — nothing that could name `sys/`, `auth/`, or `sudo`.
+    """
     name: str
     """Suffix. The policy is named `{clusterName}-{name}`, so two clusters
     granting the same kind of access do not collide on one object."""
 
-    rules: str
-    """HCL body, verbatim. The cluster's own subtree is the usual case:
+    kvMount: str
+    """The KV v2 mount the grants apply to, e.g. `clusters`. One mount per
+    policy: a grant that spans mounts is two grants with two lifetimes."""
 
-        path "kv/data/mgmt-test1/*" { capabilities = ["read"] }
+    read: [str]
+    """Subtrees of kvMount to grant read on. The literal `own` expands to this
+    cluster's own subtree — a cluster cannot spell another cluster's name into
+    that position and get it, because `own` is the only value that resolves to a
+    cluster name.
 
-    Taken as given rather than templated here: this module does not know which
-    paths a fleet uses, and a helper that guessed would be wrong the first time
-    someone needed a shared tree."""
+    A LIST because one cluster rarely wants one subtree: its own, plus whatever
+    a role it plays grants it — a cluster with the cicd profile reads the cicd
+    tree as well as its own.
+    """
 
     check:
         len(name) > 0, "a policy needs a name"
-        len(rules) > 0, "a policy with no rules grants nothing and hides that it does"
+        len(kvMount) > 0, "a policy needs the KV mount its grants apply to"
+        len(read) > 0, "a policy that grants no read grants nothing and hides that it does"
+        all s in read {regex.match(s, r"^[a-z0-9][a-z0-9._-]*$")}, "a subtree is a plain name, not a path — no slashes, no globs, no traversal"
 
 schema K8sAuth:
     name: str
@@ -263,6 +285,26 @@ _terraformBlock = lambda hasBackendConfig: bool -> str {
     'terraform {\n  required_providers {\n    vault = {\n      source  = "hashicorp/vault"\n      version = "~> 3.25"\n    }' + _k8s + '\n  }\n}\n\n'
 }
 
+# The policy body is built HERE and nowhere else — see VaultPolicy for why it
+# is not accepted as HCL. Every path is anchored at "{mount}/data/" or
+# "{mount}/metadata/", every capability list is a literal, and the only value
+# that ever reaches a path is a subtree name the schema has already constrained
+# to [a-z0-9._-]. There is no input that can widen this beyond read on one KV
+# mount.
+#
+# metadata gets list as well as read: without it `vault kv list` and the ESO
+# `find` selector fail on a tree the token can otherwise read, which reads like
+# a missing secret rather than a missing capability.
+_policyBody = lambda clusterName: str, policy: VaultPolicy -> str {
+    _subtree = lambda scope: str -> str {
+        clusterName if scope == "own" else scope
+    }
+    "\n".join(sum([[
+        'path "' + policy.kvMount + '/data/' + _subtree(s) + '/*" { capabilities = ["read"] }',
+        'path "' + policy.kvMount + '/metadata/' + _subtree(s) + '/*" { capabilities = ["read", "list"] }',
+    ] for s in policy.read], [])) + "\n"
+}
+
 _listToJson = lambda items: [str] -> str {
     '["' + '","'.join(items) + '"]'
 }
@@ -277,7 +319,7 @@ _baseVars = lambda auth: K8sAuth -> [{str:str}] {
         {key = "token_ttl", value = str(auth.tokenTtl)}
         {key = "bound_service_account_names", value = _listToJson(auth.boundServiceAccountNames)}
         {key = "bound_service_account_namespaces", value = _listToJson(auth.boundServiceAccountNamespaces)}
-        {key = "policies", value = json.encode({p.name: p.rules for p in (auth.policies or [])})}
+        {key = "policies", value = json.encode({p.name: _policyBody(auth.clusterName, p) for p in (auth.policies or [])})}
     ]
 }
 

--- a/crossplane/xplane-vault-auth-base/policy_test.k
+++ b/crossplane/xplane-vault-auth-base/policy_test.k
@@ -1,4 +1,5 @@
 # Unit tests for per-auth policy creation. `kcl test`.
+import regex
 import .main as m
 
 _auth = lambda name: str, policies: [m.VaultPolicy] -> m.K8sAuth {
@@ -13,14 +14,16 @@ _auth = lambda name: str, policies: [m.VaultPolicy] -> m.K8sAuth {
 
 _own = m.VaultPolicy {
     name = "kv-own"
-    rules = "path \"kv/data/mgmt-test1/*\" { capabilities = [\"read\"] }"
+    kvMount = "kv"
+    read = ["own"]
 }
 
 # A cluster that plays the cicd role reads that tree too — a separate grant with
 # a separate lifetime, not a longer body on the first policy.
 _cicd = m.VaultPolicy {
     name = "kv-cicd"
-    rules = "path \"kv/data/cicd/*\" { capabilities = [\"read\"] }"
+    kvMount = "kv"
+    read = ["cicd"]
 }
 
 _cfg = lambda auths: [m.K8sAuth] -> m.VaultConfig {
@@ -62,7 +65,62 @@ test_several_policies_per_auth = lambda {
 # assembled by string concatenation the way the name lists are.
 test_policy_bodies_survive_encoding = lambda {
     _v = json.decode(_vars(m.vaultK8sAuth(_cfg([_auth("eso", [_own])]))[0])["policies"])
-    assert _v["kv-own"] == _own.rules, "quotes must come back exactly as written"
+    assert "\n" in _v["kv-own"], "a multi-line body must come back multi-line"
+    assert _v["kv-own"].count("path \"") == 2, "data and metadata, per subtree"
+}
+
+# --- the body is BUILT, not accepted (crossplane-configurations#285) ---------
+
+# `own` is the only value that resolves to a cluster name. A cluster cannot put
+# another cluster's name in that position and be granted it — it would just get
+# a subtree of that literal name, which is not where anyone's secrets live.
+test_own_expands_to_this_cluster = lambda {
+    _v = json.decode(_vars(m.vaultK8sAuth(_cfg([_auth("eso", [_own])]))[0])["policies"])
+    assert 'path "kv/data/mgmt-test1/*" { capabilities = ["read"] }' in _v["kv-own"]
+    assert 'path "kv/metadata/mgmt-test1/*" { capabilities = ["read", "list"] }' in _v["kv-own"]
+}
+
+# metadata needs list as well as read, or `vault kv list` and the ESO `find`
+# selector fail on a tree the token can otherwise read — which reads like a
+# missing secret rather than a missing capability.
+test_metadata_gets_list = lambda {
+    _v = json.decode(_vars(m.vaultK8sAuth(_cfg([_auth("eso", [_own])]))[0])["policies"])
+    assert '"read", "list"' in _v["kv-own"]
+}
+
+# A named subtree stays a named subtree — this is the cicd case, and it must NOT
+# pick up the cluster name.
+test_named_subtree_is_not_rewritten = lambda {
+    _v = json.decode(_vars(m.vaultK8sAuth(_cfg([_auth("eso", [_cicd])]))[0])["policies"])
+    assert 'path "kv/data/cicd/*"' in _v["kv-cicd"]
+    assert "mgmt-test1" not in _v["kv-cicd"]
+}
+
+# Every path is anchored at the declared mount, and no capability beyond
+# read/list ever appears. This is the whole security property in one assertion:
+# there is no input that reaches `sys/`, `auth/`, or `sudo`.
+test_nothing_escapes_the_kv_mount = lambda {
+    _both = m.VaultPolicy {name = "wide", kvMount = "clusters", read = ["own", "cicd", "platform"]}
+    _v = json.decode(_vars(m.vaultK8sAuth(_cfg([_auth("eso", [_both])]))[0])["policies"])["wide"]
+    _lines = _v.splitlines()
+    assert all l in _lines {
+        l == "" or l.startswith('path "clusters/data/') or l.startswith('path "clusters/metadata/')
+    }, "every path is anchored at the declared KV mount"
+    assert "sudo" not in _v and "create" not in _v and "delete" not in _v and "update" not in _v
+    assert _v.count("path \"") == 6, "three subtrees, data and metadata each"
+}
+
+# A subtree name is a plain name. A slash, a glob or a traversal would each let
+# someone write a PATH into a position the body-builder anchors — which is the
+# one thing the schema check exists to stop. KCL raises on a failing check at
+# construction, which a test cannot catch, so the pattern itself is asserted
+# here; the schema applies the same one.
+_subtreePattern = r"^[a-z0-9][a-z0-9._-]*$"
+test_a_subtree_cannot_be_a_path = lambda {
+    _good = ["own", "cicd", "u26-rke2-1", "platform.v2"]
+    assert all n in _good {regex.match(n, _subtreePattern)}, "plain names pass"
+    _bad = ["a/b", "../etc", "*", "sys/policies", "own/*", "", "/abs", "UPPER"]
+    assert all n in _bad {not regex.match(n, _subtreePattern)}, "anything that could be a path does not"
 }
 
 # THE point of doing this in one plan. Vault accepts a role naming a policy that


### PR DESCRIPTION
`VaultPolicy` nahm `rules` als wörtliches HCL. Zusammen mit der Möglichkeit, die entstehende Policy an die **eigene** Auth-Role zu binden, ist das das Recht, sich beliebige Rechte auszustellen:

```hcl
path "clusters/*" { capabilities = ["read"] }   # alle Cluster, nicht nur der eigene
```

Den **Namen** der Policy zu beschränken hilft nicht — Vault kann nicht beschränken, was in einem Policy-Body steht. Also muss der Body hier entstehen statt hereingereicht zu werden ([crossplane-configurations#285](https://github.com/stuttgart-things/crossplane-configurations/issues/285)).

## Was an die Stelle tritt

Der Teil, der sicher konfigurierbar ist: welcher KV-Mount, und welche Teilbäume davon.

```yaml
policies:
  - name: secrets
    kvMount: clusters
    read: [own, cicd]
```

Daraus baut das Modul:

```hcl
path "clusters/data/u26-rke2-1/*"     { capabilities = ["read"] }
path "clusters/metadata/u26-rke2-1/*" { capabilities = ["read", "list"] }
path "clusters/data/cicd/*"           { capabilities = ["read"] }
path "clusters/metadata/cicd/*"       { capabilities = ["read", "list"] }
```

Beide Achsen bleiben also erhalten — eigener Baum **und** geteilte Bäume, wie beim cicd-Profil.

## Warum das dicht ist

- **`own` ist der einzige Wert, der zu einem Clusternamen wird.** Wer den Namen eines Nachbarn hinschreibt, bekommt einen Teilbaum *dieses Literals* — dort liegen keine Secrets.
- **Teilbaum-Namen sind auf `[a-z0-9._-]` beschränkt** (Schema-Check): kein Slash, kein Glob, keine Traversierung erreicht die Stelle, die der Builder verankert.
- **Jeder Pfad ist an `{mount}/data/` oder `{mount}/metadata/` verankert**, jede Capability-Liste ist ein Literal. Es gibt keine Eingabe, die `sys/`, `auth/` oder `sudo` erreicht — ein Test behauptet genau das über eine Policy mit drei Teilbäumen.

`metadata` bekommt `list` zusätzlich zu `read`: ohne das scheitern `vault kv list` und der ESO-`find`-Selector auf einem Baum, den das Token sonst lesen kann — und das sieht aus wie ein fehlendes Secret statt wie eine fehlende Capability.

## Bruch

Bewusst, und folgenlos: **nichts** benutzt `rules`. `u26-rke2-1` referenziert eine extern angelegte Policy über `tokenPolicies`, das bleibt unberührt.

Die Nachziehkette (`xplane-vault-auth`-Pin, dann die XRDs von `vault-auth` und `platform`) folgt, sobald 0.10.0 veröffentlicht ist.

Refs stuttgart-things/crossplane-configurations#285