### PR TITLE
fix(xplane-flux-catalog): a kustomize Component CAN be its own Kustomization (0.14.1)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/cilium.k
+++ b/crossplane/xplane-flux-catalog/apps/cilium.k
@@ -13,12 +13,20 @@ import ..schema as s
 # should be added: a cluster that needs Cilium INSTALLED is served by the
 # bootstrap/cilium Configuration instead.
 #
-# Both pieces are kustomize `kind: Component`, not standalone Kustomizations,
-# so they cannot be split into two Flux Kustomizations — lb and gateway arrive
-# together or not at all. Worth knowing because the gateway's TLS listener
-# needs a certificate that a fresh cluster does not have yet: the HTTP listener
-# works immediately, HTTPS stays certificate-less until something issues into
-# CILIUM_GATEWAY_TLS_SECRET.
+# lb and gateway are shipped as one component here, not because they must be:
+# both are kustomize `kind: Component`, and this entry claimed for months that
+# a Component therefore cannot be a Flux Kustomization of its own. That is
+# WRONG — `kustomize build` on a Component directory works, and Flux runs
+# nothing else. Verified 2026-08-17 against all four tekton components and both
+# cilium ones.
+#
+# They stay together because they belong together — an L2 pool without a
+# Gateway announces nothing, a Gateway without a pool has no address — not
+# because kustomize forces it. Splitting them is available if a reason appears.
+#
+# Worth knowing either way: the gateway's TLS listener needs a certificate a
+# fresh cluster does not have yet. The HTTP listener works immediately, HTTPS
+# stays certificate-less until something issues into CILIUM_GATEWAY_TLS_SECRET.
 #
 # Prerequisite is a cluster fact rather than a catalog dependency: Cilium must
 # already run WITH Gateway API and L2 announcements enabled

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.14.0"
+version = "0.14.1"


### PR DESCRIPTION
Der cilium-Eintrag behauptet seit Monaten, `lb` und `gateway` ließen sich nicht in zwei Flux-Kustomizations trennen, weil sie kustomize-`kind: Component` sind.

**Das stimmt nicht.** `kustomize build` auf ein Component-Verzeichnis funktioniert, und Flux macht nichts anderes.

Am 17.08.2026 gegen alle vier Komponenten von `cicd/tekton` und beide von `infra/cilium` geprüft — jede baut eigenständig und liefert die erwarteten Manifeste:

```console
$ kubectl kustomize cicd/tekton/components/ci-namespace
apiVersion: v1
kind: Namespace
  annotations:
    operator.tekton.dev/prune.skip: "true"

$ kubectl kustomize infra/cilium/components/gateway
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
```

## Warum die Behauptung nicht harmlos war

Sie hätte fast einen Schema-Umbau über zwei Repositories gekostet: `tekton` in diesen Katalog aufzunehmen schien ein `components: [str]`-Feld auf `Component` plus Durchreichung in `xplane-platform` zu brauchen, nur um `ci-namespace` und `dashboard-httproute` zu erreichen.

Beides ist unnötig — ein Katalog-Eintrag kann `./components/<name>` als `path` benennen, so wie `dapr` längst zwei benennt.

## Was bleibt

`lb` und `gateway` bleiben eine Komponente, weil sie **zusammengehören**: ein L2-Pool ohne Gateway kündigt nichts an, ein Gateway ohne Pool hat keine Adresse. Das ist ein Grund. kustomize war keiner.