### PR TITLE
feat(xplane-platform): catalog 0.15.0 brings tekton (0.20.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.19.1"
+version = "0.20.0"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.14.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.15.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.14.0"
-    version = "0.14.0"
-    sum = "hIyrkc6MxE9oUy1zXsYRbI3x5LMugOObh71i1VYLp84="
+    full_name = "xplane-flux-catalog_0.15.0"
+    version = "0.15.0"
+    sum = "TailTu6qqU0aJ12fcttiTp5tOpUMMS631sxW/PodTUc="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.14.0"
+    oci_tag = "0.15.0"


### PR DESCRIPTION
Zieht Katalog 0.15.0 nach ([kcl#149](https://github.com/stuttgart-things/kcl/pull/149)).

Ein `AnsibleRun` ist ein Tekton-PipelineRun — ein Management-Cluster ohne Tekton erzeugt eine VM und kann sie nicht fertigstellen. `u26-rke2-1` stand am 17.08. genau dort: jede Configuration `Healthy`, 22 XRDs, kein Tekton.

Der Eintrag ist in `install` / `ci-namespace` / `dashboard` geteilt, sodass nur das Dashboard einen getippten Wert kostet — und dank `gateway.name` aus 0.19.0 ist das allein der Hostname.

Enthält außerdem 0.14.1, das eine Behauptung im cilium-Eintrag korrigiert: ein kustomize-`Component` **kann** eine eigene Flux-Kustomization sein. Diese Behauptung hätte fast ein `components: [str]`-Feld im Katalog-Schema plus Durchreichung hier gekostet — umsonst.

Tests: 53/53.