### PR TITLE
feat(renovate): notice our own module and artifact versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,35 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "description": "OCI dependencies between our own KCL modules — xplane-platform pulls xplane-flux-catalog, xplane-vault-auth pulls xplane-vault-auth-base. Nothing read kcl.mod before, so every one of these was noticed by a human or not at all.",
+      "customType": "regex",
+      "fileMatch": ["(^|/)kcl\\.mod$"],
+      "matchStrings": [
+        "oci\\s*=\\s*\"oci://(?<depName>ghcr\\.io/stuttgart-things/[^\"]+)\"\\s*,\\s*tag\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "The Flux artifact each catalog entry pins. This is the chain that cost four hops for one ClusterRole on 2026-08-17: flux published v1.19.3, and the catalog had to be told. artifact and defaultVersion sit on adjacent lines, which is what makes one regex enough.",
+      "customType": "regex",
+      "fileMatch": ["^crossplane/xplane-flux-catalog/apps/.+\\.k$"],
+      "matchStrings": [
+        "artifact\\s*=\\s*\"oci://(?<depName>ghcr\\.io/stuttgart-things/[^\"]+)\"[\\s\\S]*?defaultVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Our own modules and artifacts, one PR each rather than grouped. A module bump carries reasoning — catalog 0.13.0 needed a platform that publishes gateway.name — and a grouped PR would hide which half of it broke.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/stuttgart-things/**"],
+      "semanticCommitType": "feat",
+      "addLabels": ["own-module"]
+    }
   ]
 }


### PR DESCRIPTION
Renovate lief mit `config:recommended` allein — es pflegte also jede Abhängigkeit, die in einer Datei steht, die es ohnehin versteht, und **keine** von unseren. Zwei `customManagers` schließen das:

| Manager | Datei | was |
|---|---|---|
| 1 | `kcl.mod` | OCI-Abhängigkeiten zwischen unseren eigenen Modulen |
| 2 | `xplane-flux-catalog/apps/*.k` | das Flux-Artefakt, das jeder Katalog-Eintrag pinnt |

**Gegen den Baum geprüft, nicht angenommen:** Manager 1 trifft 7 Abhängigkeiten in 31 `kcl.mod`-Dateien — darunter `xplane-cluster-catalog` und die beiden `crossplane-provider-*`-Module, an die ich nicht gedacht hatte. Manager 2 trifft alle 10 Katalog-Einträge.

## Manager 2 zeigt sofort, warum es sich lohnt

**Acht der zehn Apps stehen auf `v1.18.1`**, während das flux-Repo bei v1.19.3 ist:

```
cert_manager      v1.18.1      machinery    v1.19.3
cilium            v1.18.1      openebs      v1.19.1
dapr              v1.18.1
external_secrets  v1.18.1
headlamp          v1.18.1
nfs_csi           v1.18.1
```

Das hat niemand entschieden — es hat niemand bemerkt. `machinery` ist heute nur deshalb gewandert, weil ein HTTP 500 die Frage erzwungen hat.

## Ein PR je Abhängigkeit, nicht gruppiert

Ein Modul-Bump trägt eine Begründung — Katalog 0.13.0 brauchte ein Platform-Modul, das `gateway.name` veröffentlicht, 0.14.0 ein flux-Artefakt, das lesen darf, was es beobachtet. Ein gruppierter PR würde verbergen, welche Hälfte gebrochen ist.

Renovate übernimmt das Bemerken und das Tippen. **Was landen darf, entscheidet weiterhin die CI** — und die validiert seit dagger v0.122.0 auch den gerenderten Status gegen das XRD, also genau die Fehlerklasse, die ein unbeaufsichtigter Modul-Bump sonst auf einen Cluster tragen würde.