### PR TITLE
feat(capability-catalog): ansible, and the schema change it forced (0.2.0)

### DIFF
--- a/crossplane/xplane-capability-catalog/README.md
+++ b/crossplane/xplane-capability-catalog/README.md
@@ -35,8 +35,22 @@ sthings-u26 image and the bpg provider — not of LabUL.
 
 | capability | provider config | Vault keys | required placement |
 |---|---|---|---|
+| `ansible` | **none** | `vm_ssh_user`, `vm_ssh_password` | `namespace`, `storageClass` |
 | `proxmoxvm` | `proxmoxbpg.m.crossplane.io/v1beta1` | `pve_api_url`, `pve_api_user`, `pve_api_password`, `vm_ssh_user`, `vm_ssh_password` | `node`, `datastore`, `bridge`, `vlanTag`, `pool`, `templateVmId` |
 | `vspherevm` | `vspherevm.m.stuttgart-things.com/v1beta1` | `vsphere_user`, `vsphere_password`, `vsphere_server` | `templateUuid`, `datastoreId`, `resourcePoolId`, `networkId`, `folder`, `domain` |
+
+`ansible` is the entry that made the schema earn its keep, and it differs from
+the other two in all three ways a capability can:
+
+* **no provider config** — it configures a Configuration, not a provider.
+  `providerConfig?` was optional from the first version for exactly this.
+* **two plain credential keys** instead of one JSON document, because the
+  consumer is a Tekton pipeline reading environment variables.
+* **a list-valued default.** `ansibleExtraCollections` reaches Tekton as a
+  parameter, and a stringified list is rejected there with
+  `ParameterTypeMismatch` — an error that names the Tekton parameter and
+  nothing about where the value came from. So `defaults` is `{str:any}`, and a
+  consumer must not coerce.
 
 Both were transcribed from the capability Helm charts in
 `stuttgart-things/stuttgart-things` (`crossplane/platform/capabilities/`), which

--- a/crossplane/xplane-capability-catalog/capabilities/ansible.k
+++ b/crossplane/xplane-capability-catalog/capabilities/ansible.k
@@ -1,0 +1,63 @@
+import ..schema as s
+
+# ansible — the AnsibleRun Configuration, not a provider.
+#
+# The entry that shows what the schema had to accommodate, and the reason it is
+# worth having a schema at all rather than three near-identical charts:
+#
+#   * NO providerConfig. Nothing here configures a provider; AnsibleRun renders
+#     a Tekton PipelineRun. `providerConfig?` was optional from the start for
+#     exactly this case.
+#   * TWO credential keys rather than one JSON document, because the consumer is
+#     a pipeline reading environment variables, not a Terraform provider parsing
+#     a credentials blob.
+#   * A LIST value. `ansibleExtraCollections` reaches Tekton as a parameter, and
+#     a stringified list is rejected there with ParameterTypeMismatch — an error
+#     naming the Tekton parameter and nothing about where the value came from.
+#
+# Values are transcribed from the ansible capability chart and from the
+# ansible-run-defaults EnvironmentConfig that builds this fleet's VMs today.
+ansible: s.Capability = {
+    name = "ansible"
+    credentials = s.Credentials {
+        # Plain keys: the pipeline reads them as environment variables.
+        data = {
+            ANSIBLE_USER = "{{ .vm_ssh_user }}"
+            ANSIBLE_PASSWORD = "{{ .vm_ssh_password }}"
+        }
+        vaultKeys = ["vm_ssh_user", "vm_ssh_password"]
+    }
+    environmentLabelKey = "ansible.resources.stuttgart-things.com/environment"
+    # The pipeline definition and where it runs. Facts about THIS cluster —
+    # which namespace has the Tekton pipeline SA, which StorageClass exists —
+    # so they are required rather than defaulted: a wrong storageClass leaves
+    # the PipelineRun Pending on an unbound PVC, which reads like a stuck
+    # pipeline rather than a missing class.
+    required = ["namespace", "storageClass"]
+    defaults = {
+        gitRepoUrl = "https://github.com/stuttgart-things/stage-time.git"
+        gitRevision = "main"
+        gitPath = "pipelines/execute-ansible-playbooks.yaml"
+        ansibleWorkingImage = "ghcr.io/stuttgart-things/sthings-ansible:14.0.0"
+        ansibleCredentialsSecretName = "ansible-credentials"
+        # A LIST, deliberately — see the header. Pinned versions rather than
+        # floating ones: a collection that moves under a running fleet changes
+        # what every VM build does, without a single file changing here.
+        ansibleExtraCollections = [
+            "community.crypto:3.2.1"
+            "community.general:13.0.1"
+            "ansible.posix:2.2.0"
+            "kubernetes.core:6.4.0"
+            "community.docker:5.2.1"
+            "community.vmware:6.2.0"
+            "awx.awx:24.6.1"
+            "community.hashi_vault:7.1.0"
+            "ansible.netcommon:8.5.2"
+            "https://github.com/stuttgart-things/ansible/releases/download/sthings-baseos-26.730.1176/sthings-baseos-26.730.1176.tar.gz"
+            "https://github.com/stuttgart-things/ansible/releases/download/sthings-awx-26.729.1166/sthings-awx-26.729.1166.tar.gz"
+            "https://github.com/stuttgart-things/ansible/releases/download/sthings-rke-26.730.1176/sthings-rke-26.730.1176.tar.gz"
+            "https://github.com/stuttgart-things/ansible/releases/download/sthings-container-26.730.1176/sthings-container-26.730.1176.tar.gz"
+        ]
+    }
+    optional = []
+}

--- a/crossplane/xplane-capability-catalog/catalog_test.k
+++ b/crossplane/xplane-capability-catalog/catalog_test.k
@@ -6,7 +6,7 @@ test_every_entry_is_registered_under_its_own_name = lambda {
 }
 
 test_get_rejects_an_unknown_name = lambda {
-    assert len(c.names) == 2
+    assert len(c.names) == 3
     assert "proxmoxvm" in c.names
 }
 
@@ -72,4 +72,33 @@ test_workload_secrets_are_referenced_from_placement = lambda {
 test_workload_secret_vault_keys_match_their_templates = lambda {
     _undeclared = [n + ":" + k for n in c.names for w in c.get(n).workloadSecrets for k in w.vaultKeys if not any_true([("{{ ." + k + " }}") in w.data[dk] for dk in w.data])]
     assert _undeclared == [], "declared but never referenced: " + str(_undeclared)
+}
+
+# The entry that made the schema earn its keep. `ansibleExtraCollections` reaches
+# Tekton as a parameter, and a stringified list is rejected there with
+# ParameterTypeMismatch — an error naming the Tekton parameter and nothing about
+# where the value came from. So placement values are not all strings, and the
+# renderer must not coerce them.
+test_list_valued_defaults_stay_lists = lambda {
+    _v = c.get("ansible").defaults["ansibleExtraCollections"]
+    assert typeof(_v) == "list", "a stringified list is a ParameterTypeMismatch in Tekton"
+    assert len(_v) > 0
+}
+
+# ansible configures a Configuration, not a provider — so it has no
+# ClusterProviderConfig, and the renderer must emit none rather than an empty
+# one. providerConfig was optional from the first version for this case.
+test_ansible_has_no_provider_config = lambda {
+    assert not c.get("ansible")?.providerConfig
+    assert c.get("proxmoxvm")?.providerConfig, "while a provider capability does"
+}
+
+# Two plain keys, because the consumer is a pipeline reading environment
+# variables — not a Terraform provider parsing one credentials document. The
+# single-key rule is asserted only for capabilities WITH a provider config, and
+# this is the entry that would break a rule stated too broadly.
+test_pipeline_credentials_are_plain_keys = lambda {
+    _d = c.get("ansible").credentials.data
+    assert len(_d) == 2
+    assert "ANSIBLE_USER" in _d and "ANSIBLE_PASSWORD" in _d
 }

--- a/crossplane/xplane-capability-catalog/kcl.mod
+++ b/crossplane/xplane-capability-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-capability-catalog"
 edition = "v0.12.3"
-version = "0.1.0"
+version = "0.2.0"

--- a/crossplane/xplane-capability-catalog/main.k
+++ b/crossplane/xplane-capability-catalog/main.k
@@ -7,10 +7,12 @@ not.
 """
 
 import .schema as s
+import .capabilities.ansible as ansible
 import .capabilities.proxmoxvm as proxmoxvm
 import .capabilities.vspherevm as vspherevm
 
 catalog: {str:s.Capability} = {
+    ansible = ansible.ansible
     proxmoxvm = proxmoxvm.proxmoxvm
     vspherevm = vspherevm.vspherevm
 }

--- a/crossplane/xplane-capability-catalog/schema.k
+++ b/crossplane/xplane-capability-catalog/schema.k
@@ -99,12 +99,17 @@ schema Capability:
     """Placement fields the XR MUST supply. Facts about a datacenter that
     nothing can derive: which node, which datastore, which template."""
 
-    defaults: {str:str} = {}
+    defaults: {str:any} = {}
     """Placement fields with a fleet-wide default. An XR value always wins.
     These are here rather than on the XR because they are properties of the
     IMAGE and the provider, not of the environment: sthings-u26 puts its root
     disk on virtio0, and getting that wrong produces a VM that boots to no
-    disk."""
+    disk.
+
+    Values are NOT all strings. `ansible.ansibleExtraCollections` is a list, and
+    it has to stay one: the consuming Composition hands it to Tekton, which
+    rejects a stringified list with ParameterTypeMismatch — an error that names
+    the Tekton parameter and nothing about where the value came from."""
 
     workloadSecrets: [WorkloadSecret] = []
     """Secrets that belong in the workload namespace rather than beside the


### PR DESCRIPTION
A VM built through the capability layer stops at `ansibleReady: false` — the cluster can build VMs but not provision them. This is the missing entry.

It is also the one that shows whether the schema generalizes, because it differs from `proxmoxvm` and `vspherevm` in **all three** ways a capability can:

* **no provider config** — it configures a Configuration, not a provider. `providerConfig?` was optional from the first version for exactly this.
* **two plain credential keys** instead of one JSON document, because the consumer is a Tekton pipeline reading environment variables. This is why the single-credentials-key rule is asserted only for capabilities that *have* a provider config.
* **a list-valued default** — and this one forced a schema change. `ansibleExtraCollections` reaches Tekton as a parameter, and a stringified list is rejected with `ParameterTypeMismatch`, an error naming the Tekton parameter and nothing about where the value came from. So `defaults` is now `{str:any}` and a consumer must not coerce.

Values transcribed from the ansible capability chart and from the `ansible-run-defaults` EnvironmentConfig that builds this fleet's VMs today. `namespace` and `storageClass` are required rather than defaulted: a wrong storageClass leaves the PipelineRun Pending on an unbound PVC, which reads like a stuck pipeline rather than a missing class.

`kcl test`: 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL