### PR TITLE
fix(vault-auth-base): Destroy scheitert am fehlenden Reviewer-Secret (0.11.1)

### DIFF
--- a/crossplane/xplane-vault-auth-base/backend_config_test.k
+++ b/crossplane/xplane-vault-auth-base/backend_config_test.k
@@ -1,0 +1,34 @@
+# Unit tests for the kubernetes auth backend_config HCL. `kcl test`.
+import .main as m
+
+test_destroy_tolerates_a_missing_reviewer_secret = lambda {
+    """The backend_config must not index the SA secret bare.
+
+    A bare index is re-evaluated on DESTROY, and by then the reviewer Secret
+    is gone -- it is a composed sibling of the same Platform XR and is deleted
+    in parallel. tofu raises "Attempt to index null value", the destroy removes
+    nothing, and the Workspace hangs in Deleting forever. Because its name is
+    derived from clusterName+authName, a replacement XR cannot take that name
+    either, so the whole teardown stalls.
+
+    Measured on argoplatform-test1, 2026-08-19. crossplane-configurations#333.
+    """
+    _hcl = m._backendConfigHcl
+    assert "try(data.kubernetes_secret.sa.data[var.sa_ca_cert_key], null)" in _hcl
+    assert "try(data.kubernetes_secret.sa.data[var.sa_token_key], null)" in _hcl
+    assert "= data.kubernetes_secret.sa.data[" not in _hcl, "bare index reintroduced"
+}
+
+test_a_missing_secret_still_fails_loudly_on_apply = lambda {
+    """Destroy-tolerance must not become silent acceptance on create.
+
+    try(..., null) alone would let tofu write an empty CA cert and an empty
+    token reviewer JWT into Vault, which Vault accepts -- the auth mount would
+    then exist and simply not work. The preconditions put the loud failure back
+    where it belongs; they are not evaluated on destroy.
+    """
+    _hcl = m._backendConfigHcl
+    assert "lifecycle {" in _hcl
+    assert _hcl.count("precondition {") == 2
+    assert "must exist before the Vault kubernetes auth backend can be configured" in _hcl
+}

--- a/crossplane/xplane-vault-auth-base/kcl.mod
+++ b/crossplane/xplane-vault-auth-base/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth-base"
 edition = "v0.11.0"
-version = "0.11.0"
+version = "0.11.1"
 description = "KCL library for creating Vault Kubernetes authentication backends as Crossplane v2 namespaced OpenTofu Workspaces"
 
 [dependencies]

--- a/crossplane/xplane-vault-auth-base/main.k
+++ b/crossplane/xplane-vault-auth-base/main.k
@@ -236,12 +236,39 @@ data "kubernetes_secret" "sa" {
 resource "vault_kubernetes_auth_backend_config" "kubernetes" {
   backend                = vault_auth_backend.kubernetes.path
   kubernetes_host        = var.kubernetes_host
-  kubernetes_ca_cert     = data.kubernetes_secret.sa.data[var.sa_ca_cert_key]
-  token_reviewer_jwt     = data.kubernetes_secret.sa.data[var.sa_token_key]
+  # try(): the DESTROY re-evaluates this expression, and by then the reviewer
+  # Secret is usually gone -- it is a composed child of the same Platform XR, so
+  # it is deleted in parallel with this Workspace. data.kubernetes_secret.sa.data
+  # is then null, indexing it raises "Attempt to index null value", and the
+  # destroy fails before it removes anything. The Workspace then hangs in
+  # Deleting forever and blocks the whole teardown, because its NAME is derived
+  # from clusterName+authName and a replacement XR needs that same name.
+  # Measured on argoplatform-test1, 2026-08-19 -- see
+  # crossplane-configurations#333.
+  #
+  # Destroy does not use these values, so falling back to null is correct there.
+  # On CREATE/UPDATE a null is NOT silently accepted: the precondition below
+  # fails loudly instead, which is the behaviour the bare index used to give.
+  kubernetes_ca_cert     = try(data.kubernetes_secret.sa.data[var.sa_ca_cert_key], null)
+  token_reviewer_jwt     = try(data.kubernetes_secret.sa.data[var.sa_token_key], null)
   disable_iss_validation = var.disable_iss_validation
   disable_local_ca_jwt   = var.disable_local_ca_jwt
 
   depends_on = [vault_auth_backend.kubernetes]
+
+  # Keeps the loud failure that the bare index provided, but only where it
+  # belongs. Preconditions are not evaluated when the resource is destroyed,
+  # so this cannot re-introduce the hang above.
+  lifecycle {
+    precondition {
+      condition     = try(data.kubernetes_secret.sa.data[var.sa_ca_cert_key], null) != null
+      error_message = "Secret ${var.sa_secret_namespace}/${var.sa_secret_name} has no key ${var.sa_ca_cert_key}. The reviewer ServiceAccount secret must exist before the Vault kubernetes auth backend can be configured."
+    }
+    precondition {
+      condition     = try(data.kubernetes_secret.sa.data[var.sa_token_key], null) != null
+      error_message = "Secret ${var.sa_secret_namespace}/${var.sa_secret_name} has no key ${var.sa_token_key}."
+    }
+  }
 }
 
 variable "kubernetes_host" {


### PR DESCRIPTION
Beim echten Teardown von `argoplatform-test1` hängt die OpenTofu-Workspace dauerhaft in `Deleting` und blockiert damit den gesamten Abriss. Zweimal reproduziert — einmal beim Ersetzen der Platform-XR, einmal beim Teardown.

## Fehler

```
Error: Attempt to index null value

  on main.tf line 130, in resource "vault_kubernetes_auth_backend_config" "kubernetes":
 130:   kubernetes_ca_cert = data.kubernetes_secret.sa.data[var.sa_ca_cert_key]
    │ var.sa_ca_cert_key is "ca.crt"

This value is null, so it does not have any indices.
```

## Ursache

Der Ausdruck wird beim **Destroy** erneut ausgewertet. Zu dem Zeitpunkt ist das Reviewer-Secret schon weg: es ist ein composed Geschwister derselben Platform-XR und wird parallel gelöscht. Der Destroy scheitert also, **bevor** er irgendetwas entfernt.

Verschärfend: der Workspace-Name wird aus `clusterName` + `authName` gebildet, nicht aus dem XR-Namen. Eine Ersatz-XR kann den Namen deshalb nicht übernehmen, solange die alte hängt — der Zustand löst sich von selbst nie auf.

Gemessen auf kind3, 2026-08-19. Kontext: crossplane-configurations#333.

## Fix

```hcl
kubernetes_ca_cert = try(data.kubernetes_secret.sa.data[var.sa_ca_cert_key], null)
token_reviewer_jwt = try(data.kubernetes_secret.sa.data[var.sa_token_key], null)
```

`try(..., null)` allein wäre allerdings ein Rückschritt: Vault nimmt ein leeres `ca_cert` und einen leeren `token_reviewer_jwt` **an**. Der Auth-Mount existierte dann und funktionierte einfach nicht — ein stiller Fehler statt eines lauten. Deshalb kommt die Lautstärke als `lifecycle.precondition` zurück:

```hcl
lifecycle {
  precondition {
    condition     = try(data.kubernetes_secret.sa.data[var.sa_ca_cert_key], null) != null
    error_message = "Secret ${var.sa_secret_namespace}/${var.sa_secret_name} has no key ${var.sa_ca_cert_key}. ..."
  }
  ...
}
```

Preconditions werden beim Destroy nicht ausgewertet — sie können den Hänger also nicht wieder einschleppen. Netto: laut beim Anlegen wie bisher, tolerant beim Abräumen.

## Tests

Neu `backend_config_test.k`, zwei Fälle: der blanke Index darf nicht zurückkommen, und die Preconditions müssen bleiben. Zusammen mit den bestehenden **14/14**; die Skript-Suite `tests/test_main.k` läuft ebenfalls durch.

## Rollout

Kette ist dreistufig, deshalb bewusst nur die erste Stufe in diesem PR:

```
xplane-vault-auth-base  0.11.0 → 0.11.1   ← hier
xplane-vault-auth       0.8.0            ← Pin+Lock nach dem Publish, eigener PR
vault-auth Configuration v0.3.1           ← danach
```

Den Pin im Konsumenten habe ich absichtlich **nicht** mitgezogen: `kcl.mod.lock` trägt die Prüfsumme von 0.11.0, und die von Hand umzuschreiben hieße, eine Prüfsumme zu erfinden. Nach dem Publish von 0.11.1 regeneriert `kcl mod update` sie korrekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi