### PR TITLE
feat(capability): render a cluster's capabilities from a Capability XR (0.1.0)

### DIFF
--- a/crossplane/xplane-capability/README.md
+++ b/crossplane/xplane-capability/README.md
@@ -1,0 +1,135 @@
+# xplane-capability
+
+`function-kcl` module for the **capability** Crossplane Configuration. Given a
+namespaced `Capability` XR, it emits the objects that let a management cluster
+act on an external system, onto a target cluster, one set per enabled capability:
+
+| object | why |
+|---|---|
+| `ExternalSecret` (credentials) | the provider may log in |
+| `ClusterProviderConfig` | it knows where to connect |
+| `EnvironmentConfig` | it knows which node, datastore and template to place a VM on |
+| `ExternalSecret` (workload) | only where a capability declares one — see below |
+
+Structure comes from
+[`xplane-capability-catalog`](../xplane-capability-catalog/); values come from
+the XR.
+
+## Why native rather than the Helm charts
+
+The per-capability charts in `stuttgart-things/stuttgart-things` do the same
+job. Two things get better in the move, and both follow from running *inside*
+Crossplane rather than beside it.
+
+**Two values stop being deploy-time parameters.** The charts take
+
+```yaml
+authMountPath: test-k3s-eso      # "appset injects <cluster>-eso per cluster"
+secretStore.name: vault-cicd-proxmox-labul
+```
+
+Their own comment says the mount is injected from outside. Here the cluster name
+is the XR's, so the same derivation happens where the fact lives.
+
+**Package installation stays out.** The charts can install the Configuration and
+the Provider, which is what their long comments about duplicate lock nodes are
+about. That job belongs to the `management-plane` Configuration, which installs
+packages under the CR names Crossplane itself derives — the shape in which the
+[#247](https://github.com/stuttgart-things/crossplane-configurations/issues/247)
+collision cannot occur.
+
+**What does not move:** the `sops` and `sops-git` credential backends. They
+exist so a cluster *without* Vault can still have credentials, and such a
+cluster cannot use this module at all — it would get an `ExternalSecret` nothing
+serves. For those clusters the charts remain the answer.
+
+## The XR
+
+```yaml
+spec:
+  clusterName: u26-rke2-1
+  kubernetesProviderConfigRef: u26-rke2-1-kubernetes   # the TARGET cluster
+  environment: labul              # defaults to clusterName; labels + names every object
+  namespace: crossplane-system    # where the provider reads its Secret
+  workloadNamespace: default      # where the VM XRs live
+  capabilities:
+    proxmoxvm:
+      enabled: true
+      vault:
+        secret: default           # KV key; the store defaults to vault-cluster-secrets
+      placement:
+        node: ul-pve01
+        datastore: V5010-01-1
+        bridge: vmbrvlan
+        vlanTag: "102"
+        pool: stuttgart-things
+        templateVmId: "211"
+```
+
+Everything not listed is either a catalog default or derived.
+`providerConfigName` and `providerConfigKind` are **always** derived: they name
+an object this module emits, and letting an XR state them would make it possible
+to point a VM at a config this XR did not create.
+
+## Two namespaces, not one
+
+`namespace` is where the provider reads its credentials. `workloadNamespace` is
+where the VM XRs live, and it is where a capability's *workload* secrets go —
+the cloud-init password, for `proxmoxvm`. The namespaced `EnvironmentVM` CRD
+resolves `passwordSecretRef` in the managed resource's own namespace, so a
+cloud-init password placed next to the provider is a Secret nothing reads, and
+the symptom is not a missing Secret: cloud-init applies its `lock_passwd`
+default, LOCKS the guest account, and every password-based `AnsibleRun` reports
+the host `UNREACHABLE`.
+
+## Failing the render
+
+A capability with a missing or unknown placement field aborts the whole render,
+naming every problem across every capability at once.
+
+```
+capability configuration is incomplete: proxmoxvm: missing required placement ["node"]
+```
+
+Both halves are deliberate:
+
+* **Missing** — a missing `node` does not surface as a validation error. It
+  surfaces minutes later as a VM the provider tries to place nowhere, in a
+  message that names the provider and not this XR.
+* **Unknown** — a typo'd `templateVMID` would otherwise be dropped in silence,
+  leave `templateVmId` missing, and produce an error naming the field the user
+  did *not* write.
+* **All at once** — a render is all-or-nothing, so reporting one field per
+  reconcile is the difference between one round-trip and six.
+
+An empty string counts as missing: an XRD default or a half-filled values file
+arrives as `""`, which is exactly as unusable as absent for a node name.
+
+## Invariants (`kcl test`)
+
+Decisions live in `logic.k` so they can be tested without a Crossplane request;
+`main.k` is plumbing. `validate` is a lambda rather than a module-level assert
+for the same reason — a top-level assert fires during `kcl test` too, where
+every field is legitimately absent.
+
+| test | catches |
+|---|---|
+| `test_a_missing_required_field_is_named` | the silent-placement failure above |
+| `test_a_typo_is_rejected_rather_than_dropped` | an unknown key vanishing |
+| `test_an_empty_string_counts_as_missing` | `""` passing as a value |
+| `test_defaults_apply_and_the_xr_wins` | a default that cannot be overridden — KCL treats a union over a schema-typed dict as a conflict, which would make overriding an error |
+| `test_numbers_are_stringified` | `vlanTag: 102` failing the apply on type rather than content |
+| `test_optional_fields_are_accepted_but_not_defaulted` | `cloneDatastore` acquiring a default. bpg's clone block is `ForceNew`: a value here rewrites the clone block of every VM already built under this EnvironmentConfig, and the provider answers with destroy + recreate |
+| `test_every_capability_is_reported_in_one_pass` | one-error-per-reconcile |
+
+## Naming
+
+Objects are named `<capability>-<environment>`, credentials
+`<capability>-creds-<environment>`. Two environments on one cluster (labda *and*
+labul) must not share a `ClusterProviderConfig` or a Secret.
+
+The credentials name deviates from the charts' `proxmox-creds-<env>` on purpose:
+on a cluster that still has the chart installed, colliding would give one Secret
+two owners and each ESO refresh would overwrite the other. Nothing else refers
+to the name — only the `ClusterProviderConfig` this module also emits — so a
+migration means deleting the chart's Secret, not renaming anything.

--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,0 +1,7 @@
+[package]
+name = "xplane-capability"
+edition = "v0.12.3"
+version = "0.1.0"
+
+[dependencies]
+xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-capability/kcl.mod.lock
+++ b/crossplane/xplane-capability/kcl.mod.lock
@@ -1,0 +1,9 @@
+[dependencies]
+  [dependencies.xplane-capability-catalog]
+    name = "xplane-capability-catalog"
+    full_name = "xplane-capability-catalog_0.1.0"
+    version = "0.1.0"
+    sum = "wm/8y5pwoeu+vDIGFj1TtHwTWP9WqtNEuFIsV7upkvQ="
+    reg = "ghcr.io"
+    repo = "stuttgart-things/xplane-capability-catalog"
+    oci_tag = "0.1.0"

--- a/crossplane/xplane-capability/logic.k
+++ b/crossplane/xplane-capability/logic.k
@@ -1,0 +1,62 @@
+"""
+Pure decisions, separated from rendering so they can be tested without a
+Crossplane request. main.k does the plumbing; everything that can be WRONG lives
+here.
+"""
+
+import xplane_capability_catalog.main as cat
+
+# Catalog defaults overlaid with the XR's values. Only keys the catalog knows
+# are kept — unknownFields turns the rest into an error rather than a value that
+# quietly disappears.
+placement = lambda capName: str, given: {str:} -> {str:str} {
+    _c = cat.get(capName)
+    _known = cat.fields(capName)
+    _over = {k: str(given[k]) for k in given if k in _known}
+
+    # Built key by key rather than with `|`: KCL treats a union between a
+    # schema-typed dict and an override of the same key as a CONFLICT and
+    # aborts, which would make stating a default on the XR — the one thing an
+    # override is for — an error.
+    {k: (_over[k] if k in _over else _c.defaults[k]) for k in _c.defaults} | {k: _over[k] for k in _over if k not in _c.defaults}
+}
+
+# Empty string counts as missing. An XRD default or a half-filled values file
+# reaches us as "" rather than as an absent key, and "" is exactly as unusable
+# as absent for a node name.
+missingRequired = lambda capName: str, given: {str:} -> [str] {
+    _p = placement(capName, given)
+    [f for f in cat.get(capName).required if f not in _p or _p[f] == ""]
+}
+
+# A typo'd placement key would otherwise be dropped in silence and surface much
+# later as a provider error naming a field the user never wrote.
+unknownFields = lambda capName: str, given: {str:} -> [str] {
+    _known = cat.fields(capName)
+    sorted([k for k in given if k not in _known])
+}
+
+# One message listing everything wrong with every capability, rather than
+# failing on the first. A render is all-or-nothing, so fixing one field at a
+# time costs a full reconcile per field.
+problems = lambda enabled: [str], givenFor: {str:{str:}} -> [str] {
+    sorted([n + ": missing required placement " + str(missingRequired(n, givenFor[n] or {})) for n in enabled if len(missingRequired(n, givenFor[n] or {})) > 0] + [n + ": unknown placement fields " + str(unknownFields(n, givenFor[n] or {})) + " — known: " + str(cat.fields(n)) for n in enabled if len(unknownFields(n, givenFor[n] or {})) > 0])
+}
+
+validate = lambda spec: {str:}, enabled: [str], givenFor: {str:{str:}} -> bool {
+    """Everything that must hold before a single object is emitted.
+
+    Lives in a lambda rather than at the top of main.k so it runs when it is
+    called — a module-level assert fires during `kcl test` too, where there is
+    no request and every field is legitimately absent.
+
+    Guarded on `enabled` for the same reason: a Capability XR with nothing
+    switched on emits nothing, so the refs it would need are not yet facts about
+    anything.
+    """
+    _p = problems(enabled, givenFor)
+    assert len(_p) == 0, "capability configuration is incomplete: " + "; ".join(_p)
+    assert len(enabled) == 0 or spec?.clusterName, "spec.clusterName is required"
+    assert len(enabled) == 0 or spec?.kubernetesProviderConfigRef, "spec.kubernetesProviderConfigRef is required — it names the ClusterProviderConfig for the TARGET cluster"
+    True
+}

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -1,0 +1,74 @@
+# Unit tests for the decisions. `kcl test` — no Crossplane, no cluster.
+import .logic
+import xplane_capability_catalog.main as cat
+
+_full = {
+    node = "ul-pve01"
+    datastore = "V5010-01-1"
+    bridge = "vmbrvlan"
+    vlanTag = "102"
+    pool = "stuttgart-things"
+    templateVmId = "211"
+}
+
+test_a_complete_placement_has_no_problems = lambda {
+    assert logic.missingRequired("proxmoxvm", _full) == []
+    assert logic.unknownFields("proxmoxvm", _full) == []
+    assert logic.problems(["proxmoxvm"], {proxmoxvm = _full}) == []
+}
+
+# The point of failing the render: a missing node does not surface as a
+# validation error, it surfaces minutes later as a VM the provider tries to
+# place nowhere, in a message that names the provider and not this XR.
+test_a_missing_required_field_is_named = lambda {
+    _p = logic.problems(["proxmoxvm"], {proxmoxvm = {n: _full[n] for n in _full if n != "node"}})
+    assert len(_p) == 1
+    assert "node" in _p[0]
+    assert "proxmoxvm" in _p[0]
+}
+
+# An XRD default or a half-filled values file arrives as "" rather than as an
+# absent key, and "" is exactly as unusable as absent for a node name.
+test_an_empty_string_counts_as_missing = lambda {
+    assert logic.missingRequired("proxmoxvm", _full | {node = ""}) == ["node"]
+}
+
+# Without this a typo lands nowhere: the key is dropped from the emitted
+# EnvironmentConfig, the required field it was meant to be stays missing, and
+# the error names the field the user did NOT write.
+test_a_typo_is_rejected_rather_than_dropped = lambda {
+    assert logic.unknownFields("proxmoxvm", _full | {templateVMID = "211"}) == ["templateVMID"]
+    _p = logic.problems(["proxmoxvm"], {proxmoxvm = _full | {templateVMID = "211"}})
+    assert len(_p) == 1 and "templateVMID" in _p[0]
+}
+
+# Catalog defaults must not be re-stated on the XR to take effect, and an XR
+# value must win when it is stated.
+test_defaults_apply_and_the_xr_wins = lambda {
+    _r = logic.placement("proxmoxvm", _full)
+    assert _r.diskInterface == "virtio0", "sthings-u26 boots off virtio0"
+    assert logic.placement("proxmoxvm", _full | {diskInterface = "scsi0"}).diskInterface == "scsi0"
+}
+
+# EnvironmentConfig data is string-typed. A YAML author writing `vlanTag: 102`
+# would otherwise produce an int and the apply fails on type, not on content.
+test_numbers_are_stringified = lambda {
+    assert logic.placement("proxmoxvm", _full | {vlanTag = 102}).vlanTag == "102"
+}
+
+# All capabilities are reported at once. A render is all-or-nothing, so fixing
+# one field per reconcile is the difference between one round-trip and six.
+test_every_capability_is_reported_in_one_pass = lambda {
+    _p = logic.problems(["proxmoxvm", "vspherevm"], {proxmoxvm = {}, vspherevm = {}})
+    assert len(_p) == 2
+}
+
+# cloneDatastore is optional for a reason worth keeping visible: bpg's clone
+# block is ForceNew, so a value appearing here rewrites the clone block of every
+# VM already built under this EnvironmentConfig — destroy and recreate,
+# unattended.
+test_optional_fields_are_accepted_but_not_defaulted = lambda {
+    assert "cloneDatastore" not in logic.placement("proxmoxvm", _full)
+    assert logic.placement("proxmoxvm", _full | {cloneDatastore = "V5010-01-1"}).cloneDatastore == "V5010-01-1"
+    assert "cloneDatastore" in cat.fields("proxmoxvm")
+}

--- a/crossplane/xplane-capability/main.k
+++ b/crossplane/xplane-capability/main.k
@@ -1,0 +1,302 @@
+"""
+xplane-capability — function-kcl module for the capability Crossplane Configuration.
+
+A capability is what lets a cluster ACT on an external system. The provider runs
+on every management cluster, but without a ClusterProviderConfig it does not know
+where to connect, without credentials it may not log in, and without an
+EnvironmentConfig it does not know which node, datastore or template to place a
+VM on. This module emits those three objects onto a target cluster, one set per
+enabled capability.
+
+It replaces the per-capability Helm charts in stuttgart-things/stuttgart-things
+for clusters that have external-secrets. Two things get better in the move, and
+both are consequences of running inside Crossplane rather than beside it:
+
+  * the Vault auth mount and the ClusterSecretStore no longer have to be passed
+    in. The charts take `authMountPath` with the comment "appset injects
+    <cluster>-eso per cluster"; here the cluster name IS the XR's, so the same
+    derivation happens where the fact lives.
+  * package installation stays out. The charts can install the Configuration and
+    the Provider, which is what their long comments about duplicate lock nodes
+    are about; that job belongs to the management-plane Configuration, which
+    uses the CR names Crossplane itself derives.
+
+What it does NOT do is the sops and sops-git credential backends. Those exist so
+a cluster without Vault can still have credentials, and a cluster without Vault
+cannot use this module at all — it would emit an ExternalSecret nothing serves.
+For those clusters the charts remain the answer.
+"""
+
+import xplane_capability_catalog.main as cat
+import xplane_capability_catalog.schema as capschema
+import .logic
+
+_params = option("params") or {}
+_oxr = _params?.oxr or {}
+_ocds = _params?.ocds or {}
+
+_spec = _oxr?.spec or {}
+_meta = _oxr?.metadata or {}
+
+_clusterName = _spec?.clusterName
+_k8sPcr = _spec?.kubernetesProviderConfigRef
+
+# Where the credential Secret and the ExternalSecret land ON THE TARGET. The
+# provider reads its Secret from here, so it is not the XR's own namespace.
+_ns = _spec?.namespace or "crossplane-system"
+_environment = _spec?.environment or _clusterName
+
+# The ClusterSecretStore to read from. Derived rather than required: the
+# platform Configuration creates it as `vault-cluster-secrets` through the
+# external-secrets app, and a cluster that has a store under another name says
+# so once here instead of once per capability.
+_storeName = _spec?.secretStoreName or "vault-cluster-secrets"
+
+# Where the capability's WORKLOAD secrets go — the namespace the VM XRs live in
+# on the target cluster, which is not where the provider reads its credentials.
+# The namespaced EnvironmentVM CRD resolves passwordSecretRef in the managed
+# resource's own namespace, so a cloud-init password next to the provider is a
+# Secret nothing reads.
+_workloadNs = _spec?.workloadNamespace or "default"
+_refreshInterval = _spec?.refreshInterval or "1h"
+
+_capsIn = _spec?.capabilities or {}
+_enabled = sorted([n for n in _capsIn if (_capsIn[n]?.enabled or False)])
+
+# --- naming -----------------------------------------------------------------
+# Every emitted object carries the environment label, because two environments
+# on one cluster (labda AND labul) must not collide on a shared
+# ClusterProviderConfig or credentials Secret. The charts solved this the same
+# way; the difference is that the label defaults to the cluster name here rather
+# than having to be set.
+_objName = lambda capName: str -> str {
+    capName + "-" + _environment
+}
+
+# `<capability>-creds-<env>` — NOT the charts' `proxmox-creds-<env>`. The
+# difference is deliberate: on a cluster that still has the chart installed,
+# colliding on the Secret name would give two owners to one object, and the ESO
+# refresh of whichever lost would keep overwriting the other. Nothing else
+# refers to this name — only the ClusterProviderConfig two functions down, which
+# this module also emits — so a migration means deleting the chart's Secret, not
+# renaming anything.
+_credsSecretName = lambda capName: str -> str {
+    capName + "-creds-" + _environment
+}
+
+# --- per-capability rendering ----------------------------------------------
+_capSpec = lambda capName: str -> {str:} {
+    _capsIn[capName] or {}
+}
+
+# Placement: catalog defaults, overridden by the XR. Only keys the catalog knows
+# are emitted — see _unknownFields, which turns the rest into a hard error
+# rather than a value that vanishes.
+_given = lambda capName: str -> {str:} {
+    _capSpec(capName)?.placement or {}
+}
+_placement = lambda capName: str -> {str:str} {
+    logic.placement(capName, _given(capName))
+}
+
+# Fail the whole render rather than emit a half-configured capability. A missing
+# node or templateVmId does not surface as a validation error later — it
+# surfaces as a VM the provider tries to place nowhere, minutes later, in a
+# message that names the provider and not this XR.
+_valid = logic.validate(_spec, _enabled, {n: _given(n) for n in _enabled})
+
+# --- object wrapper ---------------------------------------------------------
+# One provider-kubernetes Object per manifest, exactly as flux-apps does it.
+# managementPolicies stay at the default (full control): unlike a namespace,
+# these objects have no pre-existing owner to adopt — and a ClusterProviderConfig
+# left behind after its Secret is gone is worse than none, because a VM XR then
+# references a config that cannot authenticate.
+_object = lambda resName: str, manifest: {str:} -> {str:} {
+    {
+        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+        kind = "Object"
+        metadata = {
+            name = resName
+            namespace = _meta?.namespace or "default"
+            annotations = {"krm.kcl.dev/composition-resource-name" = resName}
+        }
+        spec = {
+            providerConfigRef = {
+                name = _k8sPcr
+                kind = "ClusterProviderConfig"
+            }
+            forProvider = {manifest = manifest}
+            readiness = {policy = "DeriveFromObject"}
+        }
+    }
+}
+
+_externalSecret = lambda capName: str -> {str:} {
+    _c = cat.get(capName)
+    _v = _capSpec(capName)?.vault or {}
+    _resName = capName + "-credentials"
+    _object(_resName, {
+        apiVersion = "external-secrets.io/v1"
+        kind = "ExternalSecret"
+        metadata = {
+            name = _credsSecretName(capName)
+            namespace = _ns
+        }
+        spec = {
+            refreshInterval = _refreshInterval
+            secretStoreRef = {
+                kind = "ClusterSecretStore"
+                name = _v?.secretStoreName or _storeName
+            }
+            target = {
+                name = _credsSecretName(capName)
+                creationPolicy = "Owner"
+                # Retain matches the ESO default. Spelling it out keeps a
+                # GitOps differ from reporting a permanent diff against a field
+                # it did not set.
+                deletionPolicy = "Retain"
+                template = {
+                    engineVersion = "v2"
+                    mergePolicy = "Replace"
+                    data = _c.credentials.data
+                }
+            }
+            dataFrom = [{
+                extract = {
+                    key = _v?.secret or "default"
+                    conversionStrategy = "Default"
+                    decodingStrategy = "None"
+                    metadataPolicy = "None"
+                    nullBytePolicy = "Ignore"
+                }
+            }]
+        }
+    })
+}
+
+# One ExternalSecret per declared workload secret. Shares the capability's Vault
+# secret — a second `extract` of the same KV entry, not a second credential.
+_workloadSecret = lambda capName: str, w: capschema.WorkloadSecret, idx: int -> {str:} {
+    _v = _capSpec(capName)?.vault or {}
+    _secretName = capName + "-" + w.nameSuffix
+    _resName = capName + "-" + w.nameSuffix + "-secret"
+    _object(_resName, {
+        apiVersion = "external-secrets.io/v1"
+        kind = "ExternalSecret"
+        metadata = {
+            name = _secretName
+            namespace = _workloadNs
+        }
+        spec = {
+            refreshInterval = _refreshInterval
+            secretStoreRef = {
+                kind = "ClusterSecretStore"
+                name = _v?.secretStoreName or _storeName
+            }
+            target = {
+                name = _secretName
+                creationPolicy = "Owner"
+                deletionPolicy = "Retain"
+                template = {
+                    engineVersion = "v2"
+                    mergePolicy = "Replace"
+                    data = w.data
+                }
+            }
+            dataFrom = [{
+                extract = {
+                    key = _v?.secret or "default"
+                    conversionStrategy = "Default"
+                    decodingStrategy = "None"
+                    metadataPolicy = "None"
+                    nullBytePolicy = "Ignore"
+                }
+            }]
+        }
+    })
+}
+
+_workloadSecretNames = lambda capName: str -> {str:str} {
+    {"ciPasswordSecretName": capName + "-" + w.nameSuffix for w in cat.get(capName).workloadSecrets if w.nameSuffix == "ci-password"}
+}
+
+_providerConfig = lambda capName: str -> {str:} {
+    _c = cat.get(capName)
+    _pc = _c.providerConfig
+    _resName = capName + "-provider-config"
+    _object(_resName, {
+        apiVersion = _pc.apiVersion
+        kind = _pc.kind
+        metadata = {name = _objName(capName)}
+        spec = {
+            credentials = {
+                source = "Secret"
+                secretRef = {
+                    name = _credsSecretName(capName)
+                    namespace = _ns
+                    key = _pc.credentialsKey
+                }
+            }
+        }
+    })
+}
+
+_environmentConfig = lambda capName: str -> {str:} {
+    _c = cat.get(capName)
+    _resName = capName + "-environment-config"
+
+    # providerConfigName/-Kind are DERIVED, never taken from the XR: they name
+    # the object rendered two functions up, and letting an XR state them makes
+    # it possible to point a VM at a config this XR did not create.
+    _derived = ({
+        providerConfigName = _objName(capName)
+        providerConfigKind = _c.providerConfig.kind
+    } if _c?.providerConfig else {}) | _workloadSecretNames(capName)
+    _object(_resName, {
+        apiVersion = "apiextensions.crossplane.io/v1beta1"
+        kind = "EnvironmentConfig"
+        metadata = {
+            name = _objName(capName)
+            labels = {(_c.environmentLabelKey) = _environment}
+        }
+        data = _placement(capName) | _derived
+    })
+}
+
+_capObjects = lambda capName: str -> [{str:}] {
+    _c = cat.get(capName)
+    [_externalSecret(capName), _environmentConfig(capName)] + ([_providerConfig(capName)] if _c?.providerConfig else []) + [_workloadSecret(capName, _c.workloadSecrets[i], i) for i in range(len(_c.workloadSecrets))]
+}
+
+_objects = sum([_capObjects(n) for n in _enabled], [])
+
+# --- status -----------------------------------------------------------------
+_isReady = lambda resName: str -> bool {
+    _found = resName in _ocds
+    _conds = _ocds[resName]?.Resource?.status?.conditions or [] if _found else []
+    len([c for c in _conds if c.type == "Ready" and c.status == "True"]) > 0
+}
+
+_capReady = lambda capName: str -> bool {
+    _names = [o.metadata.name for o in _capObjects(capName)]
+    len([n for n in _names if _isReady(n)]) == len(_names)
+}
+
+_readyCaps = [n for n in _enabled if _capReady(n)]
+_allReady = len(_readyCaps) == len(_enabled) if _enabled else True
+
+_xrStatus = _oxr | {
+    status = {
+        ready = _allReady
+        capabilityCount = len(_enabled)
+        readyCount = len(_readyCaps)
+        capabilities = {n: {
+            ready = _capReady(n)
+            environmentConfig = _objName(n)
+            credentialsSecret = _credsSecretName(n)
+            **({providerConfig = _objName(n)} if cat.get(n)?.providerConfig else {})
+        } for n in _enabled}
+    }
+}
+
+items = _objects + [_xrStatus]

--- a/crossplane/xplane-capability/test-settings.yaml
+++ b/crossplane/xplane-capability/test-settings.yaml
@@ -1,0 +1,27 @@
+kcl_options:
+  - key: params
+    value:
+      oxr:
+        apiVersion: config.stuttgart-things.com/v1alpha1
+        kind: Capability
+        metadata:
+          name: u26-rke2-1-capability
+          namespace: default
+        spec:
+          clusterName: u26-rke2-1
+          kubernetesProviderConfigRef: u26-rke2-1-kubernetes
+          environment: labul
+          capabilities:
+            proxmoxvm:
+              enabled: true
+              vault:
+                secret: default
+              placement:
+                node: ul-pve01
+                datastore: V5010-01-1
+                bridge: vmbrvlan
+                vlanTag: "102"
+                pool: stuttgart-things
+                templateVmId: "211"
+      ocds: {}
+      ctx: {}


### PR DESCRIPTION
Second half of the native capability layer (kcl#167 was the catalog) — points 2–4 of stuttgart-things/crossplane-configurations#258.

Emits per enabled capability, through `provider-kubernetes` onto a target cluster:

| object | why |
|---|---|
| `ExternalSecret` (credentials) | the provider may log in |
| `ClusterProviderConfig` | it knows where to connect |
| `EnvironmentConfig` | it knows which node, datastore, template |
| `ExternalSecret` (workload) | only where the capability declares one |

**Why native.** The charts take `authMountPath: test-k3s-eso` with their own comment saying an appset injects `<cluster>-eso` per cluster. Here the cluster name is the XR's, so that derivation happens where the fact lives. And package installation stays out — `management-plane` already does it under the CR names Crossplane derives, the shape in which the #247 collision cannot occur.

**Two namespaces.** `namespace` is where the provider reads its Secret; `workloadNamespace` is where the VM XRs live. The cloud-init password must be in the latter because the namespaced `EnvironmentVM` CRD resolves `passwordSecretRef` in the managed resource's own namespace. Wrong place → cloud-init locks the guest account and every password-based `AnsibleRun` is `UNREACHABLE`, while the cluster looks healthy.

**Failing loudly, once.** A missing or unknown placement field aborts the render and names every problem across every capability in one message. A missing `node` otherwise surfaces minutes later as a VM placed nowhere; a typo'd `templateVMID` would be dropped in silence and yield an error naming the field the user did not write.

Decisions live in `logic.k` and are unit-tested; `validate` is a lambda rather than a module-level assert, which would fire during `kcl test` where every field is legitimately absent. `kcl test`: 8/8.

Still to come: the Configuration (XRD + Composition + examples) in crossplane-configurations, then a live test on `u26-rke2-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL