### PR TITLE
fix(xplane-cluster): Usage names collided across ClusterStacks (0.7.0)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -394,12 +394,28 @@ managementPlaneChild = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
 # `kubectl delete` is swallowed and has to be issued twice.
 #
 # Usage orders DELETION ONLY, never creation: build order stays the ready gates.
-usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str, replay: bool -> {str:any} {
+#
+# `label` identifies the Usage WITHIN the composition and must stay stable;
+# `prefix` (the cluster name) is what makes the emitted OBJECT unique in the
+# namespace. They were the same string until 0.7.0, and that was a real defect:
+# every ClusterStack in a namespace emitted `access-uses-vm`, `platform-uses-vm`
+# and so on under those exact names, so the FIRST one to be created owned them
+# and every later one failed to apply with
+#
+#   Usage.protection.crossplane.io "access-uses-vm" is invalid:
+#   metadata.ownerReferences: Invalid value: [... ClusterStack "<the-first-one>"]
+#
+# — Kubernetes refuses a second controller owner. The later ClusterStack then
+# sits at Synced=False forever, while its own status.ready still reports true,
+# so it reads as finished. Observed on kind3 with three stacks: the 4-day-old
+# one held all four names, a 26-hour-old one had been unsynced that whole time
+# unnoticed, and a third could not be built at all.
+usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str, replay: bool, prefix: str -> {str:any} {
     {
         apiVersion = "protection.crossplane.io/v1beta1"
         kind = "Usage"
         metadata = {
-            name = label
+            name = "{}-{}".format(prefix, label)
             annotations = {"krm.kcl.dev/composition-resource-name" = label}
         }
         spec = {

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -204,19 +204,19 @@ test_platform_passthrough_and_derived_clusterName = lambda {
 # between an ordered teardown and Objects stuck on finalizers against a dead
 # API server.
 test_usage_protects_the_vm_from_the_platform = lambda {
-    _u = l.usage("NativeProxmoxVM", "c-vm", "Platform", "c-platform", "platform-uses-vm", True)
+    _u = l.usage("NativeProxmoxVM", "c-vm", "Platform", "c-platform", "platform-uses-vm", True, "c")
     assert _u.spec.of.kind == "NativeProxmoxVM"
     assert _u.spec.by.kind == "Platform"
     assert _u.spec.replayDeletion
 }
 
 test_usage_resolves_the_group_per_kind = lambda {
-    assert l.usage("NativeVsphereVM", "a", "Platform", "b", "u", True).spec.of.apiVersion == "resources.stuttgart-things.com/v1alpha1"
-    assert l.usage("ClusterAccess", "a", "Platform", "b", "u", True).spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
+    assert l.usage("NativeVsphereVM", "a", "Platform", "b", "u", True, "c").spec.of.apiVersion == "resources.stuttgart-things.com/v1alpha1"
+    assert l.usage("ClusterAccess", "a", "Platform", "b", "u", True, "c").spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
 
     # The teardown guard points at the COMPOSITE, which lives in the same group
     # as ClusterAccess and Platform — so it needs no special case in the lambda.
-    assert l.usage("ClusterStack", "a", "Platform", "b", "u", False).spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
+    assert l.usage("ClusterStack", "a", "Platform", "b", "u", False, "c").spec.of.apiVersion == "config.stuttgart-things.com/v1alpha1"
 }
 
 # The guard that makes a one-phase teardown impossible rather than silently
@@ -225,7 +225,7 @@ test_usage_resolves_the_group_per_kind = lambda {
 # the whole stack — an abandoned `kubectl delete` would turn a later, unrelated
 # `platformEnabled: false` into a surprise teardown of the entire cluster.
 test_stack_guard_does_not_replay_deletion = lambda {
-    _g = l.usage("ClusterStack", "c", "Platform", "c-platform", "stack-uses-platform", False)
+    _g = l.usage("ClusterStack", "c", "Platform", "c-platform", "stack-uses-platform", False, "c")
     assert _g.spec.of.kind == "ClusterStack"
     assert _g.spec.of.resourceRef.name == "c"
     assert _g.spec.by.kind == "Platform"
@@ -470,4 +470,43 @@ test_management_plane_child_ignores_a_passed_cluster_name = lambda {
     _spec = {clusterName = "right", managementPlane = {clusterName = "wrong"}}
     _c = l.managementPlaneChild("stack-1", "default", _spec)
     assert _c.spec.clusterName == "right"
+}
+
+# --- Usage object names must be namespace-unique ----------------------------
+
+# THE bug this guards. Until 0.7.0 the Usage was named after its label alone —
+# `access-uses-vm`, `platform-uses-vm`, … — with no cluster in it, while every
+# resource it REFERENCES carried the cluster name. So the first ClusterStack in
+# a namespace owned those object names and every later one failed to apply:
+#
+#   Usage.protection.crossplane.io "access-uses-vm" is invalid:
+#   metadata.ownerReferences: Invalid value: [... ClusterStack "<the-first>"]
+#
+# Kubernetes refuses a second controller owner. The later stack then sits at
+# Synced=False indefinitely while its own status.ready still says true, so it
+# reads as finished — which is how one went 26 hours unnoticed on kind3.
+test_usage_object_name_carries_the_cluster = lambda {
+    _a = l.usage("NativeProxmoxVM", "a-vm", "ClusterAccess", "a-access", "access-uses-vm", True, "a")
+    _b = l.usage("NativeProxmoxVM", "b-vm", "ClusterAccess", "b-access", "access-uses-vm", True, "b")
+    assert _a.metadata.name != _b.metadata.name, "two clusters must not collide on one object"
+    assert _a.metadata.name == "a-access-uses-vm"
+    assert _b.metadata.name == "b-access-uses-vm"
+}
+
+# The label stays the composition-resource-name. It identifies the Usage WITHIN
+# the composition, so renaming the object must not renumber it — otherwise
+# every existing stack would churn its resource identity on upgrade.
+test_composition_resource_name_is_unprefixed = lambda {
+    _u = l.usage("NativeProxmoxVM", "a-vm", "ClusterAccess", "a-access", "access-uses-vm", True, "a")
+    assert _u.metadata.annotations["krm.kcl.dev/composition-resource-name"] == "access-uses-vm"
+}
+
+# All five labels, not just the one that was caught. `prefix` is a required
+# positional argument now, so no call site can omit it — this covers the other
+# half: that each label yields a distinct, cluster-scoped object name.
+test_every_usage_label_is_prefixed = lambda {
+    _labels = ["platform-uses-vm", "platform-uses-access", "access-uses-vm", "stack-uses-platform", "mgmt-uses-vm", "mgmt-uses-access", "stack-uses-mgmt"]
+    _names = [l.usage("NativeProxmoxVM", "zeta-vm", "Platform", "zeta-platform", lb, True, "zeta").metadata.name for lb in _labels]
+    assert all n in _names {n.startswith("zeta-")}, "every Usage object name carries the cluster"
+    assert len(_names) == len({n: True for n in _names}), "and they stay distinct from each other"
 }

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -189,17 +189,17 @@ _kcChild = _reemit(_kcRun, "kubeconfig") if (len(_kcObs) > 0 and _vmIP == "") el
 # COMMAS ARE LOAD-BEARING: without them KCL parses `[a]` followed by a line
 # starting with `[` as a SUBSCRIPT, silently dropping entries instead of failing.
 _usageGroups = [
-    [l.usage(_vmKind, "{}-vm".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-vm", True)] if _platOpen else []
-    [l.usage("ClusterAccess", "{}-access".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-access", True)] if (_platOpen and _accessOpen) else []
-    [l.usage(_vmKind, "{}-vm".format(_name), "ClusterAccess", "{}-access".format(_name), "access-uses-vm", True)] if _accessOpen else []
-    [l.usage("ClusterStack", _name, "Platform", "{}-platform".format(_name), "stack-uses-platform", False)] if _platOpen else []
+    [l.usage(_vmKind, "{}-vm".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-vm", True, _name)] if _platOpen else []
+    [l.usage("ClusterAccess", "{}-access".format(_name), "Platform", "{}-platform".format(_name), "platform-uses-access", True, _name)] if (_platOpen and _accessOpen) else []
+    [l.usage(_vmKind, "{}-vm".format(_name), "ClusterAccess", "{}-access".format(_name), "access-uses-vm", True, _name)] if _accessOpen else []
+    [l.usage("ClusterStack", _name, "Platform", "{}-platform".format(_name), "stack-uses-platform", False, _name)] if _platOpen else []
     # The ManagementPlane needs the same three guards as the Platform, and for
     # the same reasons: it applies everything it owns THROUGH the VM and the
     # ClusterAccess, so losing either first leaves its Objects hanging against a
     # cluster that is gone.
-    [l.usage(_vmKind, "{}-vm".format(_name), "ManagementPlane", "{}-management-plane".format(_name), "mgmt-uses-vm", True)] if _mgmtOpen else []
-    [l.usage("ClusterAccess", "{}-access".format(_name), "ManagementPlane", "{}-management-plane".format(_name), "mgmt-uses-access", True)] if (_mgmtOpen and _accessOpen) else []
-    [l.usage("ClusterStack", _name, "ManagementPlane", "{}-management-plane".format(_name), "stack-uses-mgmt", False)] if _mgmtOpen else []
+    [l.usage(_vmKind, "{}-vm".format(_name), "ManagementPlane", "{}-management-plane".format(_name), "mgmt-uses-vm", True, _name)] if _mgmtOpen else []
+    [l.usage("ClusterAccess", "{}-access".format(_name), "ManagementPlane", "{}-management-plane".format(_name), "mgmt-uses-access", True, _name)] if (_mgmtOpen and _accessOpen) else []
+    [l.usage("ClusterStack", _name, "ManagementPlane", "{}-management-plane".format(_name), "stack-uses-mgmt", False, _name)] if _mgmtOpen else []
 ]
 _usages = sum(_usageGroups, [])
 


### PR DESCRIPTION
Jedes `Usage` hieß nur nach seinem Label — `access-uses-vm`, `platform-uses-vm`, `mgmt-uses-vm`, … — **ohne Cluster im Namen**, während jede Ressource, die diese Usages *referenzieren*, den Clusternamen trägt.

Der zuerst angelegte ClusterStack im Namespace besitzt damit diese Objektnamen, und jeder weitere scheitert beim Apply:

```
cannot apply composed resource "access-uses-vm":
Usage.protection.crossplane.io "access-uses-vm" is invalid:
metadata.ownerReferences: Invalid value: [... ClusterStack "u26-rke2-1" ...]
```

Kubernetes lässt keinen zweiten `controller`-Owner zu.

## Warum es teuer ist

Der blockierte ClusterStack steht auf `Synced=False`, meldet aber über `status.ready` weiter `true` — `kubectl get clusterstack` zeigt also einen fertig aussehenden Stack. Auf kind3:

| Stack | Alter | besitzt | SYNCED |
|---|---|---|---|
| `u26-rke2-1` | 4 Tage | alle vier gemeinsamen Namen | True |
| `mgmt-test1` | 26 h | nur die `mgmt-*` (die u26 nicht anlegt) | **False, die ganze Zeit unbemerkt** |
| `platform-test1` | neu | nichts | **False** |

Gefunden, weil der dritte gar nicht mehr gebaut werden konnte.

## Der Fix

`label` identifiziert das Usage weiterhin **innerhalb** der Composition — `krm.kcl.dev/composition-resource-name` bleibt unverändert, kein bestehender Stack nummeriert seine Ressourcen-Identität um. Das emittierte Objekt heißt jetzt `{clusterName}-{label}`. `prefix` ist ein **Pflicht**-Positionsargument, kein Aufrufer kann es also stillschweigend weglassen.

`xplane-flux-init` benennt seine Usages längst als `{cluster}-platform-flux-init-source-…-uses-flux-instance`. Das Cluster-Modul folgt jetzt derselben Regel.

## Tests

Drei neue: zwei Stacks kollidieren nicht mehr, der `composition-resource-name` bleibt unpräfixiert, und alle sieben Labels ergeben verschiedene cluster-eigene Namen. **Keiner der bisherigen 43 hätte das fangen können** — sie haben immer nur ein einzelnes Usage gebaut.