### PR TITLE
fix(capability): follow the ansible-run rename (0.4.1)

### DIFF
--- a/crossplane/xplane-capability/README.md
+++ b/crossplane/xplane-capability/README.md
@@ -85,7 +85,7 @@ spec:
 
 Everything not listed is either a catalog default or derived.
 `providerConfigName`, `providerConfigKind`, `ciPasswordSecretName` and (for
-`ansible`) `ansibleCredentialsSecretName` are **always** derived: each names an
+`ansible-run`) `ansibleCredentialsSecretName` are **always** derived: each names an
 object this module emits, and letting an XR state one makes it possible to point
 a consumer at something this XR did not create — or at a name that does not
 exist, which reads as a missing credential rather than a wrong name.
@@ -99,7 +99,7 @@ namespace does not fail — it is simply never read, and the consumer reports a
 | Secret | namespace | who reads it |
 |---|---|---|
 | credentials (default) | `spec.namespace` | the provider, beside itself |
-| credentials (`credentialsNamespaceField`) | a placement value | `ansible`: the Tekton pipeline, in its own namespace |
+| credentials (`credentialsNamespaceField`) | a placement value | `ansible-run`: the Tekton pipeline, in its own namespace |
 | workload | `spec.workloadNamespace` | the VM XR — see below |
 
 ## Two namespaces, not one

--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-capability"
 edition = "v0.12.3"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
-xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.3.0" }
+xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-capability/kcl.mod.lock
+++ b/crossplane/xplane-capability/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-capability-catalog]
     name = "xplane-capability-catalog"
-    full_name = "xplane-capability-catalog_0.3.0"
-    version = "0.3.0"
-    sum = "A88ZyRCP/3UMtSu3dFpunD0ltShKmyLodQB11jND8xs="
+    full_name = "xplane-capability-catalog_0.4.0"
+    version = "0.4.0"
+    sum = "2xGqERWAh/79km8+Dju3SNdUIaUq5pc/KZYIArx1/S0="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-capability-catalog"
-    oci_tag = "0.3.0"
+    oci_tag = "0.4.0"

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -138,14 +138,14 @@ test_status_fields_are_the_ones_the_xrd_declares = lambda {
 # stringified list with ParameterTypeMismatch, naming the Tekton parameter and
 # nothing about where the value came from.
 test_list_values_are_not_stringified = lambda {
-    _p = logic.placement("ansible", {namespace = "tekton-ci", storageClass = "openebs-hostpath"})
+    _p = logic.placement("ansible-run", {namespace = "tekton-ci", storageClass = "openebs-hostpath"})
     assert typeof(_p["ansibleExtraCollections"]) == "list"
     assert typeof(_p["gitRevision"]) == "str", "scalars still become strings"
 }
 
 # And an XR-supplied list wins the same way a scalar does.
 test_an_xr_list_overrides_the_default = lambda {
-    _p = logic.placement("ansible", {namespace = "tekton-ci", storageClass = "openebs-hostpath", ansibleExtraCollections = ["only.this:1.0.0"]})
+    _p = logic.placement("ansible-run", {namespace = "tekton-ci", storageClass = "openebs-hostpath", ansibleExtraCollections = ["only.this:1.0.0"]})
     assert _p["ansibleExtraCollections"] == ["only.this:1.0.0"]
 }
 
@@ -154,8 +154,8 @@ test_an_xr_list_overrides_the_default = lambda {
 # itself. ansible's is read by a Tekton pipeline in the pipeline's namespace;
 # a provider reads its own beside itself.
 test_credentials_land_where_their_consumer_reads_them = lambda {
-    _ap = logic.placement("ansible", {namespace = "tekton-ci", storageClass = "openebs-hostpath"})
-    assert logic.credentialsNamespace("ansible", _ap, "crossplane-system") == "tekton-ci"
+    _ap = logic.placement("ansible-run", {namespace = "tekton-ci", storageClass = "openebs-hostpath"})
+    assert logic.credentialsNamespace("ansible-run", _ap, "crossplane-system") == "tekton-ci"
     _pp = logic.placement("proxmoxvm", _full)
     assert logic.credentialsNamespace("proxmoxvm", _pp, "crossplane-system") == "crossplane-system"
 }

--- a/crossplane/xplane-capability/test-settings.yaml
+++ b/crossplane/xplane-capability/test-settings.yaml
@@ -14,7 +14,7 @@ kcl_options:
           vault:
             server: https://vault.infra.sthings-vsphere.labul.sva.de
           capabilities:
-            ansible:
+            ansible-run:
               enabled: true
               vault:
                 mount: cicd-proxmox-labul


### PR DESCRIPTION
Catalog 0.4.0 (kcl#178). The entry is named for the Configuration it configures, because the environment label is derived from the entry name and the `ansible-run` Composition selects on `ansible-run.resources.stuttgart-things.com/environment`.

`kcl test`: 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL