### PR TITLE
feat(xplane-vault-auth): carry the bounded policy shape through (0.7.0)

### DIFF
--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
-xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.9.0" }
+xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.10.0" }

--- a/crossplane/xplane-vault-auth/kcl.mod.lock
+++ b/crossplane/xplane-vault-auth/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-vault-auth-base]
     name = "xplane-vault-auth-base"
-    full_name = "xplane-vault-auth-base_0.9.0"
-    version = "0.9.0"
-    sum = "tuiEOI4H8BtjDD4ou9uh4Mq1EwF1RVmjX0ZwSRqAyhg="
+    full_name = "xplane-vault-auth-base_0.10.0"
+    version = "0.10.0"
+    sum = "0T+h2exi34BfdJcSYAKTr5DM6GCjqSP2FEHQ6n6FNRo="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-vault-auth-base"
-    oci_tag = "0.9.0"
+    oci_tag = "0.10.0"

--- a/crossplane/xplane-vault-auth/main.k
+++ b/crossplane/xplane-vault-auth/main.k
@@ -42,7 +42,8 @@ _k8sAuths = [vault_auth.K8sAuth {
     # KV subtree, plus whatever the role it plays grants it.
     policies = [vault_auth.VaultPolicy {
         name = p?.name or "default"
-        rules = p?.rules or ""
+        kvMount = p?.kvMount or ""
+        read = p?.read or []
     } for p in (auth?.policies or [])]
     backendConfig = _buildBackendConfig(auth?.backendConfig)
 } for auth in (_spec?.k8sAuths or [


### PR DESCRIPTION
Zieht `xplane-vault-auth-base` **0.10.0** nach ([kcl#136](https://github.com/stuttgart-things/kcl/pull/136)) und reicht die Ersatzfelder statt `rules` durch:

```yaml
policies:
  - name: secrets
    kvMount: clusters
    read: [own, cicd]
```

Freies HCL zusammen mit der Möglichkeit, die entstehende Policy an die eigene Auth-Role zu binden, ist das Recht, sich beliebige Rechte auszustellen — und den **Namen** zu beschränken hilft nicht, weil Vault nicht beschränken kann, was in einem Policy-Body steht. Siehe [crossplane-configurations#285](https://github.com/stuttgart-things/crossplane-configurations/issues/285).

Dieses Modul reicht nur durch: der Body, die Pfad-Verankerung und die `own`-Auflösung liegen im Base-Modul, und dort liegen auch die Tests dafür.

Tests hier: 6/6.