### PR TITLE
feat(xplane-flux-catalog): tekton, so a management cluster can finish what it starts (0.15.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/tekton.k
+++ b/crossplane/xplane-flux-catalog/apps/tekton.k
@@ -1,0 +1,78 @@
+import ..schema as s
+
+# tekton — https://github.com/stuttgart-things/flux/tree/main/cicd/tekton
+#
+# The reason a management cluster needs it at all: an `AnsibleRun` IS a Tekton
+# PipelineRun. A cluster without Tekton can create a VM and then cannot finish
+# it — the ClusterStack reaches `stage: vm` and stays there. Measured on
+# u26-rke2-1, 2026-08-17, which had every Configuration healthy and no Tekton.
+#
+# The first entry from cicd/ rather than apps/ or infra/. Those were the only
+# two directories the flux release workflow published, so none of cicd/ existed
+# as an OCI artifact until stuttgart-things/flux#196 — which is why this entry
+# could not be written earlier, not because nobody wanted it.
+#
+# FOUR components, not one, and that split is the whole point of the entry:
+# only `dashboard` needs a value nobody can default. operator needs none at
+# all, config and ci-namespace default everything. Bundled, every Tekton user
+# would owe a domain whether or not they wanted a dashboard — and Flux
+# substitutes an empty string rather than failing, so they would get a
+# certificate-less route pointing at nothing.
+tekton: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/cicd/tekton"
+    defaultVersion = "v1.20.0"
+    components = [
+        s.Component {
+            name = "install"
+            # The artifact's root pulls components/operator and components/config
+            # together: the operator, and the TektonConfig that decides which
+            # sub-components it installs. Separating them would mean a running
+            # operator with no configuration, which installs nothing.
+            path = "./"
+            # The operator brings its own CRDs and waits for them; 10m is not
+            # enough on a cluster pulling the images for the first time.
+            timeout = "15m"
+        }
+        s.Component {
+            name = "ci-namespace"
+            path = "./components/ci-namespace"
+            # Upstream calls this opt-in. Here it is ON by default, deliberately:
+            # every Tekton in this fleet exists to run Crossplane-managed
+            # PipelineRuns, and the namespace carries
+            # `operator.tekton.dev/prune.skip: "true"`. Without it the
+            # cluster-wide pruner deletes those PipelineRuns overnight and
+            # Crossplane recreates them each morning — which reads like runs
+            # re-triggering themselves and is documented in the artifact's README
+            # as exactly that confusion.
+            #
+            # No dependsOn: a namespace needs nothing the operator installs.
+        }
+        s.Component {
+            name = "dashboard"
+            path = "./components/dashboard-httproute"
+            optional = True
+            # Depends on install because the route targets the dashboard Service
+            # the operator creates. Flux would apply the HTTPRoute regardless;
+            # the dependency is what keeps it from being green while pointing at
+            # nothing.
+            dependsOn = ["install"]
+            # HOSTNAME has no manifest default and is a decision — what a service
+            # is CALLED is not a fact about the cluster. DOMAIN and GATEWAY_NAME
+            # are facts, and the platform already publishes both.
+            requiredSubstitutions = [
+                "TEKTON_DASHBOARD_DOMAIN"
+                "TEKTON_DASHBOARD_HOSTNAME"
+                "GATEWAY_NAME"
+            ]
+            # GATEWAY_NAME carries a manifest default (`cilium-gateway`), so
+            # requiring it is not about the artifact — it is this catalog's rule
+            # that a source must belong to a declared variable, or a typo in the
+            # path would resolve to nothing and stay invisible. The source always
+            # resolves; the platform sets that name on the Gateway it creates.
+            substitutionSources = {
+                TEKTON_DASHBOARD_DOMAIN = "ipReservation.domain"
+                GATEWAY_NAME = "gateway.name"
+            }
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -322,10 +322,44 @@ test_vault_discovers_the_domain_but_not_the_issuer = lambda {
 # typo in this batch fails loudly rather than as DependencyNotReady on a
 # cluster.
 test_new_entries_are_registered = lambda {
-    _want = ["external-secrets", "nfs-csi", "vault"]
+    _want = ["external-secrets", "nfs-csi", "vault", "tekton"]
     _missing = [n for n in _want if n not in c.catalog]
     assert _missing == [], "entry missing from the registry"
-    assert len(c.names) == 10
+    assert len(c.names) == 11
+}
+
+# tekton is the first entry from cicd/ rather than apps/ or infra/ — those were
+# the only directories the flux release workflow published, so nothing under
+# cicd/ existed as an OCI artifact until stuttgart-things/flux#196.
+test_tekton_is_split_so_only_the_dashboard_costs_a_value = lambda {
+    _c = {x.name: x for x in c.get("tekton").components}
+    assert sorted(_c) == ["ci-namespace", "dashboard", "install"]
+
+    # The point of splitting: operator and config need nothing, the namespace
+    # defaults its own. Bundled, every Tekton user would owe a domain whether or
+    # not they wanted a dashboard — and Flux substitutes an empty string rather
+    # than failing, so they would get a route pointing at nothing.
+    assert _c["install"].requiredSubstitutions == []
+    assert _c["ci-namespace"].requiredSubstitutions == []
+    assert "TEKTON_DASHBOARD_DOMAIN" in _c["dashboard"].requiredSubstitutions
+
+    # Only the dashboard is a choice. The CI namespace is ON by default although
+    # upstream calls it opt-in: every Tekton here runs Crossplane-managed
+    # PipelineRuns, and that namespace carries the prune.skip annotation which
+    # keeps the cluster-wide pruner from deleting them overnight.
+    assert _c["dashboard"].optional
+    assert not _c["ci-namespace"].optional
+    assert not _c["install"].optional
+}
+
+# Of the dashboard's three required variables only the hostname is typed — what
+# a service is CALLED is a decision. Domain and Gateway name are facts the
+# platform already publishes.
+test_tekton_dashboard_costs_one_typed_value = lambda {
+    _d = [x for x in c.get("tekton").components if x.name == "dashboard"][0]
+    _typed = [v for v in _d.requiredSubstitutions if v not in _d.substitutionSources]
+    assert _typed == ["TEKTON_DASHBOARD_HOSTNAME"]
+    assert _d.substitutionSources["GATEWAY_NAME"] == "gateway.name"
 }
 
 # Every one of the five is REQUIRED although the artifact defaults it, and each

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.14.1"
+version = "0.15.0"

--- a/crossplane/xplane-flux-catalog/main.k
+++ b/crossplane/xplane-flux-catalog/main.k
@@ -11,6 +11,7 @@ import .apps.headlamp as headlamp
 import .apps.machinery as machinery
 import .apps.nfs_csi as nfs_csi
 import .apps.openebs as openebs
+import .apps.tekton as tekton
 import .apps.trust_manager as trust_manager
 import .apps.vault as vault
 import schema as s
@@ -24,6 +25,7 @@ catalog: {str:s.App} = {
     machinery = machinery.machinery
     "nfs-csi" = nfs_csi.nfsCsi
     openebs = openebs.openebs
+    tekton = tekton.tekton
     "trust-manager" = trust_manager.trustManager
     vault = vault.vault
 }


### PR DESCRIPTION
Ein `AnsibleRun` **ist** ein Tekton-PipelineRun. Ein Cluster ohne Tekton erzeugt eine VM und kann sie dann nicht fertigstellen — die ClusterStack erreicht `stage: vm` und bleibt dort.

Gemessen auf `u26-rke2-1` am 17.08.2026: jede Configuration `Healthy`, 22 XRDs registriert, und nirgends ein Tekton.

## Erster Eintrag aus `cicd/`

Der flux-Release-Workflow veröffentlichte ausschließlich `apps/*` und `infra/*` — unter `flux/cicd/` existierte deshalb **kein einziges** Artefakt, bis [flux#196](https://github.com/stuttgart-things/flux/pull/196) das änderte. Darum konnte dieser Eintrag nicht früher geschrieben werden; nicht, weil ihn niemand wollte.

## Vier Komponenten, und der Schnitt ist der Punkt

| Komponente | Inhalt | Substitutionen |
|---|---|---|
| `install` | operator + config | **keine** |
| `ci-namespace` | CI-Namespace | defaultet die eigene |
| `dashboard` | HTTPRoute | die einzige, die etwas kostet |

Gebündelt schuldete **jeder** Tekton-Nutzer eine Domain, ob er ein Dashboard wollte oder nicht — und Flux substituiert einen leeren String statt zu scheitern, es gäbe also eine zertifikatslose Route ins Leere.

## Zwei Entscheidungen, die Erklärung brauchen

**`ci-namespace` ist standardmäßig AN**, obwohl upstream es opt-in nennt. Jedes Tekton in dieser Fleet existiert, um Crossplane-verwaltete PipelineRuns auszuführen, und dieser Namespace trägt `operator.tekton.dev/prune.skip: "true"`. Ohne ihn löscht der clusterweite Pruner sie über Nacht und Crossplane legt sie morgens neu an — was sich liest, als triggerten sich Läufe selbst.

**`GATEWAY_NAME` ist required**, obwohl das Manifest es defaultet. Das ist die Regel dieses Katalogs: eine Quelle muss zu einer deklarierten Variable gehören, sonst bliebe ein Tippfehler im Quellpfad unsichtbar. Die Quelle löst immer auf.

## Kosten

Das Dashboard kostet **genau einen** getippten Wert: den Hostnamen. Domain und Gateway-Name sind Tatsachen, die die Platform seit v0.4.3 veröffentlicht.

Tests: 31/31.

Dritter von drei PRs — nach flux#196 (Artefakte) und kcl#148 (die falsche Component-Behauptung korrigiert).