### PR TITLE
fix(vault-auth): the policy that grants the secret itself (0.8.0)

### DIFF
--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
-xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.10.0" }
+xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.11.0" }

--- a/crossplane/xplane-vault-auth/kcl.mod.lock
+++ b/crossplane/xplane-vault-auth/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-vault-auth-base]
     name = "xplane-vault-auth-base"
-    full_name = "xplane-vault-auth-base_0.10.0"
-    version = "0.10.0"
+    full_name = "xplane-vault-auth-base_0.11.0"
+    version = "0.11.0"
     sum = "0T+h2exi34BfdJcSYAKTr5DM6GCjqSP2FEHQ6n6FNRo="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-vault-auth-base"
-    oci_tag = "0.10.0"
+    oci_tag = "0.11.0"


### PR DESCRIPTION
Pin `xplane-vault-auth-base` 0.10.0 → 0.11.0 (kcl#171): the policy body granted `{mount}/data/{subtree}/*` but not `{mount}/data/{subtree}`, and every capability credential lives at exactly that leaf path (`cicd-proxmox-labul/data/default`).

`kcl test`: 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL