### PR TITLE
style(xplane-platform): kcl fmt

### DIFF
--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -313,6 +313,7 @@ test_openebs_renders_from_a_bare_enable = lambda {
     _named = [s for s in _srcs if s.name == "openebs"]
     assert len(_named) == 1
     assert _named[0].url == "oci://ghcr.io/stuttgart-things/flux/infra/openebs"
+
     # Two floors, both load-bearing: v1.19.1 can say no to Loki/MinIO/Alloy,
     # v1.20.1 makes openebs-hostpath the DEFAULT StorageClass. rke2 ships no
     # default at all, so without the second a cluster installs openebs and still


### PR DESCRIPTION
Der Kommentar zum openebs-Floor landete unformatiert, deshalb schlug `lint-and-test` auf main fehl und `publish-to-oci` wurde übersprungen — 0.20.1 wurde nie gepusht.