### PR TITLE
fix(capability): write the status field the XRD declares (0.3.1)

### DIFF
--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-capability"
 edition = "v0.12.3"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.1.0" }

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -120,3 +120,16 @@ test_secret_objects_derive_readiness_from_themselves = lambda {
     _wrong = [k for k in ["ExternalSecret", "ClusterSecretStore"] if logic.readinessFor(k).policy != "DeriveFromObject"]
     assert _wrong == [], "these carry the only evidence that Vault answered: " + str(_wrong)
 }
+
+# The XRD declares status.capabilities.<n>.secretStore, and for one release the
+# module did not write it — an edit lost to a reformat. #283 is the same drift
+# in the other direction (module writes, XRD does not declare), where every
+# compose fails; this direction breaks nothing and is therefore worse to spot:
+# the field is documented and simply never appears. Both need the two sides
+# named in one place.
+statusFields = ["ready", "environmentConfig", "credentialsSecret", "secretStore", "providerConfig"]
+
+test_status_fields_are_the_ones_the_xrd_declares = lambda {
+    _want = ["credentialsSecret", "environmentConfig", "providerConfig", "ready", "secretStore"]
+    assert sorted(statusFields) == _want, "keep this in step with the XRD in crossplane-configurations/bootstrap/capability"
+}

--- a/crossplane/xplane-capability/main.k
+++ b/crossplane/xplane-capability/main.k
@@ -387,6 +387,7 @@ _xrStatus = _oxr | {
             ready = _capReady(n)
             environmentConfig = _objName(n)
             credentialsSecret = _credsSecretName(n)
+            secretStore = _storeNameFor(n)
             **({providerConfig = _objName(n)} if cat.get(n)?.providerConfig else {})
         } for n in _enabled}
     }


### PR DESCRIPTION
Found while reading the live XR on `u26-rke2-1`: the XRD declares `status.capabilities.<n>.secretStore`, the module never wrote it. The edit was lost to a reformat in 0.2.0 and nothing complained.

This is #283's drift in the **other** direction. There the module writes a field the XRD does not declare and every compose fails — loud, and now caught by CI. Here nothing breaks: the field is documented and simply never appears, so the only way to notice is to go looking for it.

Worth having rather than dropping from the XRD: the store name is derived, so it is otherwise invisible to anyone reading the XR.

`kcl test`: 14/14, including one that names the status fields in one place so the two sides can be compared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL