### PR TITLE
fix(xplane-platform): gate on the webhook's Endpoints, not its Deployment (0.22.1)

### DIFF
--- a/crossplane/xplane-platform/kcl.mod
+++ b/crossplane/xplane-platform/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-platform"
 edition = "v0.12.3"
-version = "0.22.0"
+version = "0.22.1"
 
 [dependencies]
 xplane-flux-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-flux-catalog", tag = "0.19.0" }

--- a/crossplane/xplane-platform/kcl.mod.lock
+++ b/crossplane/xplane-platform/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-flux-catalog]
     name = "xplane-flux-catalog"
-    full_name = "xplane-flux-catalog_0.18.0"
-    version = "0.18.0"
-    sum = "AbDl7SZiftY571QxMrdSdJ826a+Jb1ExLstd1sl2NL0="
+    full_name = "xplane-flux-catalog_0.19.0"
+    version = "0.19.0"
+    sum = "atZMEDXx93jXenJPt/Pk5143FL3eAwHLde1upyxAyk0="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-flux-catalog"
-    oci_tag = "0.18.0"
+    oci_tag = "0.19.0"

--- a/crossplane/xplane-platform/logic.k
+++ b/crossplane/xplane-platform/logic.k
@@ -109,18 +109,27 @@ vaultIssuerEnabled = lambda spec: {str:} -> bool {
 }
 
 certManagerReady = lambda ocds: {str:}, key: str -> bool {
-    """Is cert-manager SERVING on the target?
+    """Is cert-manager's webhook SERVING on the target?
 
-    Reads readyReplicas off an observed Deployment. Deliberately not "does the
-    CRD exist": creating a ClusterIssuer goes through cert-manager's validating
-    webhook, so a present CRD with a webhook that is not serving fails the apply
-    the same way a missing CRD does. readyReplicas is the first moment both hold.
+    Reads the webhook Service's Endpoints. An address appears there only once the
+    backing pod passes its readiness probe AND the Service selects it — i.e. only
+    once a request would actually reach the webhook. Deliberately not the CRD
+    (creating a ClusterIssuer goes through the validating webhook, so a present
+    CRD with a webhook that is not serving fails the apply the same way) and
+    deliberately not the Deployment's readyReplicas, which says a pod is ready but
+    nothing about Service routing.
+
+    Endpoints also has no required properties, so the Observe child can embed a
+    bare metadata-only manifest. A Deployment cannot: `kubeconform -strict`
+    rejects one without `spec`, which is exactly how the first attempt at this
+    gate failed the Configuration's verify job (embedded-INVALID on xr-max).
 
     Absent from ocds -> False. That is the state on the very first reconcile,
-    before the Observe child has been created at all, and it must read as "not
-    ready" rather than as an error.
+    before the Observe child exists at all, and it must read as "not ready"
+    rather than as an error.
     """
-    ((ocds[key].Resource?.status?.atProvider?.manifest?.status?.readyReplicas or 0) if key in ocds else 0) > 0
+    _subsets = (ocds[key].Resource?.status?.atProvider?.manifest?.subsets or []) if key in ocds else []
+    len([s for s in _subsets if len(s?.addresses or []) > 0]) > 0
 }
 
 gateOpen = lambda ready: bool, exists: bool -> bool {

--- a/crossplane/xplane-platform/logic_test.k
+++ b/crossplane/xplane-platform/logic_test.k
@@ -670,48 +670,49 @@ test_gateway_name_absent_is_empty = lambda {
 # --- cert-manager gate -------------------------------------------------------
 # The vaultIssuer branch composes an issuer onto a cluster whose cert-manager
 # arrives through ArgoCD, i.e. through something Crossplane cannot see. These
-# three cases are the whole contract of the gate; getting the first one wrong is
-# what would make a fresh Platform emit an issuer before its CRD exists.
+# cases are the whole contract of the gate; getting the first one wrong is what
+# would make a fresh Platform emit an issuer before its CRD exists.
+#
+# The signal is the webhook Service's Endpoints, not the Deployment: an address
+# appears there only once the pod is ready AND the Service selects it. Endpoints
+# also has no required properties, so the Observe child embeds a metadata-only
+# manifest -- a bare Deployment fails `kubeconform -strict` for want of a spec.
+_epKey = "p-cert-manager-observe"
+_ep = lambda subsets: [] -> {str:} {
+    {
+        "p-cert-manager-observe" = {
+            Resource = {
+                status.atProvider.manifest = {subsets = subsets}
+            }
+        }
+    }
+}
+
 test_cert_manager_gate_closed_before_the_observe_exists = lambda {
     # First reconcile: ocds is empty, the Observe child has not been created yet.
-    assert not l.certManagerReady({}, "p-cert-manager-observe")
+    assert not l.certManagerReady({}, _epKey)
 }
 
-test_cert_manager_gate_closed_while_no_replica_is_ready = lambda {
-    # Deployment observed but still rolling out. A present CRD is not enough --
-    # the validating webhook has to be serving.
-    _ocds = {
-        "p-cert-manager-observe" = {
-            Resource = {
-                status.atProvider.manifest.status = {readyReplicas = 0}
-            }
-        }
-    }
-    assert not l.certManagerReady(_ocds, "p-cert-manager-observe")
+test_cert_manager_gate_closed_when_endpoints_have_no_addresses = lambda {
+    # Service exists, no pod backs it yet. This is the state while cert-manager
+    # is still rolling out, and the one a CRD check would miss.
+    assert not l.certManagerReady(_ep([{addresses = []}]), _epKey)
 }
 
-test_cert_manager_gate_opens_on_the_first_ready_replica = lambda {
-    _ocds = {
-        "p-cert-manager-observe" = {
-            Resource = {
-                status.atProvider.manifest.status = {readyReplicas = 1}
-            }
-        }
-    }
-    assert l.certManagerReady(_ocds, "p-cert-manager-observe")
+test_cert_manager_gate_closed_when_the_only_address_is_not_ready = lambda {
+    # Pod scheduled but failing its readiness probe -- kubelet keeps it in
+    # notReadyAddresses, and a request would not reach it.
+    assert not l.certManagerReady(_ep([{notReadyAddresses = [{ip = "10.42.0.1"}]}]), _epKey)
 }
 
-test_cert_manager_gate_survives_a_status_without_readyReplicas = lambda {
-    # A freshly created Deployment has no readyReplicas key at all. That must
-    # read as not-ready, not blow up the render for every other component.
-    _ocds = {
-        "p-cert-manager-observe" = {
-            Resource = {
-                status.atProvider.manifest.status = {replicas = 1}
-            }
-        }
-    }
-    assert not l.certManagerReady(_ocds, "p-cert-manager-observe")
+test_cert_manager_gate_opens_on_the_first_ready_address = lambda {
+    assert l.certManagerReady(_ep([{addresses = [{ip = "10.42.0.46"}]}]), _epKey)
+}
+
+test_cert_manager_gate_survives_endpoints_without_subsets = lambda {
+    # A Service whose Endpoints object exists but carries no subsets at all.
+    # Must read as not-ready, not blow up the render for every other component.
+    assert not l.certManagerReady(_ep([]), _epKey)
 }
 
 # Once the issuer exists the gate must stay open, or Crossplane deletes it the

--- a/crossplane/xplane-platform/main.k
+++ b/crossplane/xplane-platform/main.k
@@ -425,10 +425,14 @@ _tokenReqBindingObj = {
 # ArgoCD" from "broken" — which is exactly the question that costs time during a
 # build (stuttgart-things#2505).
 #
-# The gate observes the cert-manager WEBHOOK deployment, not the CRD. A present
-# CRD is not enough: creating a ClusterIssuer goes through the validating
-# webhook, and an apply against a webhook that is not serving fails the same
-# way. readyReplicas is the first moment both are true.
+# The gate observes the ENDPOINTS of cert-manager's webhook Service, not the CRD
+# and not the Deployment. Not the CRD, because creating a ClusterIssuer goes
+# through the validating webhook and an apply against a webhook that is not
+# serving fails the same way. Not the Deployment, for two reasons: readyReplicas
+# says a pod is ready but nothing about Service routing, and a bare Deployment
+# manifest fails `kubeconform -strict` for want of a `spec` — which is how the
+# first version of this gate broke the Configuration's verify job. Endpoints has
+# no required properties, so a metadata-only Observe manifest validates.
 #
 # One-way via l.gateOpen: once a gated child exists, it keeps being emitted. Not
 # emitting an existing child is how Crossplane deletes it, and a gate that could
@@ -441,8 +445,8 @@ _viCmObserveObj = {
     spec = {
         managementPolicies = ["Observe"]
         forProvider.manifest = {
-            apiVersion = "apps/v1"
-            kind = "Deployment"
+            apiVersion = "v1"
+            kind = "Endpoints"
             metadata = {name = _viCmWebhookName, namespace = _viCmNs}
         }
         providerConfigRef = {name = _viTargetRef, kind = "ClusterProviderConfig"}


### PR DESCRIPTION
Nachtrag zu #184. Das dortige Gate beobachtete das cert-manager-Webhook-**Deployment** — und ist damit in der verify-Stufe von crossplane-configurations#326 aufgelaufen:

```
✗ xr-max.yaml: XRD-valid, render-ok, object-valid, status-valid, embedded-INVALID
    Deployment cert-manager-webhook is invalid: missing properties: 'spec'
```

Layer 3 fährt `kubeconform -strict` über jedes eingebettete Manifest. Ein Observe-Kind braucht nur die Identität, das Manifest ist also bewusst metadata-only — aber ein Deployment ohne `spec` ist kein gültiges Deployment. Das Reviewer-Observe kommt mit derselben Form durch, weil es ein `Secret` beobachtet, und das hat keine Pflichtfelder.

## Endpoints statt Deployment

`Endpoints` hat ebenfalls keine Pflichtfelder, das Manifest validiert also. Und es ist das **bessere Signal**: eine Adresse steht dort erst, wenn der Pod seine Readiness-Probe besteht **und** der Service ihn selektiert — also erst, wenn eine Anfrage den Webhook tatsächlich erreichen würde. `readyReplicas` sagt nur, dass der Pod bereit ist, und nichts über das Service-Routing.

An `homerun2-test1` gemessen:

```
subsets[0].addresses:      ['10.42.0.46']
subsets[0].notReadyAddresses: []
```

## Belegt

`main.k` in beiden Zuständen gerendert:

```
Gate zu     vault-auth, cert-manager-observe (Endpoints), reviewer-{sa,crb,token,observe}
Gate offen  dazu vault-pki, cluster-issuer, tokenrequest-{role,binding}
```

Tests auf die neue Form umgeschrieben, mit zwei Fällen, die die alte Fassung nicht hatte: „Endpoints existiert, trägt aber gar keine subsets" und „die einzige Adresse steht unter notReadyAddresses". **59/59**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi