### PR TITLE
feat(capability-catalog): the capability layer as structural facts (0.1.0)

### DIFF
--- a/crossplane/xplane-capability-catalog/README.md
+++ b/crossplane/xplane-capability-catalog/README.md
@@ -1,0 +1,99 @@
+# xplane-capability-catalog
+
+Structural definitions of the **capabilities** a management cluster can be given.
+
+A capability is what lets a cluster act on an external system. The provider is
+installed on every management cluster, but on its own it does nothing useful:
+
+| missing | consequence |
+|---|---|
+| `ClusterProviderConfig` | the provider runs and does not know where to connect |
+| credentials | it knows where, and may not log in |
+| `EnvironmentConfig` | it is logged in and does not know which node, datastore or template to place a VM on |
+
+This module says what each capability's three objects look like.
+[`xplane-capability`](../xplane-capability/) renders them onto a target cluster
+from a `Capability` XR.
+
+## What belongs here — and what does not
+
+Structural facts only: which `ClusterProviderConfig` kind a provider reads, how
+one Vault KV secret maps into the credential payload it expects, which placement
+fields exist, and which of them have fleet-wide defaults.
+
+VALUES do not. `node: ul-pve01`, `templateVmId: "211"`, the Vault path — those
+are per-cluster and belong on the XR. Same split as
+[`xplane-flux-catalog`](../xplane-flux-catalog/), for the same reason: a value
+copied here drifts from the environment that owns it, silently, because nothing
+compares them.
+
+The dividing question is not "does it change often" but "who owns it". `virtio0`
+is a default here even though it never changes, because it is a property of the
+sthings-u26 image and the bpg provider — not of LabUL.
+
+## Entries
+
+| capability | provider config | Vault keys | required placement |
+|---|---|---|---|
+| `proxmoxvm` | `proxmoxbpg.m.crossplane.io/v1beta1` | `pve_api_url`, `pve_api_user`, `pve_api_password`, `vm_ssh_user`, `vm_ssh_password` | `node`, `datastore`, `bridge`, `vlanTag`, `pool`, `templateVmId` |
+| `vspherevm` | `vspherevm.m.stuttgart-things.com/v1beta1` | `vsphere_user`, `vsphere_password`, `vsphere_server` | `templateUuid`, `datastoreId`, `resourcePoolId`, `networkId`, `folder`, `domain` |
+
+Both were transcribed from the capability Helm charts in
+`stuttgart-things/stuttgart-things` (`crossplane/platform/capabilities/`), which
+are the shapes the `proxmoxvm` and `vspherevm` Compositions already read.
+Deviating from those field names would not be a redesign — the Compositions look
+them up by name, so it would be a silent break.
+
+## Three fields, three kinds of ownership
+
+```kcl
+required = ["node", "datastore", ...]   # facts about a datacenter; nothing can derive them
+defaults = {diskInterface = "virtio0"}  # facts about the image and the provider; an XR value wins
+optional = ["cloneDatastore", ...]      # emitted only when stated, and one of them bites
+```
+
+`cloneDatastore` is why `optional` exists as its own list rather than being a
+default with an empty value. bpg's clone block is `ForceNew`: a value appearing
+on an `EnvironmentConfig` rewrites the clone block of every VM already built
+under it, and the provider answers with destroy + recreate — unattended, under
+`compositionUpdatePolicy: Automatic`.
+
+## Workload secrets
+
+`proxmoxvm` declares one. It is not a credential for the provider; it is the
+cloud-init password, and it lives in the namespace where the VM XRs are, because
+the namespaced `EnvironmentVM` CRD resolves `passwordSecretRef` in the managed
+resource's own namespace.
+
+Skipping it is the kind of omission that hides. Without a `cipassword` in the
+user-data Proxmox emits, cloud-init applies its `lock_passwd` default and LOCKS
+the guest account on first boot, discarding what the Packer build baked in. Key
+logins keep working, so the cluster looks healthy — what breaks is every
+password-based `AnsibleRun`, each host simply `UNREACHABLE`.
+
+## Invariants (`kcl test`)
+
+| test | catches |
+|---|---|
+| `test_declared_vault_keys_match_the_templates` | a typo'd Vault key. ESO renders a missing key as the empty string, so the provider gets a syntactically valid credential that does not authenticate |
+| `test_workload_secret_vault_keys_match_their_templates` | the same, one level worse: an empty password locks the guest account and the cluster still comes up |
+| `test_provider_capabilities_ship_a_single_credentials_key` | a per-field Secret. The bpg and vsphere providers parse ONE JSON document out of ONE key |
+| `test_tls_flags_are_json_strings` | `"insecure": true`. The field unmarshals into a string, and a bare boolean fails the parse naming neither field nor Secret |
+| `test_provider_config_groups_are_namespaced_variants` | the cluster-scoped CRD instead of the namespaced `.m.` one — "no matches for kind" at apply time |
+| `test_environment_label_is_capability_scoped` | a label the consuming Composition does not select on |
+| `test_fields_are_disjoint` | a placement field in two lists, where the emitted value would be arbitrary |
+| `test_workload_secrets_are_referenced_from_placement` | a workload Secret nothing reads |
+
+## Adding a capability
+
+1. `capabilities/<name>.k` — one `s.Capability`, transcribed from the consuming
+   Composition's field names, not invented.
+2. Register it in `main.k`.
+3. `kcl test` — the invariants above apply to it automatically.
+
+## Not covered
+
+The `sops` and `sops-git` credential backends the Helm charts offer. Those exist
+so a cluster **without** Vault can still have credentials, and such a cluster
+cannot use this catalog's consumer at all — it would get an `ExternalSecret`
+nothing serves. For those clusters the charts remain the answer.

--- a/crossplane/xplane-capability-catalog/capabilities/proxmoxvm.k
+++ b/crossplane/xplane-capability-catalog/capabilities/proxmoxvm.k
@@ -1,0 +1,60 @@
+import ..schema as s
+
+# proxmoxvm — provider-proxmox-bpg + the proxmoxvm Configuration.
+#
+# Placement fields are transcribed from the capability Helm chart
+# (stuttgart-things/stuttgart-things, crossplane/platform/capabilities/proxmoxvm),
+# which is the shape the proxmoxvm Composition already reads. Deviating from it
+# would not be a redesign, it would be a silent break: the Composition looks the
+# keys up by name.
+proxmoxvm: s.Capability = {
+    name = "proxmoxvm"
+    providerConfig = s.ProviderConfig {
+        apiVersion = "proxmoxbpg.m.crossplane.io/v1beta1"
+    }
+    credentials = s.Credentials {
+        # ONE key holding JSON — the bpg provider parses this document, it does
+        # not read a Secret with one key per field.
+        #
+        # `insecure` is the string "true", not the boolean. The provider
+        # unmarshals into a string field, and a bare true fails the parse with a
+        # type error that names neither the field nor this Secret.
+        data = {
+            credentials = '{"endpoint":"{{ .pve_api_url }}","username":"{{ .pve_api_user }}","password":"{{ .pve_api_password }}","insecure":"true","ssh_username":"{{ .vm_ssh_user }}","ssh_password":"{{ .vm_ssh_password }}"}'
+        }
+        vaultKeys = ["pve_api_url", "pve_api_user", "pve_api_password", "vm_ssh_user", "vm_ssh_password"]
+    }
+    # The cloud-init password. Same Vault secret as the credentials, different
+    # namespace: the namespaced EnvironmentVM CRD resolves passwordSecretRef in
+    # the managed resource's own namespace, i.e. the XR's, not the provider's.
+    workloadSecrets = [
+        s.WorkloadSecret {
+            nameSuffix = "ci-password"
+            data = {password = "{{ .vm_ssh_password }}"}
+            vaultKeys = ["vm_ssh_password"]
+        }
+    ]
+    environmentLabelKey = "proxmoxvm.resources.stuttgart-things.com/environment"
+    required = ["node", "datastore", "bridge", "vlanTag", "pool", "templateVmId"]
+    defaults = {
+        cpuType = "host"
+        osType = "l26"
+        bios = "seabios"
+        # sthings-u26 carries its root disk on virtio0. scsi0 — the obvious
+        # default — produces a VM that boots to no disk.
+        diskInterface = "virtio0"
+        networkModel = "virtio"
+        ciUsername = "sthings"
+        ciPasswordSecretKey = "password"
+        annotation = "PROXMOX-VM BUILD w/ CROSSPLANE (native) FOR STUTTGART-THINGS"
+    }
+    # cloneDatastore: bpg's clone block is ForceNew. A value here rewrites the
+    # clone block of every VM already built under this EnvironmentConfig, and
+    # the provider answers with destroy + recreate — unattended, under
+    # compositionUpdatePolicy Automatic. Requires proxmoxvm >= v0.11.0, whose
+    # `none` sentinel is how an individual XR declines it.
+    #
+    # snippetsDatastore is NOT the hostname lever (that is the PVE VM name);
+    # it only pins the cloud-init instance-id.
+    optional = ["cloneDatastore", "snippetsDatastore", "smbiosManufacturer", "smbiosProduct", "ciPasswordSecretName"]
+}

--- a/crossplane/xplane-capability-catalog/capabilities/vspherevm.k
+++ b/crossplane/xplane-capability-catalog/capabilities/vspherevm.k
@@ -1,0 +1,34 @@
+import ..schema as s
+
+# vspherevm — provider-vspherevm + the vspherevm Configuration.
+#
+# Second entry deliberately: one capability cannot show whether the schema
+# generalizes. It differs from proxmoxvm in every part that matters — a
+# different provider group, four Vault keys instead of five under different
+# names, a flat JSON without SSH credentials, and placement by folder/pool
+# rather than node/datastore.
+vspherevm: s.Capability = {
+    name = "vspherevm"
+    providerConfig = s.ProviderConfig {
+        apiVersion = "vspherevm.m.stuttgart-things.com/v1beta1"
+    }
+    credentials = s.Credentials {
+        data = {
+            credentials = '{"user":"{{ .vsphere_user }}","password":"{{ .vsphere_password }}","server":"{{ .vsphere_server }}","allow_unverified_ssl":"true"}'
+        }
+        vaultKeys = ["vsphere_user", "vsphere_password", "vsphere_server"]
+    }
+    environmentLabelKey = "vspherevm.resources.stuttgart-things.com/environment"
+    # MOIDs, not names: vSphere placement is by managed-object ID
+    # (datastore-12, resgroup-8, dvportgroup-2048), and templateUuid is the
+    # BIOS config.uuid rather than the VM name.
+    required = ["templateUuid", "datastoreId", "resourcePoolId", "networkId", "folder", "domain"]
+    defaults = {
+        firmware = "bios"
+        guestId = "ubuntu64Guest"
+        scsiType = "pvscsi"
+        adapterType = "vmxnet3"
+        annotation = "VSPHERE-VM BUILD w/ CROSSPLANE FOR STUTTGART-THINGS"
+    }
+    optional = ["hostSystemId"]
+}

--- a/crossplane/xplane-capability-catalog/catalog_test.k
+++ b/crossplane/xplane-capability-catalog/catalog_test.k
@@ -1,0 +1,75 @@
+import .main as c
+
+test_every_entry_is_registered_under_its_own_name = lambda {
+    _wrong = [n for n in c.names if c.catalog[n].name != n]
+    assert _wrong == [], "catalog key and Capability.name disagree: " + str(_wrong)
+}
+
+test_get_rejects_an_unknown_name = lambda {
+    assert len(c.names) == 2
+    assert "proxmoxvm" in c.names
+}
+
+# The templates are opaque strings to this module, so nothing else would catch a
+# key that is referenced but not declared — and the failure mode is quiet: ESO
+# renders a missing key as the empty string, so the provider gets a
+# syntactically valid credential that simply does not authenticate.
+test_declared_vault_keys_match_the_templates = lambda {
+    _undeclared = [n + ":" + k for n in c.names for k in c.get(n).credentials.vaultKeys if not any_true([("{{ ." + k + " }}") in v for v in [c.get(n).credentials.data[dk] for dk in c.get(n).credentials.data]])]
+    assert _undeclared == [], "declared but never referenced: " + str(_undeclared)
+}
+
+# The bpg and vsphere providers parse ONE JSON document out of ONE Secret key.
+# A per-field Secret looks tidier and fails at login with an error that names
+# neither the field nor the Secret.
+test_provider_capabilities_ship_a_single_credentials_key = lambda {
+    _split = [n for n in c.names if c.get(n)?.providerConfig and len(c.get(n).credentials.data) != 1]
+    assert _split == [], "a provider capability needs exactly one credentials key: " + str(_split)
+}
+
+# `insecure` / `allow_unverified_ssl` unmarshal into STRING fields. A bare JSON
+# true fails the parse with a type error naming neither field nor Secret.
+test_tls_flags_are_json_strings = lambda {
+    _bad = [n for n in c.names for v in [c.get(n).credentials.data[dk] for dk in c.get(n).credentials.data] if '"insecure":true' in v or '"allow_unverified_ssl":true' in v]
+    assert _bad == [], "TLS flag must be a quoted string: " + str(_bad)
+}
+
+# The consuming Composition selects EnvironmentConfigs on this label, so it is
+# part of a contract with another Configuration rather than free-form.
+test_environment_label_is_capability_scoped = lambda {
+    _bad = [n for n in c.names if c.get(n).environmentLabelKey != n + ".resources.stuttgart-things.com/environment"]
+    assert _bad == [], "label key must be scoped to the capability: " + str(_bad)
+}
+
+# fields() is what lets a consumer reject a typo'd placement key. If a field
+# appeared in two of the three lists, the rejection would still work but the
+# emitted EnvironmentConfig would take one of them arbitrarily.
+test_fields_are_disjoint = lambda {
+    _dupes = [n for n in c.names if len(c.fields(n)) != len({f: "" for f in c.fields(n)})]
+    assert _dupes == [], "a placement field appears in more than one list: " + str(_dupes)
+}
+
+# A ClusterProviderConfig is a different CRD from the cluster-scoped
+# ProviderConfig, and the namespaced variants live under a `.m.` group. Naming
+# the wrong one produces "no matches for kind" at apply time.
+test_provider_config_groups_are_namespaced_variants = lambda {
+    _bad = [n for n in c.names if c.get(n)?.providerConfig and ".m." not in c.get(n).providerConfig.apiVersion]
+    assert _bad == [], "expected the namespaced (.m.) provider group: " + str(_bad)
+}
+
+# A workload secret only helps if it lands where the consumer looks: the
+# namespaced EnvironmentVM CRD resolves passwordSecretRef in the managed
+# resource's own namespace. An entry declaring one must therefore also expose
+# the field that names it, or the Secret exists and nothing reads it.
+test_workload_secrets_are_referenced_from_placement = lambda {
+    _orphan = [n for n in c.names if len(c.get(n).workloadSecrets) > 0 and "ciPasswordSecretName" not in c.fields(n)]
+    assert _orphan == [], "workload secret with no placement field naming it: " + str(_orphan)
+}
+
+# Same trap as Credentials.vaultKeys, and worth its own test because this one is
+# invisible twice over: a mistyped key yields an empty password, cloud-init
+# locks the account, and the cluster still comes up.
+test_workload_secret_vault_keys_match_their_templates = lambda {
+    _undeclared = [n + ":" + k for n in c.names for w in c.get(n).workloadSecrets for k in w.vaultKeys if not any_true([("{{ ." + k + " }}") in w.data[dk] for dk in w.data])]
+    assert _undeclared == [], "declared but never referenced: " + str(_undeclared)
+}

--- a/crossplane/xplane-capability-catalog/kcl.mod
+++ b/crossplane/xplane-capability-catalog/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "xplane-capability-catalog"
+edition = "v0.12.3"
+version = "0.1.0"

--- a/crossplane/xplane-capability-catalog/main.k
+++ b/crossplane/xplane-capability-catalog/main.k
@@ -1,0 +1,32 @@
+"""
+The stuttgart-things capability catalog.
+
+Consumers import `catalog` (or call `get`) and combine an entry with the
+per-cluster values on an XR. See schema.k for what belongs here and what does
+not.
+"""
+
+import .schema as s
+import .capabilities.proxmoxvm as proxmoxvm
+import .capabilities.vspherevm as vspherevm
+
+catalog: {str:s.Capability} = {
+    proxmoxvm = proxmoxvm.proxmoxvm
+    vspherevm = vspherevm.vspherevm
+}
+
+names: [str] = sorted([n for n in catalog])
+
+get = lambda name: str -> s.Capability {
+    assert name in catalog, "unknown capability '" + name + "' — known: " + ", ".join(names)
+    catalog[name]
+}
+
+# Every placement field a capability can emit, in one list. A consumer needs
+# this to reject an XR key that matches nothing: a typo'd `datastoreID` would
+# otherwise be dropped in silence and surface as a provider error naming a field
+# the user never wrote.
+fields = lambda name: str -> [str] {
+    _c = get(name)
+    _c.required + sorted([k for k in _c.defaults]) + _c.optional
+}

--- a/crossplane/xplane-capability-catalog/schema.k
+++ b/crossplane/xplane-capability-catalog/schema.k
@@ -1,0 +1,124 @@
+"""
+Structural definitions for the stuttgart-things capability catalog.
+
+A *capability* is what lets a cluster act on an external system: the provider
+runs, but without a ClusterProviderConfig it does not know where; without
+credentials it may not log in; without an EnvironmentConfig it does not know
+which node, datastore or template to place a VM on.
+
+Holds STRUCTURAL facts only — which ClusterProviderConfig kind a provider reads,
+how one Vault KV secret maps into the credential payload it expects, which
+placement fields exist and which of them have fleet-wide defaults. VALUES
+(node, datastore, templateVmId, the Vault path) are per-cluster and belong on
+the XR. Same split as xplane-flux-catalog, for the same reason: a value copied
+here drifts from the environment that owns it.
+"""
+
+schema ProviderConfig:
+    """
+    The provider's own config object.
+
+    Optional on a capability: `ansible` configures a Configuration rather than a
+    provider and has none, while `proxmoxvm` cannot place a single VM without
+    one.
+    """
+    apiVersion: str
+    """Full apiVersion of the provider's ClusterProviderConfig CRD, e.g.
+    'proxmoxbpg.m.crossplane.io/v1beta1'. Providers do NOT share a group, and
+    the namespaced (`.m.`) variants are separate CRDs from the cluster-scoped
+    ones — see CLAUDE.md."""
+
+    kind: str = "ClusterProviderConfig"
+
+    credentialsKey: str = "credentials"
+    """Key WITHIN the Secret the provider reads. For the bpg and vsphere
+    providers this is a single key holding a JSON document, not one key per
+    field."""
+
+schema Credentials:
+    """
+    How one Vault KV-v2 secret becomes the Secret a capability consumes.
+
+    `data` values are ESO templates (engineVersion v2) evaluated against the
+    keys of the extracted Vault secret, so `{{ .pve_api_url }}` refers to the
+    Vault key `pve_api_url`. They are stored as opaque strings here: this module
+    never renders them, it only decides which capability gets which shape.
+    """
+    data: {str:str}
+    """Target Secret key -> ESO template."""
+
+    vaultKeys: [str]
+    """Vault keys the templates reference. Redundant with `data` by
+    construction, and that is the point: a missing key renders as the empty
+    string rather than failing, so a provider gets a syntactically valid
+    credential that simply does not authenticate. Declaring them lets a test
+    catch a typo that Vault would only reveal at first login."""
+
+    check:
+        len(data) > 0, "a capability with no credential data has nothing to authenticate with"
+        len(vaultKeys) > 0, "declare the Vault keys the templates read"
+
+schema WorkloadSecret:
+    """
+    A second Secret the capability needs, in the namespace where the XRs live
+    rather than where the provider reads its credentials.
+
+    Only proxmoxvm has one, and skipping it is the kind of omission that hides:
+    without a cipassword in the user-data Proxmox emits, cloud-init applies its
+    `lock_passwd` default and LOCKS the guest account on first boot, discarding
+    what the Packer build baked in. Key logins keep working, so the cluster
+    looks fine — what breaks is every password-based AnsibleRun, each host
+    simply UNREACHABLE.
+    """
+    nameSuffix: str
+    """Appended to the capability name: 'ci-password' -> 'proxmoxvm-ci-password'."""
+
+    data: {str:str}
+    """Target Secret key -> ESO template, same rules as Credentials.data."""
+
+    vaultKeys: [str]
+
+    check:
+        len(data) > 0, "a workload secret with no data is not worth an object"
+
+schema Capability:
+    """One capability: provider config + credentials + placement facts."""
+    name: str
+    """Catalog key. Also the default prefix for every emitted object name."""
+
+    providerConfig?: ProviderConfig
+    credentials: Credentials
+
+    environmentLabelKey: str
+    """Label key on the emitted EnvironmentConfig. The consuming Composition
+    selects on it, so it is part of the contract with that Configuration and NOT
+    free-form — proxmoxvm reads
+    `proxmoxvm.resources.stuttgart-things.com/environment`."""
+
+    required: [str]
+    """Placement fields the XR MUST supply. Facts about a datacenter that
+    nothing can derive: which node, which datastore, which template."""
+
+    defaults: {str:str} = {}
+    """Placement fields with a fleet-wide default. An XR value always wins.
+    These are here rather than on the XR because they are properties of the
+    IMAGE and the provider, not of the environment: sthings-u26 puts its root
+    disk on virtio0, and getting that wrong produces a VM that boots to no
+    disk."""
+
+    workloadSecrets: [WorkloadSecret] = []
+    """Secrets that belong in the workload namespace rather than beside the
+    provider. See WorkloadSecret."""
+
+    optional: [str] = []
+    """Placement fields that are neither required nor defaulted — emitted only
+    when the XR sets them. `cloneDatastore` is the cautionary one: bpg's clone
+    block is ForceNew, so a value appearing on an EnvironmentConfig rewrites the
+    clone block of every VM already built under it, and the provider answers
+    with destroy + recreate."""
+
+    check:
+        len(required) > 0, "a capability with no required placement fields is a defaults bundle, not a capability"
+        len([k for k in defaults if k in required]) == 0, "a field cannot be both required and defaulted"
+        len([k for k in optional if k in required or k in defaults]) == 0, "optional fields must not repeat required or defaulted ones"
+


### PR DESCRIPTION
First half of the native capability layer — points 2–4 of stuttgart-things/crossplane-configurations#258 (ClusterProviderConfigs, credentials, EnvironmentConfigs). The renderer follows in a second PR, because it pins this module by OCI tag.

**What a capability is.** The provider is installed on every management cluster and on its own does nothing useful: without a `ClusterProviderConfig` it does not know where to connect, without credentials it may not log in, without an `EnvironmentConfig` it does not know which node, datastore or template to place a VM on.

**Transcribed, not designed.** Both entries come from the capability Helm charts in `stuttgart-things/stuttgart-things` (`crossplane/platform/capabilities/`). The `proxmoxvm` and `vspherevm` Compositions look those `EnvironmentConfig` keys up **by name**, so a nicer vocabulary would be a silent break, not a redesign.

**Two entries on purpose.** One capability cannot show whether the schema generalizes. `vspherevm` differs from `proxmoxvm` in provider group, Vault key names, credential JSON shape and placement vocabulary (MOIDs rather than names).

**Values stay out**, same split as `xplane-flux-catalog`. The dividing question is not how often something changes but who owns it: `virtio0` is a default here although it never changes, because it is a property of the sthings-u26 image and the bpg provider rather than of LabUL.

**The tests target quiet failures.** ESO renders a missing Vault key as the empty string, so a typo yields a syntactically valid credential that does not authenticate; an empty cloud-init password locks the guest account while the cluster still comes up healthy and only every password-based `AnsibleRun` breaks.

`kcl test`: 10/10.

Not covered: the `sops` / `sops-git` backends. They exist so a cluster **without** Vault can have credentials, and such a cluster cannot use the renderer at all — it would get an `ExternalSecret` nothing serves. The charts stay the answer there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL