### PR TITLE
fix(xplane-flux-catalog): openebs v1.20.1 makes its StorageClass the default (0.16.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/openebs.k
+++ b/crossplane/xplane-flux-catalog/apps/openebs.k
@@ -36,7 +36,14 @@ import ..schema as s
 # safe rather than a surprise.
 openebs: s.App = {
     artifact = "oci://ghcr.io/stuttgart-things/flux/infra/openebs"
-    defaultVersion = "v1.19.1"
+    # v1.20.1 makes openebs-hostpath the DEFAULT StorageClass
+    # (stuttgart-things/flux#198). rke2 ships no default at all, so every
+    # cluster that installed openebs still had none, and every PVC that did not
+    # name a class stayed Pending. Found through Tekton, of all things: its
+    # Results component wants a PostgreSQL, the PVC hung, the operator blocked
+    # on it, and the Dashboard never appeared. Nothing in that failure named
+    # storage. Do not pin below v1.20.1.
+    defaultVersion = "v1.20.1"
     components = [
         s.Component {
             name = "install"

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -103,15 +103,23 @@ test_openebs_declares_no_required_substitutions = lambda {
 }
 
 # The catalog version is the FLUX ARTIFACT tag, never the openebs chart version
-# (which the artifact pins separately as OPENEBS_VERSION, default 4.2.0). v1.19.1
-# is the floor because it is the first release that carries flux#192 — before
-# it, the artifact had no loki/alloy keys, so raising OPENEBS_VERSION to 4.5.x
-# would have silently deployed Loki, MinIO and Alloy with no way to say no.
+# (which the artifact pins separately as OPENEBS_VERSION, default 4.2.0). Two
+# floors, both load-bearing:
+#
+#   v1.19.1  first release carrying flux#192 — before it the artifact had no
+#            loki/alloy keys, so raising OPENEBS_VERSION to 4.5.x would have
+#            silently deployed Loki, MinIO and Alloy with no way to say no.
+#   v1.20.1  makes openebs-hostpath the DEFAULT StorageClass (flux#198). rke2
+#            ships no default at all, so a cluster could install openebs and
+#            still have every unclassed PVC hang. Found through Tekton: its
+#            Results component wants a PostgreSQL, the PVC stayed Pending, the
+#            operator blocked, and the Dashboard never appeared — a failure
+#            that named neither storage nor a class.
 test_openebs_pins_a_release_that_can_say_no_to_loki = lambda {
     _v = c.get("openebs").defaultVersion
     assert _v.startswith("v")
-    assert _v != "v4.2.0"
-    assert _v == "v1.19.1"
+    assert _v != "v4.2.0", "the artifact tag, not the chart version"
+    assert _v == "v1.20.1"
 }
 
 test_cilium_is_registered = lambda {

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.15.0"
+version = "0.16.0"


### PR DESCRIPTION
rke2 liefert **keine** Default-StorageClass. Ein Cluster konnte also openebs installieren — dessen einziger Zweck `openebs-hostpath` ist — und trotzdem blieb jede PVC ohne explizite Klasse `Pending`:

```
FailedBinding  no persistent volumes available for this claim and
               no storage class is set
```

[flux#198](https://github.com/stuttgart-things/flux/pull/198) setzt `isDefaultClass`, überschreibbar für den einen Fall, in dem es falsch ist (ein kind-Ziel bringt `standard` schon mit).

## Gefunden ausgerechnet über Tekton

Dessen `all`-Profil installiert Results, Results will eine PostgreSQL, deren PVC hing, der Operator blockierte darauf — und **nichts nach Results** wurde installiert, einschließlich des Dashboards.

Nichts am sichtbaren Fehler nannte Speicher oder eine Klasse. Die Suche ging durch den Operator, seine Logs, einen Neustart und zwei Komponenten-CRs, bevor sie bei einer PVC ankam.

## Der Versions-Floor trägt jetzt beide Gründe

`v1.19.1` (flux#192, loki/alloy abschaltbar) **und** `v1.20.1` (Default-StorageClass) — damit keiner davon verlorengeht, wenn jemand nur die Assertion liest.

Tests: 31/31.
