### PR TITLE
fix(xplane-platform): pull catalog 0.14.0 for machinery v1.19.3 (0.19.1)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.19.0"
+version = "0.19.1"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.13.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.14.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.13.0"
-    version = "0.13.0"
-    sum = "aEFDIcG6/RRZXwoG49faIVmozPBNmNd6ex2DJGyqlhc="
+    full_name = "xplane-flux-catalog_0.14.0"
+    version = "0.14.0"
+    sum = "hIyrkc6MxE9oUy1zXsYRbI3x5LMugOObh71i1VYLp84="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.13.0"
+    oci_tag = "0.14.0"


### PR DESCRIPTION
Der machinery-Pin des Katalogs steht auf **v1.19.3**, das die RBAC mitbringt, um die beobachteten Arten überhaupt zu lesen ([flux#195](https://github.com/stuttgart-things/flux/pull/195)).

Ohne sie deployt die App, die Route hängt, TLS antwortet — und jede Anfrage ist ein 500, weil jeder Informer auf `forbidden` steht. Genau so beim ersten Deploy auf u26-rke2-1 gesehen.

Tests: 53/53.