### PR TITLE
feat(xplane-flux-catalog): the Gateway's name is a fact, not a decision (0.13.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/cilium.k
+++ b/crossplane/xplane-flux-catalog/apps/cilium.k
@@ -44,6 +44,7 @@ cilium: s.App = {
                 "CILIUM_LB_IP_STOP"
                 "CILIUM_GATEWAY_DOMAIN"
                 "CILIUM_GATEWAY_TLS_SECRET"
+                "CILIUM_GATEWAY_NAME"
             ]
             # Three of the four are FACTS the platform already discovered, and
             # repeating them on the XR is how they drift: when the reservation
@@ -61,6 +62,16 @@ cilium: s.App = {
                 CILIUM_LB_IP_START = "ipReservation.ipAddresses[0]"
                 CILIUM_LB_IP_STOP = "ipReservation.ipAddresses[0]"
                 CILIUM_GATEWAY_DOMAIN = "ipReservation.domain"
+                # NOT in requiredSubstitutions: the artifact defaults it to
+                # `cilium-gateway`, so leaving it unset is harmless. It is listed
+                # here so the value the platform PUBLISHES is also the value the
+                # Gateway is CREATED with — otherwise the same default would live
+                # in two repositories and drift the first time one moved.
+                #
+                # This is what makes the name discoverable for everything else:
+                # machinery and headlamp read the identical `gateway.name`, so a
+                # cluster that renames its Gateway renames it everywhere at once.
+                CILIUM_GATEWAY_NAME = "gateway.name"
             }
         }
     ]

--- a/crossplane/xplane-flux-catalog/apps/headlamp.k
+++ b/crossplane/xplane-flux-catalog/apps/headlamp.k
@@ -23,11 +23,15 @@ headlamp: s.App = {
             # DOMAIN is the cluster's own domain — the same value the Gateway
             # listener's wildcard and the certificate CN are built from. Typing
             # it on the XR is how those three drift apart; the platform already
-            # discovered it. HOSTNAME and GATEWAY_NAME stay manual: which name
+            # discovered it, and so is GATEWAY_NAME — the platform sets that
+            # name on the Gateway it creates. HOSTNAME stays manual: which name
             # this app answers on, and which Gateway it attaches to, are
             # decisions no status can answer.
             substitutionSources = {
                 DOMAIN = "ipReservation.domain"
+                # No longer a required substitution: the platform publishes the
+                # Gateway's name it also creates it with, so nobody states it.
+                GATEWAY_NAME = "gateway.name"
             }
         }
     ]

--- a/crossplane/xplane-flux-catalog/apps/machinery.k
+++ b/crossplane/xplane-flux-catalog/apps/machinery.k
@@ -48,11 +48,18 @@ machinery: s.App = {
             # MACHINERY_HOSTNAME (machinery), MACHINERY_NAMESPACE (machinery)
             # and GATEWAY_NAMESPACE (default) carry usable defaults too.
             requiredSubstitutions = ["DOMAIN", "GATEWAY_NAME"]
-            # DOMAIN is the cluster's own — the same value the Gateway listener
-            # wildcard and the certificate CN are built from. GATEWAY_NAME stays
-            # manual: which Gateway a service attaches to is a decision.
+            # Both are facts about the cluster now. DOMAIN is its own — the
+            # same value the Gateway listener wildcard and the certificate CN are
+            # built from. GATEWAY_NAME used to be called a decision and typed by
+            # hand; it is the name the platform SETS on the Gateway it creates
+            # (cilium reads the identical `gateway.name`), so stating it again
+            # was only a chance to state it differently. Enabling this app now
+            # costs no typed value at all.
             substitutionSources = {
                 DOMAIN = "ipReservation.domain"
+                # No longer a required substitution: the platform publishes the
+                # Gateway's name it also creates it with, so nobody states it.
+                GATEWAY_NAME = "gateway.name"
             }
         }
     ]

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -132,7 +132,25 @@ test_cilium_declares_required_substitutions = lambda {
         "CILIUM_LB_IP_STOP"
         "CILIUM_GATEWAY_DOMAIN"
         "CILIUM_GATEWAY_TLS_SECRET"
+        "CILIUM_GATEWAY_NAME"
     ]
+}
+
+# CILIUM_GATEWAY_NAME is the odd one out: the artifact DOES default it
+# (`${CILIUM_GATEWAY_NAME:-cilium-gateway}`), so leaving it unset would be
+# harmless. It is required anyway, because required-and-sourced is the only
+# combination this catalog allows — a source without a requirement would make a
+# typo in the source path invisible. The source always resolves (the platform
+# defaults the name), so requiring it costs nothing.
+test_cilium_gateway_name_is_required_only_to_be_sourced = lambda {
+    _c = c.get("cilium").components[0]
+    assert _c.substitutionSources["CILIUM_GATEWAY_NAME"] == "gateway.name"
+    assert "CILIUM_GATEWAY_NAME" in _c.requiredSubstitutions
+
+    # The same fact reaches the Gateway that CREATES it and every app that
+    # merely REFERENCES it, so a rename can never desynchronise the two.
+    assert c.get("machinery").components[0].substitutionSources["GATEWAY_NAME"] == "gateway.name"
+    assert c.get("headlamp").components[0].substitutionSources["GATEWAY_NAME"] == "gateway.name"
 }
 
 # cilium is CONFIG-ONLY and must stay that way. The artifact ships a
@@ -185,25 +203,34 @@ test_substitution_sources_name_declared_variables = lambda {
 }
 
 # headlamp's DOMAIN is the cluster domain — discoverable, and the same value the
-# Gateway listener wildcard and the certificate CN come from. HOSTNAME and
-# GATEWAY_NAME are decisions and must stay manual.
-test_headlamp_discovers_only_the_domain = lambda {
+# Gateway listener wildcard and the certificate CN come from. GATEWAY_NAME is
+# discovered too now: the platform publishes the name it also creates the
+# Gateway with. HOSTNAME stays manual — what a service is CALLED is a decision,
+# not a fact about the cluster.
+test_headlamp_discovers_domain_and_gateway = lambda {
     _c = c.get("headlamp").components[0]
-    assert _c.substitutionSources == {DOMAIN = "ipReservation.domain"}
-    assert "HOSTNAME" not in _c.substitutionSources
-    assert "GATEWAY_NAME" not in _c.substitutionSources
+    assert _c.substitutionSources == {DOMAIN = "ipReservation.domain", GATEWAY_NAME = "gateway.name"}
+    assert "HOSTNAME" not in _c.substitutionSources, "the name is a decision"
+
+    # Still REQUIRED, and that is the point: required-and-discovered is what
+    # makes a component defer until the value exists (#277) instead of
+    # deploying with a blank Flux would substitute without complaint.
+    assert "GATEWAY_NAME" in _c.requiredSubstitutions
+    _typed = [v for v in _c.requiredSubstitutions if v not in _c.substitutionSources]
+    assert _typed == ["HOSTNAME"], "only the name is still typed"
 }
 
-# The machinery SERVICE, not the bootstrap play of the same name. Two required
-# variables, one of them discovered — so enabling it costs a single typed
-# value. That is the payoff of substitutionSources, and the assertion is here
-# so a later artifact change that adds a required variable is noticed.
-test_machinery_costs_one_typed_value = lambda {
+# The machinery SERVICE, not the bootstrap play of the same name. Enabling it
+# now costs NO typed value at all: DOMAIN comes from the reservation, the
+# Gateway's name from the platform that creates it. That is the payoff of
+# substitutionSources, and the assertion is here so a later artifact change
+# adding a required variable is noticed.
+test_machinery_costs_no_typed_value = lambda {
     _c = c.get("machinery").components[0]
     assert _c.requiredSubstitutions == ["DOMAIN", "GATEWAY_NAME"]
-    assert _c.substitutionSources == {DOMAIN = "ipReservation.domain"}
+    assert _c.substitutionSources == {DOMAIN = "ipReservation.domain", GATEWAY_NAME = "gateway.name"}
     _typed = [v for v in _c.requiredSubstitutions if v not in _c.substitutionSources]
-    assert _typed == ["GATEWAY_NAME"], "only the Gateway choice — which Gateway a service attaches to is a decision, not a fact"
+    assert _typed == [], "a bare enable is now enough"
 
     # MACHINERY_VERSION was required until stuttgart-things/flux#193 fixed the
     # artifact's `1.13.4` default (published tags read `v1.13.4`). It must stay

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.12.0"
+version = "0.13.0"


### PR DESCRIPTION
`GATEWAY_NAME` war eine required Substitution auf `headlamp` und `machinery` — jedes XR musste also einen Namen nennen, den das System längst kennt.

Das cilium-Artefakt nimmt ihn seit jeher als

```yaml
name: ${CILIUM_GATEWAY_NAME:-cilium-gateway}
```

**konfigurierbar und nie konfiguriert.** Jeder Cluster bekam still den Default, während jeder Konsument ihn von Hand gesagt bekam.

## Was sich ändert

Alle drei lesen jetzt dasselbe `gateway.name` — die App, die das Gateway **erzeugt**, und die zwei, die es nur **referenzieren**. Ein Cluster, der sein Gateway umbenennt, benennt es überall gleichzeitig um; die beiden können nicht mehr auseinanderlaufen.

| App | vorher | jetzt |
|---|---|---|
| `cilium` | Name nie gesetzt → Artefakt-Default | `CILIUM_GATEWAY_NAME` aus `gateway.name` |
| `machinery` | `GATEWAY_NAME` getippt | entdeckt |
| `headlamp` | `GATEWAY_NAME` getippt | entdeckt (`HOSTNAME` bleibt manuell) |

## Zwei Entscheidungen, die erklärungsbedürftig sind

**`CILIUM_GATEWAY_NAME` wird required**, obwohl das Artefakt es defaultet. Grund ist die Invariante dieses Katalogs, die ein bestehender Test festhält: eine Quelle ohne Anforderung würde einen Tippfehler im Quellpfad unsichtbar machen. Die Quelle löst immer auf (das Modul defaultet den Namen), fordern kostet also nichts.

**`GATEWAY_NAME` bleibt required** auf headlamp und machinery, statt optional zu werden. Required-and-discovered ist genau das, was eine Komponente sich zurückstellen lässt, bis der Wert da ist ([#277](https://github.com/stuttgart-things/crossplane-configurations/issues/277)) — statt mit einem leeren Wert zu deployen, den Flux klaglos substituiert.

## Reihenfolge

Braucht `xplane-platform`, das `gateway.name` veröffentlicht. Der Pin ist das, was verhindert, dass ein altes Platform-Modul diesen Katalog konsumiert und `cilium-config` auf einem funktionierenden Cluster zurückstellt.

Tests: 29/29.