### PR TITLE
feat(vault-auth): xplane-vault-auth-base 0.11.1 übernehmen (0.8.1)

### DIFF
--- a/crossplane/xplane-vault-auth/kcl.mod
+++ b/crossplane/xplane-vault-auth/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-vault-auth"
 edition = "v0.11.2"
-version = "0.8.0"
+version = "0.8.1"
 
 [dependencies]
-xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.11.0" }
+xplane-vault-auth-base = { oci = "oci://ghcr.io/stuttgart-things/xplane-vault-auth-base", tag = "0.11.1" }

--- a/crossplane/xplane-vault-auth/kcl.mod.lock
+++ b/crossplane/xplane-vault-auth/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-vault-auth-base]
     name = "xplane-vault-auth-base"
-    full_name = "xplane-vault-auth-base_0.11.0"
-    version = "0.11.0"
-    sum = "0T+h2exi34BfdJcSYAKTr5DM6GCjqSP2FEHQ6n6FNRo="
+    full_name = "xplane-vault-auth-base_0.11.1"
+    version = "0.11.1"
+    sum = "8pHmZXEdcryv8Hgl1CJVQkUlRjImb3XDWIlBGkLwp1M="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-vault-auth-base"
-    oci_tag = "0.11.0"
+    oci_tag = "0.11.1"


### PR DESCRIPTION
Zieht den Destroy-Fix aus #187 in den Konsumenten. Ohne diesen Bump rendert `xplane-vault-auth` weiter den blanken Index — und jeder Teardown einer Platform mit `vaultIssuer` hängt an der OpenTofu-Workspace (crossplane-configurations#333, am 2026-08-19 an argoplatform-test1 real erlebt).

## Warum nicht Renovate #188

Renovate hat den Pin in `kcl.mod` gehoben, aber nur den. Zwei Dinge fehlen:

**`kcl.mod.lock` trug weiter die Prüfsumme von 0.11.0.** Und die ist eine andere:

```
0T+h2exi34BfdJcSYAKTr5DM6GCjqSP2FEHQ6n6FNRo=   0.11.0
8pHmZXEdcryv8Hgl1CJVQkUlRjImb3XDWIlBGkLwp1M=   0.11.1
```

Deshalb hatte ich den Pin bewusst aus #187 herausgelassen: von Hand geschrieben wäre das eine erfundene Prüfsumme gewesen. Jetzt, wo 0.11.1 publiziert ist, erzeugt `kcl mod update` sie korrekt.

**`version` blieb auf `0.8.0`.** Die CI publiziert bei Merge auf `main` anhand dieses Feldes — ohne Bump gäbe es kein neues `xplane-vault-auth`-Tag, und die `vault-auth`-Configuration hätte nichts zum Pinnen.

#188 schließe ich als überholt.

## Nachweis

`kcl test` 6/6. Und der über die Modulgrenze importierte HCL trägt den Fix tatsächlich:

```
hasFix:        true     ← try(data.kubernetes_secret.sa.data[var.sa_ca_cert_key], null)
hasBare:       false    ← der blanke Index ist weg
preconditions: 2        ← die laute Prüfung beim Anlegen bleibt
```

## Danach

`vault-auth`-Configuration auf `xplane-vault-auth:0.8.1` pinnen, publizieren, auf kind3 ausrollen. Das rendert die Workspace-Module der **bestehenden** XRs neu — der Fix greift also rückwirkend für `homerun2-test1` und `u26-rke2-1`, ohne dass dafür etwas abgerissen werden muss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi