### PR TITLE
feat(xplane-platform): gate the vaultIssuer branch on cert-manager (0.22.0)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.21.1"
+version = "0.22.0"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.18.0" }

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -108,6 +108,21 @@ vaultIssuerEnabled = lambda spec: {str:} -> bool {
     (spec?.vaultIssuer or {})?.enabled or False
 }
 
+certManagerReady = lambda ocds: {str:}, key: str -> bool {
+    """Is cert-manager SERVING on the target?
+
+    Reads readyReplicas off an observed Deployment. Deliberately not "does the
+    CRD exist": creating a ClusterIssuer goes through cert-manager's validating
+    webhook, so a present CRD with a webhook that is not serving fails the apply
+    the same way a missing CRD does. readyReplicas is the first moment both hold.
+
+    Absent from ocds -> False. That is the state on the very first reconcile,
+    before the Observe child has been created at all, and it must read as "not
+    ready" rather than as an error.
+    """
+    ((ocds[key].Resource?.status?.atProvider?.manifest?.status?.readyReplicas or 0) if key in ocds else 0) > 0
+}
+
 gateOpen = lambda ready: bool, exists: bool -> bool {
     """Should a gated child be emitted?
 

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -680,19 +680,37 @@ test_cert_manager_gate_closed_before_the_observe_exists = lambda {
 test_cert_manager_gate_closed_while_no_replica_is_ready = lambda {
     # Deployment observed but still rolling out. A present CRD is not enough --
     # the validating webhook has to be serving.
-    _ocds = {"p-cert-manager-observe" = {Resource = {status.atProvider.manifest.status = {readyReplicas = 0}}}}
+    _ocds = {
+        "p-cert-manager-observe" = {
+            Resource = {
+                status.atProvider.manifest.status = {readyReplicas = 0}
+            }
+        }
+    }
     assert not l.certManagerReady(_ocds, "p-cert-manager-observe")
 }
 
 test_cert_manager_gate_opens_on_the_first_ready_replica = lambda {
-    _ocds = {"p-cert-manager-observe" = {Resource = {status.atProvider.manifest.status = {readyReplicas = 1}}}}
+    _ocds = {
+        "p-cert-manager-observe" = {
+            Resource = {
+                status.atProvider.manifest.status = {readyReplicas = 1}
+            }
+        }
+    }
     assert l.certManagerReady(_ocds, "p-cert-manager-observe")
 }
 
 test_cert_manager_gate_survives_a_status_without_readyReplicas = lambda {
     # A freshly created Deployment has no readyReplicas key at all. That must
     # read as not-ready, not blow up the render for every other component.
-    _ocds = {"p-cert-manager-observe" = {Resource = {status.atProvider.manifest.status = {replicas = 1}}}}
+    _ocds = {
+        "p-cert-manager-observe" = {
+            Resource = {
+                status.atProvider.manifest.status = {replicas = 1}
+            }
+        }
+    }
     assert not l.certManagerReady(_ocds, "p-cert-manager-observe")
 }
 

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -666,3 +666,39 @@ test_gateway_name_absent_is_empty = lambda {
         gateway = {}
     }, "gateway.name") == ""
 }
+
+# --- cert-manager gate -------------------------------------------------------
+# The vaultIssuer branch composes an issuer onto a cluster whose cert-manager
+# arrives through ArgoCD, i.e. through something Crossplane cannot see. These
+# three cases are the whole contract of the gate; getting the first one wrong is
+# what would make a fresh Platform emit an issuer before its CRD exists.
+test_cert_manager_gate_closed_before_the_observe_exists = lambda {
+    # First reconcile: ocds is empty, the Observe child has not been created yet.
+    assert not l.certManagerReady({}, "p-cert-manager-observe")
+}
+
+test_cert_manager_gate_closed_while_no_replica_is_ready = lambda {
+    # Deployment observed but still rolling out. A present CRD is not enough --
+    # the validating webhook has to be serving.
+    _ocds = {"p-cert-manager-observe" = {Resource = {status.atProvider.manifest.status = {readyReplicas = 0}}}}
+    assert not l.certManagerReady(_ocds, "p-cert-manager-observe")
+}
+
+test_cert_manager_gate_opens_on_the_first_ready_replica = lambda {
+    _ocds = {"p-cert-manager-observe" = {Resource = {status.atProvider.manifest.status = {readyReplicas = 1}}}}
+    assert l.certManagerReady(_ocds, "p-cert-manager-observe")
+}
+
+test_cert_manager_gate_survives_a_status_without_readyReplicas = lambda {
+    # A freshly created Deployment has no readyReplicas key at all. That must
+    # read as not-ready, not blow up the render for every other component.
+    _ocds = {"p-cert-manager-observe" = {Resource = {status.atProvider.manifest.status = {replicas = 1}}}}
+    assert not l.certManagerReady(_ocds, "p-cert-manager-observe")
+}
+
+# Once the issuer exists the gate must stay open, or Crossplane deletes it the
+# next time cert-manager rolls a pod -- gateOpen is what makes it one-way.
+test_cert_manager_gate_is_one_way_once_the_issuer_exists = lambda {
+    assert l.gateOpen(False, True)
+    assert not l.gateOpen(False, False)
+}

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -280,6 +280,7 @@ _viPkiMount = _viSpec?.pkiMount or "pki"
 _viIssuerName = _viSpec?.issuerName or "vault-pki-k8s"
 _viCaSecret = _viSpec?.caSecretName or "vault-pki-ca"
 _viTargetRef = _shared.kubernetesProviderConfigRef
+_viCmWebhookName = _viSpec?.certManagerWebhookName or "cert-manager-webhook"
 
 # --- Reviewer JWT provisioning (auto) ---
 # Vault's k8s-auth mount needs a token_reviewer_jwt from the TARGET (an
@@ -413,6 +414,42 @@ _tokenReqBindingObj = {
     }
 }
 
+# --- cert-manager gate -------------------------------------------------
+# The ClusterIssuer, the wildcard Certificate, the CA Secret and the
+# TokenRequest RBAC all land on the TARGET and all need cert-manager to be there
+# first. On a Flux-driven cluster that is true by the time this runs, because
+# apps.cert-manager is a sibling of this branch. On an ARGOCD-driven cluster it
+# is not: cert-manager arrives through an ApplicationSet that Crossplane knows
+# nothing about, so a one-shot apply composes an issuer whose CRD does not exist
+# yet. It converges by retry, but for minutes nobody can tell "waiting for
+# ArgoCD" from "broken" — which is exactly the question that costs time during a
+# build (stuttgart-things#2505).
+#
+# The gate observes the cert-manager WEBHOOK deployment, not the CRD. A present
+# CRD is not enough: creating a ClusterIssuer goes through the validating
+# webhook, and an apply against a webhook that is not serving fails the same
+# way. readyReplicas is the first moment both are true.
+#
+# One-way via l.gateOpen: once a gated child exists, it keeps being emitted. Not
+# emitting an existing child is how Crossplane deletes it, and a gate that could
+# re-close would tear the issuer down every time cert-manager rolls a new pod.
+_viCmObserveKey = "{}-cert-manager-observe".format(_name)
+_viCmObserveObj = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {name = _viCmObserveKey, namespace = _namespace, annotations = {"krm.kcl.dev/composition-resource-name" = _viCmObserveKey}}
+    spec = {
+        managementPolicies = ["Observe"]
+        forProvider.manifest = {
+            apiVersion = "apps/v1"
+            kind = "Deployment"
+            metadata = {name = _viCmWebhookName, namespace = _viCmNs}
+        }
+        providerConfigRef = {name = _viTargetRef, kind = "ClusterProviderConfig"}
+    }
+}
+_viCmReady = l.certManagerReady(_ocds, _viCmObserveKey)
+
 # --- auto-reviewer Objects (only when autoReviewer) ---
 _viRevSAObj = {
     apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
@@ -533,7 +570,19 @@ _viCertObj = {
     }
 }
 
-_vaultIssuerChildren = ([_vaultK8sAuthXR, _vaultPkiSecretXR, _issuerObj, _tokenReqRoleObj, _tokenReqBindingObj] + _viReviewerObjects + ([_viCertObj] if _viCertEnabled else [])) if _vaultIssuerEnabled else []
+# UNGATED: the Vault side and the reviewer chain. VaultK8sAuth drives Vault
+# through OpenTofu and the reviewer SA/token live in kube-system — none of it
+# touches cert-manager, and all of it is the slow half. Holding it back would
+# serialise two independent waits for no reason.
+_viUngated = [_vaultK8sAuthXR, _viCmObserveObj] + _viReviewerObjects
+
+# GATED on cert-manager: everything that lands in its namespace or needs its
+# CRDs. VaultPkiSecret writes the CA Secret into _viCmNs, the TokenRequest RBAC
+# is a Role/RoleBinding there, and the issuer plus the wildcard Certificate need
+# the CRDs and the webhook.
+_viGated = [_vaultPkiSecretXR, _issuerObj, _tokenReqRoleObj, _tokenReqBindingObj] + ([_viCertObj] if _viCertEnabled else [])
+
+_vaultIssuerChildren = (_viUngated + (_viGated if l.gateOpen(_viCmReady, _issuerKey in _ocds) else [])) if _vaultIssuerEnabled else []
 
 _children = ([_cniXR] if _cniEnabled else []) + ([_ipReservationXR] if _ipResEnabled else []) + ([_fluxInitXR] if (_fluxEnabled and l.gateOpen(_networkReady, _fluxKey in _ocds)) else []) + ([_fluxAppsXR] if (_appsEnabled and l.gateOpen(_networkReady, _appsKey in _ocds)) else []) + ([_ciliumXR] if (_ciliumEnabled and l.gateOpen(_networkReady, _ciliumKey in _ocds)) else []) + _vaultIssuerChildren
 
@@ -633,6 +682,12 @@ _xrStatus = _oxr | {
                 authReady = _vaultAuthReady
                 caReady = _vaultPkiReady
                 issuerReady = _issuerReady
+                # The single field that answers "is it broken or is it waiting?".
+                # Without it a gated branch and a failed one look identical from
+                # the outside: not-ready, no issuer, no CA. On an ArgoCD-driven
+                # cluster the wait is normal and can last minutes.
+                certManagerReady = _viCmReady
+                waitingForCertManager = _vaultIssuerEnabled and not _viCmReady and _issuerKey not in _ocds
                 # What Vault actually created, keyed by auth name. This is what
                 # lets external-secrets discover its own cluster's mount instead
                 # of being told the name by hand — the gap that kept it out of


### PR DESCRIPTION
Gefunden beim Bau von `homerun2-test1` (stuttgart-things/stuttgart-things#2505, PR #2519).

## Das Problem

`vaultIssuer` komponiert vier Dinge, die auf dem Zielcluster landen und cert-manager voraussetzen: den `ClusterIssuer`, das Wildcard-`Certificate`, das CA-Secret (in dessen Namespace) und das TokenRequest-RBAC (ebenfalls dort).

Auf einem **Flux**-Cluster stimmt das bauartbedingt — `apps.cert-manager` ist ein Geschwisterkind desselben XR. Auf einem **ArgoCD**-Cluster nicht: cert-manager kommt über ein ApplicationSet, das Crossplane nicht sieht. Ein Ein-Schritt-Apply komponiert also einen Issuer, dessen CRD es noch nicht gibt.

Das konvergiert durch Wiederholung. Aber minutenlang kann niemand „wartet auf ArgoCD" von „kaputt" unterscheiden — und genau das war beim Bau zweimal die Frage. Der Behelf war, die XR **zweimal** anzuwenden: erst ohne `vaultIssuer`, dann mit. Damit ist das committete Manifest nicht mehr von Null anwendbar, was schlechter ist als das ursprüngliche Problem.

## Der Gate

Auf das **Webhook-Deployment**, nicht auf die CRD. Eine vorhandene CRD reicht nicht: das Anlegen eines ClusterIssuer geht durch den Validating Webhook, und ein Apply gegen einen nicht bedienenden Webhook scheitert genauso. `readyReplicas > 0` ist der erste Moment, in dem beides gilt.

**Ungated bleiben** `VaultK8sAuth`, die Reviewer-Kette und der Observe selbst — nichts davon berührt cert-manager, und es ist die langsame Hälfte. Sie zurückzuhalten würde zwei unabhängige Wartezeiten hintereinanderhängen.

**Einwegig** über das vorhandene `gateOpen`. Existiert der Issuer erst, wird er weiter emittiert; sonst würde Crossplane ihn jedes Mal löschen, wenn cert-manager einen Pod neu ausrollt.

## Sichtbarkeit

`status.components.vaultIssuer` bekommt `certManagerReady` und `waitingForCertManager`. Ohne die sehen ein gehaltener und ein gescheiterter Zweig von außen identisch aus: not-ready, kein Issuer, keine CA.

## Belegt

`main.k` in beiden Zuständen gerendert:

```
Gate zu     6 Kinder   vault-auth, reviewer-{sa,crb,token,observe}, cert-manager-observe
Gate offen 10 Kinder   dazu vault-pki, cluster-issuer, tokenrequest-{role,binding}
```

Die Entscheidung liegt in `logic.k` (`certManagerReady`), nicht inline in `main.k` — nach dem Prinzip, das der Header der Composition selbst aufstellt. 5 neue Tests, **58/58 grün**, darunter der Fall „Deployment frisch angelegt, `readyReplicas` fehlt ganz", der sonst den Render für alle anderen Komponenten mitreißen würde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi