### PR TITLE
feat(xplane-platform): publish the Gateway's name (0.19.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.18.0"
+version = "0.19.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.12.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.13.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.12.0"
-    version = "0.12.0"
-    sum = "6To7Sub66tRGhgKcNWqua4IcbyIuQ5t6MIgCyc6brRg="
+    full_name = "xplane-flux-catalog_0.13.0"
+    version = "0.13.0"
+    sum = "aEFDIcG6/RRZXwoG49faIVmozPBNmNd6ex2DJGyqlhc="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.12.0"
+    oci_tag = "0.13.0"

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -160,8 +160,9 @@ test_headlamp_missing_vars_detected = lambda {
             headlamp = {}
         }
     }
-    assert len(l.missingSubstitutions(_spec)) == 2
-    assert l.pendingSubstitutions(_spec) == ["headlamp-app: DOMAIN"]
+    # HOSTNAME alone is unsuppliable now — GATEWAY_NAME became discoverable.
+    assert l.missingSubstitutions(_spec) == ["headlamp-app: HOSTNAME"]
+    assert l.pendingSubstitutions(_spec) == ["headlamp-app: DOMAIN", "headlamp-app: GATEWAY_NAME"]
 }
 
 # --- cross-artifact dependsOn -------------------------------------------------
@@ -354,7 +355,7 @@ test_apps_cilium_bare_enable_is_rejected = lambda {
         apps = {
             cilium = {enabled = True}
         }
-    })) == 3, "the other three wait for the reservation"
+    })) == 4, "the other four wait — three on the reservation, the name on the platform"
 }
 
 # The wildcard the clusterbook reservation publishes is not the domain — the
@@ -372,7 +373,11 @@ test_cluster_domain_passes_through_non_wildcards = lambda {
     assert l.clusterDomain("gw.example.com") == "gw.example.com"
 }
 
+# gateway.name is in EVERY real _discovered — the module defaults it to
+# "cilium-gateway" rather than letting the artifact do so, precisely so it is
+# always resolvable. The fixture says so too.
 _disc = {
+    gateway = {name = "cilium-gateway"}
     ipReservation = {domain = "u26-rke2-1.sthings-vsphere.labul.sva.de", ipAddresses = ["10.31.102.8"], zone = "sthings-vsphere.labul.sva.de"}
 }
 
@@ -408,8 +413,8 @@ test_discovery_satisfies_required_substitutions = lambda {
     _spec = {clusterName = "c", apps = {
         cilium = {enabled = True}
     }}
-    assert len(l.pendingSubstitutions(_spec)) == 3, "nothing discovered yet: three still waiting"
-    assert len(l.pendingSubstitutions(_spec, _disc)) == 0, "discovery clears all three"
+    assert len(l.pendingSubstitutions(_spec)) == 4, "nothing discovered yet: four still waiting"
+    assert len(l.pendingSubstitutions(_spec, _disc)) == 0, "discovery clears all four"
     _m = l.missingSubstitutions(_spec, _disc)
     assert _m == ["cilium-config: CILIUM_GATEWAY_TLS_SECRET"], "only the decision is left"
 }
@@ -478,13 +483,15 @@ test_apps_machinery_discovers_its_domain = lambda {
     assert _k.substitute["DOMAIN"] == "u26-rke2-1.sthings-vsphere.labul.sva.de"
 }
 
-test_apps_machinery_costs_one_typed_value = lambda {
+test_apps_machinery_costs_no_typed_value = lambda {
     # stuttgart-things/flux#193 fixed the artifact default (it read `1.13.4`
     # while the published tags read `v1.13.4`, so the OCIRepository never
     # resolved), and catalog 0.9.0 dropped MACHINERY_VERSION from the required
-    # list. What remains is GATEWAY_NAME — a decision, not a fact, so nothing
-    # can discover it.
+    # list. GATEWAY_NAME was the last typed value and was called a decision —
+    # until it turned out the platform SETS that name on the Gateway it creates,
+    # so stating it again was only a chance to state it differently.
     _d = {
+        gateway = {name = "cilium-gateway"}
         ipReservation = {domain = "u26-rke2-1.sthings-vsphere.labul.sva.de", ipAddresses = [], zone = "z"}
     }
     _withGateway = {clusterName = "c", apps = {
@@ -495,9 +502,11 @@ test_apps_machinery_costs_one_typed_value = lambda {
     _bare = {clusterName = "c", apps = {
         machinery = {enabled = True}
     }}
-    _missing = l.missingSubstitutions(_bare, _d)
-    assert len(_missing) == 1, "the Gateway choice stays required"
-    assert "GATEWAY_NAME" in ", ".join(_missing)
+
+    # Used to cost exactly one typed value, the Gateway's name. It does not any
+    # more: the platform publishes the name it also creates the Gateway with.
+    assert l.missingSubstitutions(_bare, _d) == [], "a bare enable is enough"
+    assert l.pendingSubstitutions(_bare, _d) == [], "and nothing is left waiting"
 }
 
 # The resolver grew from two segments to four when the Vault mount a cluster
@@ -620,4 +629,36 @@ test_unsuppliable_variable_is_still_fatal = lambda {
             "nfs-csi" = {enabled = True}
         }
     }) == []
+}
+
+# --- the gateway name is discovered, not typed -------------------------------
+
+# GATEWAY_NAME was a required substitution on headlamp and machinery, so every
+# XR had to state a name the system already knew. The cilium artifact took it as
+# ${CILIUM_GATEWAY_NAME:-cilium-gateway} all along — configurable and never
+# configured. Now the module sets it and publishes the same value, and consumers
+# read it through substitutionSources like any other discovered fact.
+_gwDisc = {
+    gateway = {name = "cilium-gateway"}
+}
+
+test_gateway_name_resolves_for_consumers = lambda {
+    assert l.resolveSource(_gwDisc, "gateway.name") == "cilium-gateway"
+}
+
+# An XR that names its own Gateway must win — same rule as every other
+# discovered value: what the cluster states beats what the platform found.
+test_gateway_name_override_is_visible = lambda {
+    assert l.resolveSource({
+        gateway = {name = "edge"}
+    }, "gateway.name") == "edge"
+}
+
+# Absent, it must resolve to "" so requiredSubstitutions still rejects by name
+# rather than substituting a blank Flux would deploy without complaint.
+test_gateway_name_absent_is_empty = lambda {
+    assert l.resolveSource({}, "gateway.name") == ""
+    assert l.resolveSource({
+        gateway = {}
+    }, "gateway.name") == ""
 }

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -65,7 +65,28 @@ _isReady = lambda st: {str:} -> bool {
 #
 # Only facts belong here. A value a cluster CHOOSES (which Secret a certificate
 # lands in) has no entry and stays the XR's job.
+# The Gateway's name. The cilium artifact takes it as
+# `${CILIUM_GATEWAY_NAME:-cilium-gateway}`, so it has ALWAYS been configurable
+# and never configured — every cluster silently got the default, and every app
+# that needed the name had to be told it by hand (GATEWAY_NAME was a required
+# substitution on headlamp and machinery).
+#
+# So the module now SETS it rather than letting the artifact default it, and
+# publishes the same value. Setting what we publish is the point: reading the
+# artifact's default into a constant here would put the same string in two
+# repositories, and the next person to change one would not find the other.
+#
+# The default stays `cilium-gateway`, deliberately. Deriving it from the cluster
+# name would be defensible — but the Gateway lives on the TARGET cluster, one
+# per cluster, so it does not collide, and renaming it on an existing cluster
+# breaks every HTTPRoute that already references it. Discoverability is the gap;
+# a rename is a separate decision.
+_gatewayName = ((_spec?.apps or {})?.cilium?.substitute or {})?.CILIUM_GATEWAY_NAME or "cilium-gateway"
+
 _discovered = {
+    gateway = {
+        name = _gatewayName
+    }
     ipReservation = {
         domain = l.clusterDomain(_readStatus(_ipResKey)?.fqdn or "")
         ipAddresses = _readStatus(_ipResKey)?.ipAddresses or []
@@ -595,6 +616,13 @@ _xrStatus = _oxr | {
             cilium = {
                 enabled = _ciliumEnabled
                 ready = _ciliumReady
+                # The Gateway's name, published so nothing has to be told it.
+                # Set here rather than defaulted by the artifact — see the note
+                # above _gatewayName. Present even when the cilium INSTALL child
+                # is disabled (the usual case on rke2, where the CNI comes from
+                # the AnsibleRun and only the config app runs): the name belongs
+                # to the cluster, not to that child.
+                gatewayName = _gatewayName
                 loadBalancerReady = _ciliumStatus?.loadBalancerReady or False
                 gatewayReady = _ciliumStatus?.gatewayReady or False
                 networkKey = _ciliumStatus?.networkKey or ""


### PR DESCRIPTION
Zieht `xplane-flux-catalog` 0.13.0 nach ([kcl#141](https://github.com/stuttgart-things/kcl/pull/141)).

Das cilium-Artefakt nimmt den Gateway-Namen seit jeher als `${CILIUM_GATEWAY_NAME:-cilium-gateway}` — **konfigurierbar und nie konfiguriert**. Jeder Cluster bekam still den Default, während `headlamp` und `machinery` ihn als required Substitution führten und von Hand gesagt bekamen.

## Was sich ändert

Das Modul **setzt** den Namen und veröffentlicht denselben Wert auf `status.components.cilium.gatewayName`. Setzen, was man veröffentlicht, ist dabei der Punkt: den Artefakt-Default hier als Konstante einzulesen hieße, denselben String in zwei Repositories zu halten — und wer eines ändert, findet das andere nicht.

Der Katalog reicht ihn über den gewöhnlichen `substitutionSources`-Pfad an cilium **zurück**. Damit lesen die App, die das Gateway erzeugt, und die zwei, die es referenzieren, **eine** Tatsache und können nicht auseinanderlaufen.

## Zwei bewusste Entscheidungen

**Der Default bleibt `cilium-gateway`**, statt aus dem Clusternamen abgeleitet zu werden. Ableiten wäre vertretbar — das Gateway lebt auf dem Zielcluster, eines pro Cluster, kollidiert also nicht. Aber es auf einem bestehenden Cluster umzubenennen bricht jede HTTPRoute, die schon darauf zeigt. Die Lücke war die *Entdeckbarkeit*, nicht der Name. Ein XR kann heute umbenennen über `apps.cilium.substitute.CILIUM_GATEWAY_NAME` — der Wert gewinnt und wird veröffentlicht.

**`gatewayName` liegt unter `components.cilium`**, auch wenn das cilium-**Install**-Kind deaktiviert ist — der Normalfall auf rke2, wo der CNI aus dem AnsibleRun kommt und nur die Config-App läuft. Der Name gehört dem Cluster, nicht diesem Kind.

## Wirkung

`machinery` zu aktivieren kostet jetzt **keinen** getippten Wert mehr; `headlamp` ist auf `HOSTNAME` herunter, und das ist tatsächlich eine Entscheidung.

Tests: 53/53.