### PR TITLE
feat(capability): render ansible, lists and relocated credentials (0.4.0)

### DIFF
--- a/crossplane/xplane-capability-catalog/README.md
+++ b/crossplane/xplane-capability-catalog/README.md
@@ -51,6 +51,13 @@ the other two in all three ways a capability can:
   `ParameterTypeMismatch` — an error that names the Tekton parameter and
   nothing about where the value came from. So `defaults` is `{str:any}`, and a
   consumer must not coerce.
+* **credentials that live somewhere else.** A Tekton pipeline reads its Secret
+  by NAME, in its OWN namespace. So the entry declares
+  `credentialsNameField` and `credentialsNamespaceField` and the renderer
+  fills both in — a catalog default for either would be a second source of a
+  derived value, and both failures are silent: an EnvironmentConfig naming a
+  Secret that does not exist reports a missing credential rather than a wrong
+  name, and a Secret beside the provider is simply never read.
 
 Both were transcribed from the capability Helm charts in
 `stuttgart-things/stuttgart-things` (`crossplane/platform/capabilities/`), which

--- a/crossplane/xplane-capability-catalog/capabilities/ansible.k
+++ b/crossplane/xplane-capability-catalog/capabilities/ansible.k
@@ -27,6 +27,11 @@ ansible: s.Capability = {
         }
         vaultKeys = ["vm_ssh_user", "vm_ssh_password"]
     }
+    # Both derived, not defaulted. The pipeline looks the Secret up by name and
+    # reads it in ITS OWN namespace, so a catalog default for either would be a
+    # second source that silently diverges from what is actually created.
+    credentialsNameField = "ansibleCredentialsSecretName"
+    credentialsNamespaceField = "namespace"
     environmentLabelKey = "ansible.resources.stuttgart-things.com/environment"
     # The pipeline definition and where it runs. Facts about THIS cluster —
     # which namespace has the Tekton pipeline SA, which StorageClass exists —
@@ -39,7 +44,6 @@ ansible: s.Capability = {
         gitRevision = "main"
         gitPath = "pipelines/execute-ansible-playbooks.yaml"
         ansibleWorkingImage = "ghcr.io/stuttgart-things/sthings-ansible:14.0.0"
-        ansibleCredentialsSecretName = "ansible-credentials"
         # A LIST, deliberately — see the header. Pinned versions rather than
         # floating ones: a collection that moves under a running fleet changes
         # what every VM build does, without a single file changing here.

--- a/crossplane/xplane-capability-catalog/catalog_test.k
+++ b/crossplane/xplane-capability-catalog/catalog_test.k
@@ -102,3 +102,21 @@ test_pipeline_credentials_are_plain_keys = lambda {
     assert len(_d) == 2
     assert "ANSIBLE_USER" in _d and "ANSIBLE_PASSWORD" in _d
 }
+
+# The name and the namespace of a credentials Secret are DERIVED, and both are
+# silent when wrong: an EnvironmentConfig naming a Secret that does not exist
+# makes the consumer report a missing credential rather than a wrong name, and
+# a Secret beside the provider is simply never read by a pipeline running
+# elsewhere.
+test_derived_credential_fields_are_not_also_defaulted = lambda {
+    _bad = [n for n in c.names if c.get(n)?.credentialsNameField and c.get(n).credentialsNameField in c.get(n).defaults]
+    assert _bad == [], "a derived field must not have a default that diverges from it: " + str(_bad)
+}
+
+# ansible's credentials are read by a Tekton pipeline in the pipeline's own
+# namespace — the same trap as a cloud-init password beside the provider.
+test_ansible_credentials_live_where_the_pipeline_runs = lambda {
+    _a = c.get("ansible")
+    assert _a.credentialsNamespaceField == "namespace"
+    assert _a.credentialsNamespaceField in _a.required, "and that namespace must be stated, not guessed"
+}

--- a/crossplane/xplane-capability-catalog/kcl.mod
+++ b/crossplane/xplane-capability-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-capability-catalog"
 edition = "v0.12.3"
-version = "0.2.0"
+version = "0.3.0"

--- a/crossplane/xplane-capability-catalog/main.k
+++ b/crossplane/xplane-capability-catalog/main.k
@@ -30,5 +30,10 @@ get = lambda name: str -> s.Capability {
 # the user never wrote.
 fields = lambda name: str -> [str] {
     _c = get(name)
-    _c.required + sorted([k for k in _c.defaults]) + _c.optional
+
+    # Derived fields count as known: an XR may not set them (the consumer
+    # rejects unknown keys, and these are filled in by the renderer), but they
+    # must not be rejected as typos either.
+    _derived = [f for f in [_c?.credentialsNameField] if f]
+    _c.required + sorted([k for k in _c.defaults]) + _c.optional + [f for f in _derived if f not in _c.required and f not in _c.defaults and f not in _c.optional]
 }

--- a/crossplane/xplane-capability-catalog/schema.k
+++ b/crossplane/xplane-capability-catalog/schema.k
@@ -111,6 +111,23 @@ schema Capability:
     rejects a stringified list with ParameterTypeMismatch — an error that names
     the Tekton parameter and nothing about where the value came from."""
 
+    credentialsNameField?: str
+    """Placement key that must carry the NAME of the credentials Secret.
+
+    Set it whenever the consumer looks the Secret up by a field rather than
+    receiving it directly. The name is derived per environment, so a catalog
+    default would be a second, diverging source of it — and the failure is
+    silent: the EnvironmentConfig names a Secret that does not exist, and the
+    consumer reports a missing credential rather than a wrong name."""
+
+    credentialsNamespaceField?: str
+    """Placement key naming the NAMESPACE the credentials Secret must live in.
+
+    Unset means beside the provider (the XR's spec.namespace). ansible sets it,
+    because its 'credentials' are read by a Tekton pipeline in the pipeline's
+    own namespace — a Secret next to the provider would be one nothing reads,
+    which is the same trap as a cloud-init password in the wrong namespace."""
+
     workloadSecrets: [WorkloadSecret] = []
     """Secrets that belong in the workload namespace rather than beside the
     provider. See WorkloadSecret."""

--- a/crossplane/xplane-capability/README.md
+++ b/crossplane/xplane-capability/README.md
@@ -84,9 +84,23 @@ spec:
 ```
 
 Everything not listed is either a catalog default or derived.
-`providerConfigName` and `providerConfigKind` are **always** derived: they name
-an object this module emits, and letting an XR state them would make it possible
-to point a VM at a config this XR did not create.
+`providerConfigName`, `providerConfigKind`, `ciPasswordSecretName` and (for
+`ansible`) `ansibleCredentialsSecretName` are **always** derived: each names an
+object this module emits, and letting an XR state one makes it possible to point
+a consumer at something this XR did not create — or at a name that does not
+exist, which reads as a missing credential rather than a wrong name.
+
+## Three namespaces, not one
+
+Where a Secret goes is decided per capability, because a Secret in the wrong
+namespace does not fail — it is simply never read, and the consumer reports a
+*missing* credential while pointing at itself.
+
+| Secret | namespace | who reads it |
+|---|---|---|
+| credentials (default) | `spec.namespace` | the provider, beside itself |
+| credentials (`credentialsNamespaceField`) | a placement value | `ansible`: the Tekton pipeline, in its own namespace |
+| workload | `spec.workloadNamespace` | the VM XR — see below |
 
 ## Two namespaces, not one
 
@@ -138,6 +152,8 @@ every field is legitimately absent.
 | `test_numbers_are_stringified` | `vlanTag: 102` failing the apply on type rather than content |
 | `test_optional_fields_are_accepted_but_not_defaulted` | `cloneDatastore` acquiring a default. bpg's clone block is `ForceNew`: a value here rewrites the clone block of every VM already built under this EnvironmentConfig, and the provider answers with destroy + recreate |
 | `test_every_capability_is_reported_in_one_pass` | one-error-per-reconcile |
+| `test_list_values_are_not_stringified` | `ansibleExtraCollections` reaching Tekton as a string — rejected there with `ParameterTypeMismatch`, an error naming the Tekton parameter and nothing about where the value came from |
+| `test_credentials_land_where_their_consumer_reads_them` | a credentials Secret beside the provider when a pipeline elsewhere reads it |
 | `test_a_store_without_a_server_is_rejected` | a store with nothing left to derive |
 | `test_an_existing_store_needs_no_vault_facts` | requiring Vault facts from a cluster that reuses a store it already trusts |
 | `test_status_less_objects_do_not_derive_readiness_from_themselves` | an EnvironmentConfig or ClusterProviderConfig stuck at Ready=False forever |

--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-capability"
 edition = "v0.12.3"
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies]
-xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.1.0" }
+xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -4,4 +4,4 @@ edition = "v0.12.3"
 version = "0.4.0"
 
 [dependencies]
-xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.2.0" }
+xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.3.0" }

--- a/crossplane/xplane-capability/kcl.mod.lock
+++ b/crossplane/xplane-capability/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-capability-catalog]
     name = "xplane-capability-catalog"
-    full_name = "xplane-capability-catalog_0.1.0"
-    version = "0.1.0"
-    sum = "wm/8y5pwoeu+vDIGFj1TtHwTWP9WqtNEuFIsV7upkvQ="
+    full_name = "xplane-capability-catalog_0.2.0"
+    version = "0.2.0"
+    sum = "nVAEpddlkcMpcbe7sUx8pi1JHSWZsrvvwnGpa2vIhN4="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-capability-catalog"
-    oci_tag = "0.1.0"
+    oci_tag = "0.2.0"

--- a/crossplane/xplane-capability/kcl.mod.lock
+++ b/crossplane/xplane-capability/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-capability-catalog]
     name = "xplane-capability-catalog"
-    full_name = "xplane-capability-catalog_0.2.0"
-    version = "0.2.0"
-    sum = "nVAEpddlkcMpcbe7sUx8pi1JHSWZsrvvwnGpa2vIhN4="
+    full_name = "xplane-capability-catalog_0.3.0"
+    version = "0.3.0"
+    sum = "A88ZyRCP/3UMtSu3dFpunD0ltShKmyLodQB11jND8xs="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-capability-catalog"
-    oci_tag = "0.2.0"
+    oci_tag = "0.3.0"

--- a/crossplane/xplane-capability/logic.k
+++ b/crossplane/xplane-capability/logic.k
@@ -97,3 +97,13 @@ schema Readiness:
 readinessFor = lambda kind: str -> Readiness {
     Readiness {policy = "DeriveFromCelQuery", celQuery = "true"} if kind in ["EnvironmentConfig", "ClusterProviderConfig"] else Readiness {policy = "DeriveFromObject"}
 }
+
+# Which namespace a capability's credentials Secret belongs in. Beside the
+# provider by default; a capability whose consumer reads it elsewhere names the
+# placement key holding that namespace. Here rather than inline so it is
+# testable: a Secret in the wrong namespace does not fail, it is simply never
+# read — the consumer reports a missing credential and points at itself.
+credentialsNamespace = lambda capName: str, placementOf: {str:}, providerNs: str -> str {
+    _f = cat.get(capName)?.credentialsNamespaceField
+    str(placementOf[_f]) if _f else providerNs
+}

--- a/crossplane/xplane-capability/logic.k
+++ b/crossplane/xplane-capability/logic.k
@@ -9,10 +9,21 @@ import xplane_capability_catalog.main as cat
 # Catalog defaults overlaid with the XR's values. Only keys the catalog knows
 # are kept — unknownFields turns the rest into an error rather than a value that
 # quietly disappears.
-placement = lambda capName: str, given: {str:} -> {str:str} {
+# Scalars become strings, everything else is passed through untouched.
+# EnvironmentConfig data is not string-only, and the one list in the catalog —
+# ansible's collection set — is handed to Tekton as a parameter, where a
+# stringified list is rejected with ParameterTypeMismatch: an error naming the
+# Tekton parameter and nothing about where the value came from. A YAML author
+# writing `vlanTag: 102` still has to be caught, so ints and bools keep being
+# coerced.
+_coerce = lambda v: any -> any {
+    v if typeof(v) in ["list", "dict"] else str(v)
+}
+
+placement = lambda capName: str, given: {str:} -> {str:} {
     _c = cat.get(capName)
     _known = cat.fields(capName)
-    _over = {k: str(given[k]) for k in given if k in _known}
+    _over = {k: _coerce(given[k]) for k in given if k in _known}
 
     # Built key by key rather than with `|`: KCL treats a union between a
     # schema-typed dict and an override of the same key as a CONFLICT and

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -148,3 +148,14 @@ test_an_xr_list_overrides_the_default = lambda {
     _p = logic.placement("ansible", {namespace = "tekton-ci", storageClass = "openebs-hostpath", ansibleExtraCollections = ["only.this:1.0.0"]})
     assert _p["ansibleExtraCollections"] == ["only.this:1.0.0"]
 }
+
+# A credentials Secret in the wrong namespace does not fail — it is simply
+# never read, and the consumer reports a missing credential while pointing at
+# itself. ansible's is read by a Tekton pipeline in the pipeline's namespace;
+# a provider reads its own beside itself.
+test_credentials_land_where_their_consumer_reads_them = lambda {
+    _ap = logic.placement("ansible", {namespace = "tekton-ci", storageClass = "openebs-hostpath"})
+    assert logic.credentialsNamespace("ansible", _ap, "crossplane-system") == "tekton-ci"
+    _pp = logic.placement("proxmoxvm", _full)
+    assert logic.credentialsNamespace("proxmoxvm", _pp, "crossplane-system") == "crossplane-system"
+}

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -133,3 +133,18 @@ test_status_fields_are_the_ones_the_xrd_declares = lambda {
     _want = ["credentialsSecret", "environmentConfig", "providerConfig", "ready", "secretStore"]
     assert sorted(statusFields) == _want, "keep this in step with the XRD in crossplane-configurations/bootstrap/capability"
 }
+
+# The catalog's one list value must survive rendering. Tekton rejects a
+# stringified list with ParameterTypeMismatch, naming the Tekton parameter and
+# nothing about where the value came from.
+test_list_values_are_not_stringified = lambda {
+    _p = logic.placement("ansible", {namespace = "tekton-ci", storageClass = "openebs-hostpath"})
+    assert typeof(_p["ansibleExtraCollections"]) == "list"
+    assert typeof(_p["gitRevision"]) == "str", "scalars still become strings"
+}
+
+# And an XR-supplied list wins the same way a scalar does.
+test_an_xr_list_overrides_the_default = lambda {
+    _p = logic.placement("ansible", {namespace = "tekton-ci", storageClass = "openebs-hostpath", ansibleExtraCollections = ["only.this:1.0.0"]})
+    assert _p["ansibleExtraCollections"] == ["only.this:1.0.0"]
+}

--- a/crossplane/xplane-capability/main.k
+++ b/crossplane/xplane-capability/main.k
@@ -106,6 +106,15 @@ _credsSecretName = lambda capName: str -> str {
     capName + "-creds-" + _environment
 }
 
+# Where the credentials Secret goes. Beside the provider by default; a
+# capability whose consumer reads it elsewhere says so with
+# credentialsNamespaceField, and the value comes from its own placement — for
+# ansible that is the Tekton pipeline's namespace, and a Secret in
+# crossplane-system would simply never be read.
+_credsNamespace = lambda capName: str -> str {
+    logic.credentialsNamespace(capName, _placement(capName), _ns)
+}
+
 # A capability names a KV mount -> it gets its own store. Names one that already
 # exists -> that one is used and nothing is created.
 _vaultOf = lambda capName: str -> {str:} {
@@ -196,7 +205,7 @@ _externalSecret = lambda capName: str -> {str:} {
         kind = "ExternalSecret"
         metadata = {
             name = _credsSecretName(capName)
-            namespace = _ns
+            namespace = _credsNamespace(capName)
         }
         spec = {
             refreshInterval = _refreshInterval
@@ -341,10 +350,16 @@ _environmentConfig = lambda capName: str -> {str:} {
     # providerConfigName/-Kind are DERIVED, never taken from the XR: they name
     # the object rendered two functions up, and letting an XR state them makes
     # it possible to point a VM at a config this XR did not create.
+    # Derived, never taken from the XR: each names an object rendered by this
+    # same module, and letting an XR state one makes it possible to point a
+    # consumer at something this XR did not create — or at a name that does not
+    # exist, which reads as a missing credential rather than a wrong name.
     _derived = ({
         providerConfigName = _objName(capName)
         providerConfigKind = _c.providerConfig.kind
-    } if _c?.providerConfig else {}) | _workloadSecretNames(capName)
+    } if _c?.providerConfig else {}) | _workloadSecretNames(capName) | ({
+        (_c.credentialsNameField) = _credsSecretName(capName)
+    } if _c?.credentialsNameField else {})
     _object(_resName, {
         apiVersion = "apiextensions.crossplane.io/v1beta1"
         kind = "EnvironmentConfig"

--- a/crossplane/xplane-capability/main.k
+++ b/crossplane/xplane-capability/main.k
@@ -135,7 +135,7 @@ _capSpec = lambda capName: str -> {str:} {
 _given = lambda capName: str -> {str:} {
     _capSpec(capName)?.placement or {}
 }
-_placement = lambda capName: str -> {str:str} {
+_placement = lambda capName: str -> {str:} {
     logic.placement(capName, _given(capName))
 }
 

--- a/crossplane/xplane-capability/test-settings.yaml
+++ b/crossplane/xplane-capability/test-settings.yaml
@@ -14,6 +14,13 @@ kcl_options:
           vault:
             server: https://vault.infra.sthings-vsphere.labul.sva.de
           capabilities:
+            ansible:
+              enabled: true
+              vault:
+                mount: cicd-proxmox-labul
+              placement:
+                namespace: tekton-ci
+                storageClass: openebs-hostpath
             proxmoxvm:
               enabled: true
               vault:


### PR DESCRIPTION
Picks up catalog 0.3.0 (kcl#174 + kcl#176). Three changes, each forced by **rendering** the ansible entry rather than reading it.

**Placement values are no longer coerced to strings.** `ansibleExtraCollections` is a list and reaches Tekton as a parameter, where a stringified list is rejected with `ParameterTypeMismatch` — an error naming the Tekton parameter and nothing about where the value came from. Scalars are still coerced, so `vlanTag: 102` is still caught.

**The credentials Secret name is derived** into whichever placement field the catalog names. The EnvironmentConfig previously announced `ansible-credentials` while the renderer created `ansible-creds-labul` — the consumer would report a *missing* credential rather than a wrong name.

**And that Secret goes where its consumer reads it.** Beside the provider by default; in a placement-named namespace where the catalog says so. ansible's is read by a Tekton pipeline in the pipeline's own namespace, so one in `crossplane-system` would be a Secret nothing reads.

Rendered output for a two-capability XR:

```
ClusterSecretStore     ansible-labul            (cluster-scoped)
ExternalSecret         ansible-creds-labul      tekton-ci
EnvironmentConfig      ansible-labul            (cluster-scoped)   ansibleCredentialsSecretName = ansible-creds-labul
ClusterSecretStore     proxmoxvm-labul          (cluster-scoped)
ExternalSecret         proxmoxvm-creds-labul    crossplane-system
EnvironmentConfig      proxmoxvm-labul          (cluster-scoped)
ClusterProviderConfig  proxmoxvm-labul          (cluster-scoped)
ExternalSecret         proxmoxvm-ci-password    default
```

ansible correctly gets no ClusterProviderConfig. `kcl test`: 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL