### PR TITLE
fix(vault-auth-base): grant the secret, not only what is below it (0.11.0)

### DIFF
--- a/crossplane/xplane-vault-auth-base/kcl.mod
+++ b/crossplane/xplane-vault-auth-base/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth-base"
 edition = "v0.11.0"
-version = "0.10.0"
+version = "0.11.0"
 description = "KCL library for creating Vault Kubernetes authentication backends as Crossplane v2 namespaced OpenTofu Workspaces"
 
 [dependencies]

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -299,8 +299,19 @@ _policyBody = lambda clusterName: str, policy: VaultPolicy -> str {
     _subtree = lambda scope: str -> str {
         clusterName if scope == "own" else scope
     }
+
+    # FOUR paths per subtree, not two. Vault matches a policy path exactly
+    # unless it ends in a glob, and `x/data/default/*` does NOT match
+    # `x/data/default` — so a secret that IS the subtree (the cicd mounts put
+    # theirs directly under the mount, at cicd-proxmox-labul/data/default) was
+    # denied by a policy that appeared to grant it. Measured on u26-rke2-1:
+    # external-secrets logged 403 on exactly that path while the
+    # ClusterSecretStore reported Valid, so the login worked and only the read
+    # failed.
     "\n".join(sum([[
+        'path "' + policy.kvMount + '/data/' + _subtree(s) + '" { capabilities = ["read"] }'
         'path "' + policy.kvMount + '/data/' + _subtree(s) + '/*" { capabilities = ["read"] }'
+        'path "' + policy.kvMount + '/metadata/' + _subtree(s) + '" { capabilities = ["read", "list"] }'
         'path "' + policy.kvMount + '/metadata/' + _subtree(s) + '/*" { capabilities = ["read", "list"] }'
     ] for s in policy.read], [])) + "\n"
 }

--- a/crossplane/xplane-vault-auth-base/policy_test.k
+++ b/crossplane/xplane-vault-auth-base/policy_test.k
@@ -66,7 +66,7 @@ test_several_policies_per_auth = lambda {
 test_policy_bodies_survive_encoding = lambda {
     _v = json.decode(_vars(m.vaultK8sAuth(_cfg([_auth("eso", [_own])]))[0])["policies"])
     assert "\n" in _v["kv-own"], "a multi-line body must come back multi-line"
-    assert _v["kv-own"].count("path \"") == 2, "data and metadata, per subtree"
+    assert _v["kv-own"].count("path \"") == 4, "data and metadata, each as the subtree itself and as a glob below it"
 }
 
 # --- the body is BUILT, not accepted (crossplane-configurations#285) ---------
@@ -107,7 +107,7 @@ test_nothing_escapes_the_kv_mount = lambda {
         l == "" or l.startswith('path "clusters/data/') or l.startswith('path "clusters/metadata/')
     }, "every path is anchored at the declared KV mount"
     assert "sudo" not in _v and "create" not in _v and "delete" not in _v and "update" not in _v
-    assert _v.count("path \"") == 6, "three subtrees, data and metadata each"
+    assert _v.count("path \"") == 12, "three subtrees x data/metadata x subtree-itself/below-it"
 }
 
 # A subtree name is a plain name. A slash, a glob or a traversal would each let
@@ -147,4 +147,24 @@ test_policy_name_is_derived = lambda {
 test_token_policies_are_not_rewritten = lambda {
     _v = _vars(m.vaultK8sAuth(_cfg([_auth("eso", [_own])]))[0])
     assert _v["token_policies"] == "[\"read-secrets\"]"
+}
+
+# Vault matches a policy path EXACTLY unless it ends in a glob, so
+# `x/data/default/*` does not match `x/data/default`. That is not a corner case:
+# the cicd mounts put their secret directly under the mount
+# (cicd-proxmox-labul/data/default), so a policy that looked like it granted
+# read denied it. Measured on u26-rke2-1 — external-secrets logged 403 on that
+# exact path while the ClusterSecretStore reported Valid, i.e. the login worked
+# and only the read failed.
+test_a_leaf_secret_is_granted_not_only_its_children = lambda {
+    _leaf = m.VaultPolicy {
+        name = "read-proxmox"
+        kvMount = "cicd-proxmox-labul"
+        read = ["default"]
+    }
+    _v = json.decode(_vars(m.vaultK8sAuth(_cfg([_auth("eso", [_leaf])]))[0])["policies"])
+    _b = _v["read-proxmox"]
+    assert 'path "cicd-proxmox-labul/data/default" { capabilities = ["read"] }' in _b, "the secret itself"
+    assert 'path "cicd-proxmox-labul/data/default/*" { capabilities = ["read"] }' in _b, "and anything below it"
+    assert 'path "cicd-proxmox-labul/metadata/default" { capabilities = ["read", "list"] }' in _b
 }


### PR DESCRIPTION
Found while live-testing the new capability Configuration on `u26-rke2-1`.

Vault matches a policy path **exactly** unless it ends in a glob, and `x/data/default/*` does not match `x/data/default`. The body builder emitted only the glob, so a policy that reads as a grant on a subtree denies the secret **at** that subtree.

Not a corner case: the cicd mounts put their secret directly under the mount — `cicd-proxmox-labul/data/default` — which is what every capability's credentials use.

Measured, not reasoned: external-secrets logged

```
GET https://vault.infra.sthings-vsphere.labul.sva.de/v1/cicd-proxmox-labul/data/default
Code: 403 ... permission denied
```

while the `ClusterSecretStore` reported `Valid`. That combination is what makes it hard to see — the login worked, so the store looks healthy and only the read fails.

Four paths per subtree now: data and metadata, each as the subtree itself and as a glob below it. The security property is unchanged — every path still anchored at the declared mount, no capability beyond read/list — and `test_nothing_escapes_the_kv_mount` still asserts it, with the count updated from 6 to 12.

`kcl test`: 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL