### PR TITLE
feat(capability-catalog): credentials that live somewhere else (0.3.0)

### DIFF
--- a/crossplane/xplane-capability-catalog/README.md
+++ b/crossplane/xplane-capability-catalog/README.md
@@ -51,6 +51,13 @@ the other two in all three ways a capability can:
   `ParameterTypeMismatch` — an error that names the Tekton parameter and
   nothing about where the value came from. So `defaults` is `{str:any}`, and a
   consumer must not coerce.
+* **credentials that live somewhere else.** A Tekton pipeline reads its Secret
+  by NAME, in its OWN namespace. So the entry declares
+  `credentialsNameField` and `credentialsNamespaceField` and the renderer
+  fills both in — a catalog default for either would be a second source of a
+  derived value, and both failures are silent: an EnvironmentConfig naming a
+  Secret that does not exist reports a missing credential rather than a wrong
+  name, and a Secret beside the provider is simply never read.
 
 Both were transcribed from the capability Helm charts in
 `stuttgart-things/stuttgart-things` (`crossplane/platform/capabilities/`), which

--- a/crossplane/xplane-capability-catalog/capabilities/ansible.k
+++ b/crossplane/xplane-capability-catalog/capabilities/ansible.k
@@ -27,6 +27,11 @@ ansible: s.Capability = {
         }
         vaultKeys = ["vm_ssh_user", "vm_ssh_password"]
     }
+    # Both derived, not defaulted. The pipeline looks the Secret up by name and
+    # reads it in ITS OWN namespace, so a catalog default for either would be a
+    # second source that silently diverges from what is actually created.
+    credentialsNameField = "ansibleCredentialsSecretName"
+    credentialsNamespaceField = "namespace"
     environmentLabelKey = "ansible.resources.stuttgart-things.com/environment"
     # The pipeline definition and where it runs. Facts about THIS cluster —
     # which namespace has the Tekton pipeline SA, which StorageClass exists —
@@ -39,7 +44,6 @@ ansible: s.Capability = {
         gitRevision = "main"
         gitPath = "pipelines/execute-ansible-playbooks.yaml"
         ansibleWorkingImage = "ghcr.io/stuttgart-things/sthings-ansible:14.0.0"
-        ansibleCredentialsSecretName = "ansible-credentials"
         # A LIST, deliberately — see the header. Pinned versions rather than
         # floating ones: a collection that moves under a running fleet changes
         # what every VM build does, without a single file changing here.

--- a/crossplane/xplane-capability-catalog/catalog_test.k
+++ b/crossplane/xplane-capability-catalog/catalog_test.k
@@ -102,3 +102,21 @@ test_pipeline_credentials_are_plain_keys = lambda {
     assert len(_d) == 2
     assert "ANSIBLE_USER" in _d and "ANSIBLE_PASSWORD" in _d
 }
+
+# The name and the namespace of a credentials Secret are DERIVED, and both are
+# silent when wrong: an EnvironmentConfig naming a Secret that does not exist
+# makes the consumer report a missing credential rather than a wrong name, and
+# a Secret beside the provider is simply never read by a pipeline running
+# elsewhere.
+test_derived_credential_fields_are_not_also_defaulted = lambda {
+    _bad = [n for n in c.names if c.get(n)?.credentialsNameField and c.get(n).credentialsNameField in c.get(n).defaults]
+    assert _bad == [], "a derived field must not have a default that diverges from it: " + str(_bad)
+}
+
+# ansible's credentials are read by a Tekton pipeline in the pipeline's own
+# namespace — the same trap as a cloud-init password beside the provider.
+test_ansible_credentials_live_where_the_pipeline_runs = lambda {
+    _a = c.get("ansible")
+    assert _a.credentialsNamespaceField == "namespace"
+    assert _a.credentialsNamespaceField in _a.required, "and that namespace must be stated, not guessed"
+}

--- a/crossplane/xplane-capability-catalog/kcl.mod
+++ b/crossplane/xplane-capability-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-capability-catalog"
 edition = "v0.12.3"
-version = "0.2.0"
+version = "0.3.0"

--- a/crossplane/xplane-capability-catalog/main.k
+++ b/crossplane/xplane-capability-catalog/main.k
@@ -30,5 +30,10 @@ get = lambda name: str -> s.Capability {
 # the user never wrote.
 fields = lambda name: str -> [str] {
     _c = get(name)
-    _c.required + sorted([k for k in _c.defaults]) + _c.optional
+
+    # Derived fields count as known: an XR may not set them (the consumer
+    # rejects unknown keys, and these are filled in by the renderer), but they
+    # must not be rejected as typos either.
+    _derived = [f for f in [_c?.credentialsNameField] if f]
+    _c.required + sorted([k for k in _c.defaults]) + _c.optional + [f for f in _derived if f not in _c.required and f not in _c.defaults and f not in _c.optional]
 }

--- a/crossplane/xplane-capability-catalog/schema.k
+++ b/crossplane/xplane-capability-catalog/schema.k
@@ -111,6 +111,23 @@ schema Capability:
     rejects a stringified list with ParameterTypeMismatch — an error that names
     the Tekton parameter and nothing about where the value came from."""
 
+    credentialsNameField?: str
+    """Placement key that must carry the NAME of the credentials Secret.
+
+    Set it whenever the consumer looks the Secret up by a field rather than
+    receiving it directly. The name is derived per environment, so a catalog
+    default would be a second, diverging source of it — and the failure is
+    silent: the EnvironmentConfig names a Secret that does not exist, and the
+    consumer reports a missing credential rather than a wrong name."""
+
+    credentialsNamespaceField?: str
+    """Placement key naming the NAMESPACE the credentials Secret must live in.
+
+    Unset means beside the provider (the XR's spec.namespace). ansible sets it,
+    because its 'credentials' are read by a Tekton pipeline in the pipeline's
+    own namespace — a Secret next to the provider would be one nothing reads,
+    which is the same trap as a cloud-init password in the wrong namespace."""
+
     workloadSecrets: [WorkloadSecret] = []
     """Secrets that belong in the workload namespace rather than beside the
     provider. See WorkloadSecret."""


### PR DESCRIPTION
Found by rendering the ansible entry rather than reading it. Two mismatches, both of the kind that produce a Secret nobody reads.

**The name.** The EnvironmentConfig announced `ansibleCredentialsSecretName: ansible-credentials` while the renderer creates `<capability>-creds-<environment>`. The name is derived per environment, so a catalog default is a second source that diverges silently — the consumer then reports a *missing* credential rather than a wrong name.

**The namespace.** The Secret landed beside the provider in `crossplane-system`, while the Tekton pipeline reads it in its own namespace. Same trap as a cloud-init password in the wrong namespace, which this catalog already had a field for.

An entry can now declare `credentialsNameField` and `credentialsNamespaceField`, and the renderer fills both in. Tests assert that a derived field never also carries a default, and that ansible's namespace is required rather than guessed.

(This is the change #175 was meant to carry — that PR merged an empty diff because the commit had gone to a different branch. Content unchanged.)

`kcl test`: 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL