### PR TITLE
docs(flux-catalog): name what the sops artifact is actually built from (0.18.1)

### DIFF
--- a/crossplane/xplane-flux-catalog/apps/sops_secrets_operator.k
+++ b/crossplane/xplane-flux-catalog/apps/sops_secrets_operator.k
@@ -8,17 +8,19 @@ import ..schema as s
 # credentials stay encrypted blobs and every provider that needs them sits
 # without a config.
 #
-# NOT a HelmRelease: the app pulls a kustomize base built from the operator's
-# config/default, so there is no chart to wait on. 10m rather than the 15m the
+# NOT a HelmRelease: the app pulls the published sops-secrets-operator-kustomize
+# artifact, so there is no chart to wait on. 10m rather than the 15m the
 # Helm-wrapping entries use — CRDs and a Deployment, no chart pull.
 #
 # NO cert-manager dependency, which is worth stating because the obvious
 # assumption is wrong. Upstream (isindir/sops-secrets-operator, group
-# isindir.github.com) ships a validating webhook and `config/default` wires in
-# ../webhook and ../certmanager. This is NOT that operator: it is
-# stuttgart-things/sops-secrets-operator, group sops.stuttgart-things.com, and
-# the artifact it publishes contains exactly a Namespace, 5 CRDs, a
-# ServiceAccount, a ClusterRole+Binding and a Deployment. Verified against the
+# isindir.github.com) ships a validating webhook. Our own repo reads that way
+# too — its kubebuilder config/default composes ../webhook and ../certmanager,
+# so a `kubectl apply -k .../config/default` install really does need
+# cert-manager. This app installs neither: the published
+# sops-secrets-operator-kustomize artifact is rendered by the release workflow
+# from the repo's kcl/ deploy profile, and contains exactly a Namespace, 5
+# CRDs, a ServiceAccount, a ClusterRole+Binding and a Deployment. Verified against the
 # published v0.9.0 artifact and against a live install on u26-rke2-1
 # (2026-08-17): no ValidatingWebhookConfiguration, no Certificate, no cert
 # volume on the Deployment. Adding the dependency back would not be a harmless

--- a/crossplane/xplane-flux-catalog/kcl.mod
+++ b/crossplane/xplane-flux-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-flux-catalog"
 edition = "v0.12.3"
-version = "0.18.0"
+version = "0.18.1"


### PR DESCRIPTION
Comment-only follow-up to #162; rendered output unchanged.

#162 removed the wrong cert-manager dependency but left a second inaccuracy in place: the comment said the app pulls a kustomize base built from the operator's `config/default`. It does not — the release workflow renders the published artifact from the repo's `kcl/` deploy profile via `dagger kcl push-kustomize-base`.

That difference is the entire point of the entry. `config/default` **does** compose `../webhook` and `../certmanager`, which is exactly why the dependency looked obviously right, and why someone reading the operator repo will reach the opposite conclusion. Both halves are now in the comment.

`kcl test`: 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL