### PR TITLE
fix(xplane-flux-catalog): machinery v1.19.3, which may read what it watches (0.14.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/machinery.k
+++ b/crossplane/xplane-flux-catalog/apps/machinery.k
@@ -30,9 +30,17 @@ import ..schema as s
 # The artifact now ships the watch set as a file, covering ClusterStack,
 # Platform, XIPReservation and VaultK8sAuth. Enabling this app is therefore
 # enough — no ConfigMap has to be placed on the cluster by hand.
+#
+# v1.19.3 adds the RBAC to actually READ those kinds (stuttgart-things/flux#195).
+# The watch set lived in the flux artifact while the ClusterRole lived in the
+# machinery kustomize base — a different repository — so #193 changed what the
+# app looks at without changing what it may read. On the first deploy through
+# this catalog the Deployment was 1/1, the HTTPRoute attached and HTTPS answered
+# in 79ms, while every request was a 500 and every informer sat on
+# `clusterstacks... is forbidden`. Do not pin below v1.19.3.
 machinery: s.App = {
     artifact = "oci://ghcr.io/stuttgart-things/flux/apps/machinery"
-    defaultVersion = "v1.19.2"
+    defaultVersion = "v1.19.3"
     components = [
         s.Component {
             name = "app"

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.13.0"
+version = "0.14.0"


### PR DESCRIPTION
Hebt den machinery-Pin `v1.19.2` → **`v1.19.3`** ([stuttgart-things/flux#195](https://github.com/stuttgart-things/flux/pull/195)).

Das Watch-Set lag im flux-Artefakt, die ClusterRole in der Kustomize-Basis von `stuttgart-things/machinery` — einem anderen Repository. flux#193 hat das Watch-Set auf die XRs dieser Fleet umgestellt, ohne die Rechte mitzuziehen.

**Beim ersten Deploy über diesen Katalog** (u26-rke2-1, 2026-08-17): Deployment `1/1`, HTTPRoute am Gateway, HTTPS in 79 ms — und jede Anfrage ein **500**, weil jeder Informer auf `clusterstacks... is forbidden` feststeckte. Für alle vier beobachteten Arten, und die ServiceAccount hatte überhaupt keine ClusterRoleBinding.

v1.19.3 legt `rbac.yaml` neben `watch-config.yaml`, sodass beide nicht wieder auseinanderlaufen können.

**Nicht unter v1.19.3 pinnen.**