### PR TITLE
fix(xplane-management-plane): the ProviderConfig Objects never became ready (0.4.0)

### DIFF
--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-management-plane"
 edition = "v0.12.3"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-management-plane/logic.k
+++ b/crossplane/xplane-management-plane/logic.k
@@ -137,3 +137,31 @@ clusterAdminEnabled = lambda spec: {str:} -> bool {
 }
 
 rbacSubjectGroup = "system:serviceaccounts:crossplane-system"
+
+# --- provider config readiness ----------------------------------------------
+
+# NOT the default SuccessfulCreate. provider-kubernetes never marks an Object
+# ready when the managed manifest is a ClusterProviderConfig — measured on a
+# live cluster, not guessed (crossplane-configurations#294):
+#
+#   SuccessfulCreate     Ready=False Creating       never evaluated
+#   AllTrue              Ready=False Unavailable    evaluated, and false on an
+#                                                   empty condition list
+#   DeriveFromCelQuery   Ready=True  Available
+#
+# Three probes of the same Object shape across two target clusters behaved
+# alike, while the identical shape managing a ConfigMap went ready in seconds —
+# so it is the managed KIND, not the provider, the target cluster or a race.
+#
+# The cost of getting this wrong is out of proportion to the cause: ONE stuck
+# ProviderConfig Object keeps the whole ManagementPlane from ever reporting
+# ready, and with managementPlaneEnabled it would hold the entire ClusterStack.
+# u26-rke2-1-mgmt sat that way for 31 hours.
+#
+# `true` is the honest query, not a workaround in disguise: a ProviderConfig has
+# no lifecycle and no conditions. It is ready once it exists — which is exactly
+# what SuccessfulCreate is supposed to express and, for this kind, does not.
+providerConfigReadiness = {
+    policy = "DeriveFromCelQuery"
+    celQuery = "true"
+}

--- a/crossplane/xplane-management-plane/logic_test.k
+++ b/crossplane/xplane-management-plane/logic_test.k
@@ -108,3 +108,23 @@ test_cluster_admin_rbac_defaults_on = lambda {
     assert l.clusterAdminEnabled({clusterName = "c"})
     assert not l.clusterAdminEnabled({clusterName = "c", clusterAdminRbac = False})
 }
+
+# --- provider config readiness (crossplane-configurations#294) ---------------
+
+# The default SuccessfulCreate leaves an Object managing a ClusterProviderConfig
+# at Ready=False Creating FOREVER — measured on a live cluster, with the
+# identical Object shape managing a ConfigMap going ready in seconds. One stuck
+# ProviderConfig holds the entire ManagementPlane, so this must not silently
+# fall back to the default.
+test_provider_config_readiness_is_not_the_default = lambda {
+    assert l.providerConfigReadiness.policy == "DeriveFromCelQuery", "SuccessfulCreate never marks this kind ready"
+    assert l.providerConfigReadiness.celQuery == "true"
+}
+
+# AllTrue looks like the tidy choice for an object with no conditions — it is
+# not. It evaluates, and returns FALSE on an empty condition list
+# (Ready=False Unavailable), which is why the query is explicit instead.
+test_provider_config_readiness_is_not_alltrue = lambda {
+    assert l.providerConfigReadiness.policy != "AllTrue"
+    assert l.providerConfigReadiness.policy != "SuccessfulCreate"
+}

--- a/crossplane/xplane-management-plane/main.k
+++ b/crossplane/xplane-management-plane/main.k
@@ -161,6 +161,9 @@ _providerConfigObject = lambda i: int, pc -> any {
                 name = _k8sPcr
                 kind = "ClusterProviderConfig"
             }
+            # See l.providerConfigReadiness — the default policy never marks
+            # these ready, which would hold the whole ManagementPlane (#294).
+            readiness = l.providerConfigReadiness
         }
     }
 }


### PR DESCRIPTION
provider-kubernetes markiert ein `Object` **nicht** ready, wenn das verwaltete Manifest eine `ClusterProviderConfig` ist. Am lebenden Cluster gemessen, nicht vermutet ([crossplane-configurations#294](https://github.com/stuttgart-things/crossplane-configurations/issues/294)):

| Policy | Ergebnis |
|---|---|
| `SuccessfulCreate` (Default) | `Ready=False **Creating**` — wird nie ausgewertet |
| `AllTrue` | `Ready=False **Unavailable**` — ausgewertet, aber bei leerer Condition-Liste falsch |
| `DeriveFromCelQuery` + `"true"` | **`Ready=True Available`** |

Drei Sonden derselben Object-Form über zwei Zielcluster verhielten sich gleich, während dieselbe Form mit einer **ConfigMap** binnen Sekunden ready wurde — es ist also die verwaltete **Art**, nicht der Provider, nicht der Zielcluster und kein Rennen.

## Warum das unverhältnismäßig teuer ist

**Ein** hängendes ProviderConfig-Object verhindert, dass die ganze ManagementPlane je ready meldet — und mit `managementPlaneEnabled` würde es die komplette ClusterStack halten.

`u26-rke2-1-mgmt` stand **31 Stunden** so da. Sichtbar wurde es erst, nachdem die doppelte READY-Spalte weg war ([#288](https://github.com/stuttgart-things/crossplane-configurations/issues/288)/[#292](https://github.com/stuttgart-things/crossplane-configurations/issues/292)) — davor sagte unsere eigene Spalte `true` neben Crossplanes `false`.

## Zur Wahl von `celQuery: "true"`

Das ist die **ehrliche** Abfrage, keine verkleidete Umgehung: ein ProviderConfig hat keinen Lebenszyklus und keine Conditions. Er ist fertig, sobald er existiert — genau das, was `SuccessfulCreate` ausdrücken soll und für diese Art nicht tut.

Die Entscheidung liegt in `logic.k` mit den Messungen daneben, damit zwei Tests festhalten können, dass sie nicht stillschweigend auf eine der beiden erprobten und verworfenen Policies zurückfällt.

Tests: 16/16.