### PR TITLE
fix(capability-catalog): the entry is called ansible-run (0.4.0)

### DIFF
--- a/crossplane/xplane-capability-catalog/README.md
+++ b/crossplane/xplane-capability-catalog/README.md
@@ -35,11 +35,11 @@ sthings-u26 image and the bpg provider — not of LabUL.
 
 | capability | provider config | Vault keys | required placement |
 |---|---|---|---|
-| `ansible` | **none** | `vm_ssh_user`, `vm_ssh_password` | `namespace`, `storageClass` |
+| `ansible-run` | **none** | `vm_ssh_user`, `vm_ssh_password` | `namespace`, `storageClass` |
 | `proxmoxvm` | `proxmoxbpg.m.crossplane.io/v1beta1` | `pve_api_url`, `pve_api_user`, `pve_api_password`, `vm_ssh_user`, `vm_ssh_password` | `node`, `datastore`, `bridge`, `vlanTag`, `pool`, `templateVmId` |
 | `vspherevm` | `vspherevm.m.stuttgart-things.com/v1beta1` | `vsphere_user`, `vsphere_password`, `vsphere_server` | `templateUuid`, `datastoreId`, `resourcePoolId`, `networkId`, `folder`, `domain` |
 
-`ansible` is the entry that made the schema earn its keep, and it differs from
+`ansible-run` is the entry that made the schema earn its keep, and it differs from
 the other two in all three ways a capability can:
 
 * **no provider config** — it configures a Configuration, not a provider.
@@ -51,6 +51,13 @@ the other two in all three ways a capability can:
   `ParameterTypeMismatch` — an error that names the Tekton parameter and
   nothing about where the value came from. So `defaults` is `{str:any}`, and a
   consumer must not coerce.
+* **a name that is not the tool's.** It is called `ansible-run`, after the
+  Configuration it configures, because the label is derived from the entry name
+  and the `ansible-run` Composition selects on
+  `ansible-run.resources.stuttgart-things.com/environment`. An entry named
+  `ansible` emits a label nothing selects; `function-environment-configs`
+  requires exactly one match, so the Composition finds zero and reports the
+  selector rather than the entry.
 * **credentials that live somewhere else.** A Tekton pipeline reads its Secret
   by NAME, in its OWN namespace. So the entry declares
   `credentialsNameField` and `credentialsNamespaceField` and the renderer

--- a/crossplane/xplane-capability-catalog/capabilities/ansible_run.k
+++ b/crossplane/xplane-capability-catalog/capabilities/ansible_run.k
@@ -1,6 +1,14 @@
 import ..schema as s
 
-# ansible — the AnsibleRun Configuration, not a provider.
+# ansible-run — the AnsibleRun Configuration, not a provider.
+#
+# Named for the Configuration it configures, not for the tool. That is not
+# cosmetic: the ansible-run Composition selects its EnvironmentConfig on the
+# label `ansible-run.resources.stuttgart-things.com/environment`, this catalog
+# derives that label from the entry name, and function-environment-configs
+# requires EXACTLY ONE match — so an entry called `ansible` emits a label
+# nothing selects, the Composition finds zero EnvironmentConfigs, and the error
+# names the selector rather than the entry.
 #
 # The entry that shows what the schema had to accommodate, and the reason it is
 # worth having a schema at all rather than three near-identical charts:
@@ -17,8 +25,8 @@ import ..schema as s
 #
 # Values are transcribed from the ansible capability chart and from the
 # ansible-run-defaults EnvironmentConfig that builds this fleet's VMs today.
-ansible: s.Capability = {
-    name = "ansible"
+ansibleRun: s.Capability = {
+    name = "ansible-run"
     credentials = s.Credentials {
         # Plain keys: the pipeline reads them as environment variables.
         data = {
@@ -32,7 +40,7 @@ ansible: s.Capability = {
     # second source that silently diverges from what is actually created.
     credentialsNameField = "ansibleCredentialsSecretName"
     credentialsNamespaceField = "namespace"
-    environmentLabelKey = "ansible.resources.stuttgart-things.com/environment"
+    environmentLabelKey = "ansible-run.resources.stuttgart-things.com/environment"
     # The pipeline definition and where it runs. Facts about THIS cluster —
     # which namespace has the Tekton pipeline SA, which StorageClass exists —
     # so they are required rather than defaulted: a wrong storageClass leaves

--- a/crossplane/xplane-capability-catalog/catalog_test.k
+++ b/crossplane/xplane-capability-catalog/catalog_test.k
@@ -80,16 +80,16 @@ test_workload_secret_vault_keys_match_their_templates = lambda {
 # where the value came from. So placement values are not all strings, and the
 # renderer must not coerce them.
 test_list_valued_defaults_stay_lists = lambda {
-    _v = c.get("ansible").defaults["ansibleExtraCollections"]
+    _v = c.get("ansible-run").defaults["ansibleExtraCollections"]
     assert typeof(_v) == "list", "a stringified list is a ParameterTypeMismatch in Tekton"
     assert len(_v) > 0
 }
 
-# ansible configures a Configuration, not a provider — so it has no
+# ansible-run configures a Configuration, not a provider — so it has no
 # ClusterProviderConfig, and the renderer must emit none rather than an empty
 # one. providerConfig was optional from the first version for this case.
-test_ansible_has_no_provider_config = lambda {
-    assert not c.get("ansible")?.providerConfig
+test_ansible_run_has_no_provider_config = lambda {
+    assert not c.get("ansible-run")?.providerConfig
     assert c.get("proxmoxvm")?.providerConfig, "while a provider capability does"
 }
 
@@ -98,7 +98,7 @@ test_ansible_has_no_provider_config = lambda {
 # single-key rule is asserted only for capabilities WITH a provider config, and
 # this is the entry that would break a rule stated too broadly.
 test_pipeline_credentials_are_plain_keys = lambda {
-    _d = c.get("ansible").credentials.data
+    _d = c.get("ansible-run").credentials.data
     assert len(_d) == 2
     assert "ANSIBLE_USER" in _d and "ANSIBLE_PASSWORD" in _d
 }
@@ -115,8 +115,24 @@ test_derived_credential_fields_are_not_also_defaulted = lambda {
 
 # ansible's credentials are read by a Tekton pipeline in the pipeline's own
 # namespace — the same trap as a cloud-init password beside the provider.
-test_ansible_credentials_live_where_the_pipeline_runs = lambda {
-    _a = c.get("ansible")
+test_ansible_run_credentials_live_where_the_pipeline_runs = lambda {
+    _a = c.get("ansible-run")
     assert _a.credentialsNamespaceField == "namespace"
     assert _a.credentialsNamespaceField in _a.required, "and that namespace must be stated, not guessed"
+}
+
+# The label a consumer selects on is derived from the entry name, and
+# function-environment-configs requires EXACTLY ONE match — so a name that does
+# not match its consumer's label produces zero matches and an error naming the
+# selector rather than the entry. These are the labels the Compositions in
+# crossplane-configurations actually select on; check there before adding one.
+test_entry_names_match_their_consumers_selectors = lambda {
+    _consumers = {
+        "ansible-run" = "ansible-run.resources.stuttgart-things.com/environment"
+        "proxmoxvm" = "proxmoxvm.resources.stuttgart-things.com/environment"
+        "vspherevm" = "vspherevm.resources.stuttgart-things.com/environment"
+    }
+    _wrong = [n for n in _consumers if c.get(n).environmentLabelKey != _consumers[n]]
+    assert _wrong == [], "these emit a label their Composition does not select: " + str(_wrong)
+    assert sorted([n for n in _consumers]) == c.names, "a new entry needs its consumer's selector checked here"
 }

--- a/crossplane/xplane-capability-catalog/kcl.mod
+++ b/crossplane/xplane-capability-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-capability-catalog"
 edition = "v0.12.3"
-version = "0.3.0"
+version = "0.4.0"

--- a/crossplane/xplane-capability-catalog/main.k
+++ b/crossplane/xplane-capability-catalog/main.k
@@ -7,12 +7,12 @@ not.
 """
 
 import .schema as s
-import .capabilities.ansible as ansible
+import .capabilities.ansible_run as ansible_run
 import .capabilities.proxmoxvm as proxmoxvm
 import .capabilities.vspherevm as vspherevm
 
 catalog: {str:s.Capability} = {
-    ansible = ansible.ansible
+    "ansible-run" = ansible_run.ansibleRun
     proxmoxvm = proxmoxvm.proxmoxvm
     vspherevm = vspherevm.vspherevm
 }


### PR DESCRIPTION
Named for the tool rather than for the Configuration it configures — and that was not cosmetic.

The environment label is derived from the entry name. The `ansible-run` Composition selects its EnvironmentConfig on `ansible-run.resources.stuttgart-things.com/environment`, and `function-environment-configs` requires **exactly one** match. So an entry called `ansible` emits a label nothing selects, the Composition finds zero, and the error names the selector rather than the entry that produced it.

Found by reading the consuming Composition before deploying rather than after.

A test now pins each entry's label against the selector its Composition actually uses, and fails when a new entry is added without that check.

`kcl test`: 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL