### PR TITLE
fix(flux-catalog): sops-secrets-operator does not need cert-manager (0.18.0)

### DIFF
--- a/crossplane/xplane-flux-catalog/README.md
+++ b/crossplane/xplane-flux-catalog/README.md
@@ -46,11 +46,14 @@ dependsOn = ["cert-manager:install"]    # a component of ANOTHER app
 
 Both resolve to the emitted Kustomization name `{app}-{component}`, which is
 globally unique because app names are. Cross-artifact dependencies are real:
-`trust-manager` cannot reconcile before cert-manager's CRDs exist, and
-`sops-secrets-operator` installs a validating webhook whose certificate
-cert-manager issues — without it the operator comes up *healthy* and then
-rejects every `SopsSecret` apply, which looks like a broken CRD rather than a
-missing dependency.
+`trust-manager` cannot reconcile before cert-manager's CRDs exist.
+
+A dependency is not a free hint. The consumer **rejects** an app whose
+dependency is not enabled, so declaring one the artifact does not actually have
+denies that app to every cluster missing the dependency. `sops-secrets-operator`
+is the case that proved it: upstream ships a webhook and a cert-manager
+Certificate, ours publishes CRDs, RBAC and a Deployment and nothing else —
+check what the artifact installs, not what the project is known for.
 
 A consumer must **reject** a reference whose target app or component is not
 enabled — `xplane-platform` does, naming what to add. Flux would otherwise leave

--- a/crossplane/xplane-flux-catalog/apps/sops_secrets_operator.k
+++ b/crossplane/xplane-flux-catalog/apps/sops_secrets_operator.k
@@ -8,15 +8,22 @@ import ..schema as s
 # credentials stay encrypted blobs and every provider that needs them sits
 # without a config.
 #
-# Depends on cert-manager for the same reason trust-manager does, but the
-# failure is nastier. trust-manager's CRDs simply do not appear; here the
-# Deployment comes up healthy and every `SopsSecret` apply is then rejected by a
-# validating webhook whose certificate was never issued — which reads like a
-# broken CRD rather than a missing dependency.
-#
 # NOT a HelmRelease: the app pulls a kustomize base built from the operator's
-# own config/default, so there is no chart to wait on. 10m rather than the
-# 15m the Helm-wrapping entries use — CRDs and a webhook, no chart pull.
+# config/default, so there is no chart to wait on. 10m rather than the 15m the
+# Helm-wrapping entries use — CRDs and a Deployment, no chart pull.
+#
+# NO cert-manager dependency, which is worth stating because the obvious
+# assumption is wrong. Upstream (isindir/sops-secrets-operator, group
+# isindir.github.com) ships a validating webhook and `config/default` wires in
+# ../webhook and ../certmanager. This is NOT that operator: it is
+# stuttgart-things/sops-secrets-operator, group sops.stuttgart-things.com, and
+# the artifact it publishes contains exactly a Namespace, 5 CRDs, a
+# ServiceAccount, a ClusterRole+Binding and a Deployment. Verified against the
+# published v0.9.0 artifact and against a live install on u26-rke2-1
+# (2026-08-17): no ValidatingWebhookConfiguration, no Certificate, no cert
+# volume on the Deployment. Adding the dependency back would not be a harmless
+# extra edge — the catalog REJECTS an app whose dependency is not enabled, so
+# it would deny this operator to any cluster that does not run cert-manager.
 #
 # The age key is deliberately absent. The operator carries none: it resolves one
 # per resource through `spec.decryption.keyRef`, so how a key reaches a cluster
@@ -31,7 +38,6 @@ sopsSecretsOperator: s.App = {
             name = "install"
             path = "./"
             timeout = "10m"
-            dependsOn = ["cert-manager:install"]
         }
     ]
 }

--- a/crossplane/xplane-flux-catalog/catalog_test.k
+++ b/crossplane/xplane-flux-catalog/catalog_test.k
@@ -336,13 +336,17 @@ test_new_entries_are_registered = lambda {
     assert len(c.names) == 12
 }
 
-# Both depend on cert-manager, and both would present as something else without
-# it. trust-manager's CRDs never appear; the sops operator's Deployment comes up
-# healthy and every SopsSecret apply is then rejected by a validating webhook
-# whose certificate was never issued — which reads like a broken CRD.
-test_webhook_apps_depend_on_cert_manager = lambda {
-    _detached = [n for n in ["trust-manager", "sops-secrets-operator"] if "cert-manager:install" not in c.get(n).components[0].dependsOn]
-    assert _detached == [], "must wait for cert-manager: " + str(_detached)
+# The obvious assumption about this operator is wrong, and the cost of acting on
+# it is not an extra edge in the graph: the catalog REJECTS an app whose
+# dependency is not enabled, so a cert-manager dependsOn here would deny the
+# operator to every cluster that does not run cert-manager. Upstream
+# (isindir/sops-secrets-operator) does ship a webhook and a cert-manager
+# Certificate; ours (group sops.stuttgart-things.com) publishes a Namespace, 5
+# CRDs, a ServiceAccount, a ClusterRole+Binding and a Deployment, and nothing
+# else — checked against the v0.9.0 artifact and a live install.
+test_sops_operator_has_no_cert_manager_dependency = lambda {
+    _c = c.get("sops-secrets-operator").components[0]
+    assert _c.dependsOn == [], "the published artifact installs no webhook and no Certificate"
 }
 
 # No HelmRelease here: the app pulls a kustomize base built from the operator's
@@ -350,9 +354,9 @@ test_webhook_apps_depend_on_cert_manager = lambda {
 # because wrapsHelmRelease also drives the default timeout, and a later editor
 # copying trust-manager wholesale would set it wrongly.
 test_sops_operator_is_not_a_helm_release = lambda {
-    _c = c.get("sops-secrets-operator").components[0]
-    assert not _c.wrapsHelmRelease
-    assert _c.requiredSubstitutions == [], "the age key is not a substitution"
+    _c2 = c.get("sops-secrets-operator").components[0]
+    assert not _c2.wrapsHelmRelease
+    assert _c2.requiredSubstitutions == [], "the age key is not a substitution"
 }
 
 # tekton is the first entry from cicd/ rather than apps/ or infra/ — those were

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.17.0"
+version = "0.18.0"


### PR DESCRIPTION
Reverts the `dependsOn: [cert-manager:install]` I added in 0.17.0, with the rationale that was wrong.

I documented that the operator installs a validating webhook whose certificate cert-manager issues. That is true of **isindir/sops-secrets-operator** (group `isindir.github.com`), whose `config/default` wires in `../webhook` and `../certmanager`. This app installs **stuttgart-things/sops-secrets-operator**, group `sops.stuttgart-things.com`.

Checked two ways:

- `flux pull artifact oci://ghcr.io/stuttgart-things/sops-secrets-operator-kustomize:v0.9.0` → Namespace, 5 CRDs, ServiceAccount, ClusterRole+Binding, Deployment. Nothing else.
- live install on `u26-rke2-1` → no `ValidatingWebhookConfiguration`, no `Certificate`, no cert volume on the pod.

**Not a harmless extra edge.** The consumer rejects an app whose dependency is not enabled, so the entry denied this operator to every cluster without cert-manager — which is exactly the kind of cluster that wants age-encrypted secrets from git.

The test flips from asserting the dependency to asserting its absence, and the README gains the general rule: check what an artifact installs, not what the project is known for.

`kcl test`: 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL