### PR TITLE
feat(flux-catalog): sops-secrets-operator joins the catalog (0.17.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/README.md
+++ b/crossplane/xplane-flux-catalog/README.md
@@ -46,7 +46,11 @@ dependsOn = ["cert-manager:install"]    # a component of ANOTHER app
 
 Both resolve to the emitted Kustomization name `{app}-{component}`, which is
 globally unique because app names are. Cross-artifact dependencies are real:
-`trust-manager` cannot reconcile before cert-manager's CRDs exist.
+`trust-manager` cannot reconcile before cert-manager's CRDs exist, and
+`sops-secrets-operator` installs a validating webhook whose certificate
+cert-manager issues — without it the operator comes up *healthy* and then
+rejects every `SopsSecret` apply, which looks like a broken CRD rather than a
+missing dependency.
 
 A consumer must **reject** a reference whose target app or component is not
 enabled — `xplane-platform` does, naming what to add. Flux would otherwise leave

--- a/crossplane/xplane-flux-catalog/apps/sops_secrets_operator.k
+++ b/crossplane/xplane-flux-catalog/apps/sops_secrets_operator.k
@@ -1,0 +1,37 @@
+import ..schema as s
+
+# sops-secrets-operator — https://github.com/stuttgart-things/flux/tree/main/apps/sops-secrets-operator
+#
+# Turns a `SopsSecret` — an age-encrypted blob committed to git — into a real
+# Kubernetes Secret. The reason a management cluster wants it: the capability
+# charts each ship their own SopsSecretManifest, so without the operator those
+# credentials stay encrypted blobs and every provider that needs them sits
+# without a config.
+#
+# Depends on cert-manager for the same reason trust-manager does, but the
+# failure is nastier. trust-manager's CRDs simply do not appear; here the
+# Deployment comes up healthy and every `SopsSecret` apply is then rejected by a
+# validating webhook whose certificate was never issued — which reads like a
+# broken CRD rather than a missing dependency.
+#
+# NOT a HelmRelease: the app pulls a kustomize base built from the operator's
+# own config/default, so there is no chart to wait on. 10m rather than the
+# 15m the Helm-wrapping entries use — CRDs and a webhook, no chart pull.
+#
+# The age key is deliberately absent. The operator carries none: it resolves one
+# per resource through `spec.decryption.keyRef`, so how a key reaches a cluster
+# is a separate decision and not one this entry should make. Today the machinery
+# play writes `sops-age-key` into the operator's namespace from SOPS_AGE_KEY; a
+# cluster with external-secrets could pull it from Vault instead.
+sopsSecretsOperator: s.App = {
+    artifact = "oci://ghcr.io/stuttgart-things/flux/apps/sops-secrets-operator"
+    defaultVersion = "v1.21.0"
+    components = [
+        s.Component {
+            name = "install"
+            path = "./"
+            timeout = "10m"
+            dependsOn = ["cert-manager:install"]
+        }
+    ]
+}

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -341,11 +341,7 @@ test_new_entries_are_registered = lambda {
 # healthy and every SopsSecret apply is then rejected by a validating webhook
 # whose certificate was never issued — which reads like a broken CRD.
 test_webhook_apps_depend_on_cert_manager = lambda {
-    _detached = [
-        n
-        for n in ["trust-manager", "sops-secrets-operator"]
-        if "cert-manager:install" not in c.get(n).components[0].dependsOn
-    ]
+    _detached = [n for n in ["trust-manager", "sops-secrets-operator"] if "cert-manager:install" not in c.get(n).components[0].dependsOn]
     assert _detached == [], "must wait for cert-manager: " + str(_detached)
 }
 

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -330,10 +330,33 @@ test_vault_discovers_the_domain_but_not_the_issuer = lambda {
 # typo in this batch fails loudly rather than as DependencyNotReady on a
 # cluster.
 test_new_entries_are_registered = lambda {
-    _want = ["external-secrets", "nfs-csi", "vault", "tekton"]
+    _want = ["external-secrets", "nfs-csi", "vault", "tekton", "sops-secrets-operator"]
     _missing = [n for n in _want if n not in c.catalog]
     assert _missing == [], "entry missing from the registry"
-    assert len(c.names) == 11
+    assert len(c.names) == 12
+}
+
+# Both depend on cert-manager, and both would present as something else without
+# it. trust-manager's CRDs never appear; the sops operator's Deployment comes up
+# healthy and every SopsSecret apply is then rejected by a validating webhook
+# whose certificate was never issued — which reads like a broken CRD.
+test_webhook_apps_depend_on_cert_manager = lambda {
+    _detached = [
+        n
+        for n in ["trust-manager", "sops-secrets-operator"]
+        if "cert-manager:install" not in c.get(n).components[0].dependsOn
+    ]
+    assert _detached == [], "must wait for cert-manager: " + str(_detached)
+}
+
+# No HelmRelease here: the app pulls a kustomize base built from the operator's
+# own config/default, so there is no chart to wait on. The assertion is here
+# because wrapsHelmRelease also drives the default timeout, and a later editor
+# copying trust-manager wholesale would set it wrongly.
+test_sops_operator_is_not_a_helm_release = lambda {
+    _c = c.get("sops-secrets-operator").components[0]
+    assert not _c.wrapsHelmRelease
+    assert _c.requiredSubstitutions == [], "the age key is not a substitution"
 }
 
 # tekton is the first entry from cicd/ rather than apps/ or infra/ — those were

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.16.0"
+version = "0.17.0"

--- a/crossplane/xplane-flux-catalog/main.k
+++ b/crossplane/xplane-flux-catalog/main.k
@@ -11,6 +11,7 @@ import .apps.headlamp as headlamp
 import .apps.machinery as machinery
 import .apps.nfs_csi as nfs_csi
 import .apps.openebs as openebs
+import .apps.sops_secrets_operator as sops_secrets_operator
 import .apps.tekton as tekton
 import .apps.trust_manager as trust_manager
 import .apps.vault as vault
@@ -25,6 +26,7 @@ catalog: {str:s.App} = {
     machinery = machinery.machinery
     "nfs-csi" = nfs_csi.nfsCsi
     openebs = openebs.openebs
+    "sops-secrets-operator" = sops_secrets_operator.sopsSecretsOperator
     tekton = tekton.tekton
     "trust-manager" = trust_manager.trustManager
     vault = vault.vault


### PR DESCRIPTION
Registers `sops-secrets-operator` (artifact published by stuttgart-things/flux#199) as the 12th catalog entry.

**Why**: the capability charts ship their credentials as age-encrypted `SopsSecret` manifests. Without the operator those stay blobs in git, and every provider that needs them sits without a config.

**cert-manager is a hard dependency**, and it fails unusually: trust-manager without cert-manager simply has no CRDs, but this operator's Deployment goes `Ready` and *then* rejects every `SopsSecret` apply against a webhook certificate that was never issued — reads like a broken CRD. Hence `dependsOn = ["cert-manager:install"]` plus a test asserting it for both webhook apps.

**Not a HelmRelease** — kustomize base from the operator's own `config/default` — so 10m, not the 15m the chart-installing entries need. A test pins that, since `wrapsHelmRelease` also drives the timeout and copying trust-manager wholesale would set it wrongly.

**No age key.** The operator carries none; it resolves one per resource via `spec.decryption.keyRef`. How a key reaches a cluster stays a separate decision — machinery writes it from `SOPS_AGE_KEY` today, external-secrets could pull it from Vault.

`kcl test`: 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL