### PR TITLE
fix(xplane-cluster): extraVars erreicht jede Stufe, fertige Stufe wird versiegelt (0.8.0)

### DIFF
--- a/crossplane/xplane-cluster/README.md
+++ b/crossplane/xplane-cluster/README.md
@@ -46,6 +46,25 @@ Three `Usage` resources, only the pairs whose absence strands a finalizer:
 
 ## Re-runs are per stage
 
+### A finished stage is sealed (0.8.0)
+
+Re-emitting a child verbatim is a flap guard — it applies while the VM's IP is
+momentarily missing — but a **finished** `PipelineRun` needs the same treatment
+for an unrelated reason: it is immutable. provider-kubernetes rejects any spec
+change on one with `Once the PipelineRun is complete, no updates are allowed:
+spec`, and keeps rejecting it every reconcile.
+
+Until 0.8.0 the rebuild was keyed on the VM's IP and not on the stage, so ANY
+edit to `spec.ansible` rewrote EVERY stage's spec — including stages that
+finished hours ago. A change aimed at an open stage therefore parked a closed
+one in a permanent `ReconcileError`, and the rebuild could not have delivered
+the change anyway, because the write is refused.
+
+The seal lifts the moment the derived name stops matching what is observed, so
+the documented repair still works: bumping `spec.runIDs.<stage>` changes both
+`pipelineRunName` and `crossplaneObjectName`, and the fix arrives as a NEW
+Object instead of an update to a sealed one.
+
 `spec.runIDs` is a map, not a single value:
 
 ```yaml

--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -253,7 +253,12 @@ kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any}
     }
     _dist = spec?.distribution or "k3s"
     _paths = ["kubeconfig_path+-" + _serverPaths[_dist]] if _dist in _serverPaths else []
-    _vars = renderVars(_stage.vars) + clusterNameVars(_dist, _cluster) + _paths
+    # extraVars belongs here too. It was wired into the base-OS and
+    # distribution stages only, so an override aimed at THIS stage —
+    # secret_path_kubeconfig is the obvious one — vanished without a word:
+    # the XRD documents the field, nothing rejects the value, and the
+    # rendered varsFile simply does not contain it.
+    _vars = renderVars(_stage.vars) + clusterNameVars(_dist, _cluster) + _paths + (stageAnsible(spec, "kubeconfig")?.extraVars or [])
 
     # STATED EXPLICITLY, even though `vault` is also ansible-run's own default.
     # Which Vault the upload authenticates against is a decision this module

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -253,6 +253,7 @@ kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any}
     }
     _dist = spec?.distribution or "k3s"
     _paths = ["kubeconfig_path+-" + _serverPaths[_dist]] if _dist in _serverPaths else []
+
     # extraVars belongs here too. It was wired into the base-OS and
     # distribution stages only, so an override aimed at THIS stage —
     # secret_path_kubeconfig is the obvious one — vanished without a word:

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -510,3 +510,36 @@ test_every_usage_label_is_prefixed = lambda {
     assert all n in _names {n.startswith("zeta-")}, "every Usage object name carries the cluster"
     assert len(_names) == len({n: True for n in _names}), "and they stay distinct from each other"
 }
+
+# extraVars must reach EVERY stage, not just the two that happened to be wired.
+# It was missing from kubeconfigRun, so an override aimed at the upload — the
+# KV mount under secret_path_kubeconfig is the one people actually want to
+# change — disappeared with no error anywhere: the XRD documents the field, the
+# value is accepted, and the rendered varsFile simply does not carry it.
+test_extra_vars_reach_the_kubeconfig_stage = lambda {
+    _spec = {
+        provider = "proxmox"
+        distribution = "rke2"
+        size = "medium"
+        ansible = {
+            stages = {
+                kubeconfig = {extraVars = ["secret_path_kubeconfig+-cicd-kubeconfigs"]}
+            }
+        }
+    }
+    _vars = l.kubeconfigRun("c", "ns", _spec, "10.0.0.1").spec.ansibleVarsFile
+    assert "secret_path_kubeconfig+-cicd-kubeconfigs" in _vars
+    # the catalog's own vars survive alongside it
+    assert "kubeconfig_path+-/etc/rancher/rke2/rke2.yaml" in _vars
+}
+
+# The shared block reaches the kubeconfig stage too, not only a per-stage one.
+test_shared_extra_vars_reach_the_kubeconfig_stage = lambda {
+    _spec = {
+        provider = "proxmox"
+        distribution = "rke2"
+        size = "medium"
+        ansible = {extraVars = ["shared_var+-1"]}
+    }
+    assert "shared_var+-1" in l.kubeconfigRun("c", "ns", _spec, "10.0.0.1").spec.ansibleVarsFile
+}

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -140,8 +140,35 @@ _reemit = lambda prev: any, stage: str -> {str:any} {
 # names are stable, so nothing re-runs until runID is bumped. Freezing
 # unconditionally, as this did first, made a broken stage unfixable without
 # deleting the child.
-_distChild = _reemit(_distRun, "distribution") if (len(_distObs) > 0 and _vmIP == "") else l.distributionRun(_name, _ns, _spec, _vmIP)
-_kcChild = _reemit(_kcRun, "kubeconfig") if (len(_kcObs) > 0 and _vmIP == "") else l.kubeconfigRun(_name, _ns, _spec, _vmIP)
+#
+# SECOND reason to re-emit, unrelated to flapping: a FINISHED PipelineRun is
+# immutable. provider-kubernetes rejects any spec change on it with
+#
+#     Once the PipelineRun is complete, no updates are allowed: spec
+#
+# and keeps rejecting it every reconcile. Because the rebuild above is driven by
+# the VM's IP and not by the stage, ANY edit to spec.ansible rewrote EVERY
+# stage's spec — including stages that finished hours ago — so a change aimed at
+# an open stage parked a closed one in a permanent ReconcileError. The rebuild
+# could never have delivered the fix anyway: the write is refused.
+#
+# So a finished stage is sealed. That is not the freeze the comment above warns
+# about, because the documented lever still works: bumping spec.runIDs.<stage>
+# changes pipelineRunName AND crossplaneObjectName, so the repair arrives as a
+# NEW Object instead of an update to a sealed one — which is why the seal is
+# lifted the moment the derived name stops matching what is observed.
+_desiredRunName = lambda stage: str -> str {
+    _rid = l.runIDFor(_spec, stage)
+    _suffix = "-{}".format(_rid) if _rid else ""
+    "{}-{}{}".format(_name, stage, _suffix)
+}
+_sealed = lambda run: {str:any}, stage: str -> bool {
+    _done = (run?.status?.succeeded or "") in ["True", "False"]
+    _done and (run?.spec?.pipelineRunName or "") == _desiredRunName(stage)
+}
+
+_distChild = _reemit(_distRun, "distribution") if (len(_distObs) > 0 and (_vmIP == "" or _sealed(_distRun, "distribution"))) else l.distributionRun(_name, _ns, _spec, _vmIP)
+_kcChild = _reemit(_kcRun, "kubeconfig") if (len(_kcObs) > 0 and (_vmIP == "" or _sealed(_kcRun, "kubeconfig"))) else l.kubeconfigRun(_name, _ns, _spec, _vmIP)
 
 # --- teardown ordering -----------------------------------------------------
 # Only the pairs that matter. Usage is not transitive, so a full mesh would be


### PR DESCRIPTION
Closes #182.

Zwei Defekte im selben Zweig, gemeldet an einem Live-rke2-Build.

## 1. `extraVars` erreichte die kubeconfig-Stufe nicht

Angehängt wurde es nur in `vmChild` (`logic.k:109`) und `distributionRun` (`:224`), nie in `kubeconfigRun`. Ein Override für die Upload-Stufe — `secret_path_kubeconfig` ist der, nach dem man greift — verschwand wortlos: das XRD dokumentiert das Feld, nichts weist den Wert zurück, die gerenderte `varsFile` enthält ihn einfach nicht.

**Eine Korrektur zur Issue-Beschreibung:** `stages` ist **nicht** kaputt. Es ist in `stageAnsible` (`logic.k:75-87`) implementiert und funktioniert — es speist nur dieselben zwei Konsumenten. Gleicher Effekt, andere Ursache.

## 2. Jede `spec.ansible`-Änderung brach abgeschlossene Stufen

Ein fertiger `PipelineRun` ist unveränderlich. Der Rebuild hing aber an der VM-IP statt an der Stufe (`main.k:143-144`), also schrieb **jede** Änderung an `spec.ansible` die Spec **jeder** Stufe neu — auch solcher, die Stunden vorher fertig geworden waren. Eine Änderung für eine offene Stufe parkte damit eine geschlossene in einem Dauerfehler:

```
Once the PipelineRun is complete, no updates are allowed: spec
```

den der Provider im Reconcile-Takt wiederholt. Ausliefern konnte der Rebuild die Änderung ohnehin nie — der Write wird abgelehnt.

Das ist der schwerere Teil: ein dokumentiertes Feld ohne Wirkung, das nebenbei eine ganz andere Stufe rot färbt.

## Der Fix

Eine fertige Stufe wird versiegelt. Das ist **nicht** das unbedingte Einfrieren, vor dem der Kommentar darüber warnt, denn der dokumentierte Hebel greift weiter: ein Bump von `spec.runIDs.<stage>` ändert `pipelineRunName` **und** `crossplaneObjectName`, die Reparatur kommt also als **neues** Object statt als Update auf ein versiegeltes. Genau deshalb fällt das Siegel, sobald der abgeleitete Name nicht mehr zum beobachteten passt.

Damit ist es die von @-Reporter vorgeschlagene Richtung „stufen-lokal rendern", nur an der Immutabilität festgemacht statt an der Stufennummer.

## Tests

Zwei neue für die kubeconfig-Verdrahtung (per-stage und shared), **48/48 grün**. Das Siegel sitzt in `main.k` und braucht eine `ocds`-Map, ist also aus dem Unit-Harness nicht erreichbar — dort verlasse ich mich auf die Live-Beobachtung aus dem Issue.

## Achtung beim Rollout

Modul geht auf **0.8.0**. `bootstrap/cluster/apis/composition.yaml` in `crossplane-configurations` pinnt weiter `xplane-cluster:0.7.0` — den Pin erst bumpen, wenn 0.8.0 publiziert ist, sonst zieht sich der Cluster ein Artefakt, das es nicht gibt.