### PR TITLE
fix(xplane-platform): catalog 0.16.0 for the default StorageClass (0.20.1)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.20.0"
+version = "0.20.1"
 
 [dependencies]
-xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.15.0" }
+xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.16.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.15.0"
-    version = "0.15.0"
-    sum = "TailTu6qqU0aJ12fcttiTp5tOpUMMS631sxW/PodTUc="
+    full_name = "xplane-flux-catalog_0.16.0"
+    version = "0.16.0"
+    sum = "AbDl7SZiftY571QxMrdSdJ826a+Jb1ExLstd1sl2NL0="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.15.0"
+    oci_tag = "0.16.0"

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -313,8 +313,11 @@ test_openebs_renders_from_a_bare_enable = lambda {
     _named = [s for s in _srcs if s.name == "openebs"]
     assert len(_named) == 1
     assert _named[0].url == "oci://ghcr.io/stuttgart-things/flux/infra/openebs"
-    # The floor that can say no to Loki/MinIO/Alloy — see the catalog entry.
-    assert _named[0].ref == "v1.19.1"
+    # Two floors, both load-bearing: v1.19.1 can say no to Loki/MinIO/Alloy,
+    # v1.20.1 makes openebs-hostpath the DEFAULT StorageClass. rke2 ships no
+    # default at all, so without the second a cluster installs openebs and still
+    # has every unclassed PVC hang. See the catalog entry.
+    assert _named[0].ref == "v1.20.1"
 }
 
 # The catalog's cilium entry, reached through spec.apps — NOT spec.cilium.


### PR DESCRIPTION
Zieht Katalog 0.16.0 nach: openebs **v1.20.1** markiert `openebs-hostpath` als Default-StorageClass.

rke2 liefert gar keine Default-Klasse, ein Cluster konnte also openebs installieren und trotzdem blieb jede PVC ohne explizite Klasse hängen. Genau das hat auf `u26-rke2-1` verhindert, dass Tektons Dashboard je installiert wurde — über Results, dessen PostgreSQL-PVC nie gebunden wurde.

Der Test zum Versions-Floor trägt jetzt beide Gründe (v1.19.1 für loki/alloy, v1.20.1 für die StorageClass).

Tests: 53/53.