### PR TITLE
feat(cluster): kubeconfig-Leseziel aus dem Upload-Ziel ableiten (0.9.0)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -294,6 +294,40 @@ kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any}
     _ansibleRun(name, ns, "kubeconfig", spec, _stage.playbooks, _vars, renderInventory(_stage.inventoryGroups, ip), _vaultSecret)
 }
 
+# vaultSecretName says WHERE THE UPLOAD WRITES, providerConfigRef says WHERE THE
+# READ COMES FROM. They must mean the same Vault, and until 0.9.0 nothing enforced
+# that: the defaults `vault` and `vault-kubeconfigs` agreed by accident, but the
+# moment someone set vaultSecretName to vault-infra -- which the ArgoCD path
+# requires, because the ClusterSecretStore reads the infra Vault -- the pair came
+# apart and the RemoteCluster looked for the kubeconfig in the other Vault:
+#
+#   cannot read kubeconfig from Vault: secret not found: at kubeconfigs/data/<c>
+#
+# Nothing above it reports an error. The ClusterStack stays Ready=True, because
+# without a ready ClusterAccess the Platform branch is not emitted at all and
+# there is nothing left to wait for. Measured on argoplatform-test2, 2026-08-19:
+# 40 minutes to find. See crossplane-configurations#336.
+#
+# So the read side is DERIVED from the upload side by default. An explicit
+# providerConfigRef still wins -- it is the escape hatch for a Vault pair this
+# map does not know -- but it is no longer required to state the obvious.
+kubeconfigVaultPairs: {str:str} = {
+    "vault" = "vault-kubeconfigs"
+    "vault-infra" = "vault-kubeconfigs-infra"
+}
+
+kubeconfigReadRef = lambda kc: {str:} -> str {
+    """The ClusterProviderConfig the ClusterAccess reads the kubeconfig through.
+
+    Explicit wins; otherwise derived from vaultSecretName. An unknown
+    vaultSecretName falls back to the historical default rather than failing --
+    the XRD rejects the two combinations we know to be wrong, and guessing past
+    that would break setups this map has never seen.
+    """
+    _upload = kc?.vaultSecretName or "vault"
+    kc?.providerConfigRef or kubeconfigVaultPairs[_upload] or "vault-kubeconfigs"
+}
+
 # --- the two downstream XRs ------------------------------------------------
 clusterAccess = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
     _cluster = spec?.clusterName or name
@@ -314,7 +348,7 @@ clusterAccess = lambda name: str, ns: str, spec: {str:any} -> {str:any} {
                 key = "kubeconfig"
             }
             secretNamespace = _kc?.secretNamespace or "crossplane-system"
-            kubeconfigProviderConfigRef = _kc?.providerConfigRef or "vault-kubeconfigs"
+            kubeconfigProviderConfigRef = kubeconfigReadRef(_kc)
         }
     }
 }

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -543,3 +543,38 @@ test_shared_extra_vars_reach_the_kubeconfig_stage = lambda {
     }
     assert "shared_var+-1" in l.kubeconfigRun("c", "ns", _spec, "10.0.0.1").spec.ansibleVarsFile
 }
+
+test_read_ref_is_derived_from_the_upload_target = lambda {
+    """providerConfigRef folgt vaultSecretName, wenn es nicht gesetzt ist.
+
+    Bis 0.8.0 waren beide getrennte Felder mit Defaults, die nur zufaellig
+    zusammenpassten. vaultSecretName: vault-infra gegen den Default
+    vault-kubeconfigs (= vault-vsphere) liess den RemoteCluster im falschen
+    Vault suchen; der Bau stand 40 Minuten, ohne dass eine Ressource darueber
+    einen Fehler meldete. crossplane-configurations#336.
+    """
+    assert l.kubeconfigReadRef({}) == "vault-kubeconfigs"
+    assert l.kubeconfigReadRef({vaultSecretName = "vault"}) == "vault-kubeconfigs"
+    assert l.kubeconfigReadRef({vaultSecretName = "vault-infra"}) == "vault-kubeconfigs-infra"
+}
+
+test_explicit_read_ref_still_wins = lambda {
+    """Der Notausgang bleibt: eine Vault-Paarung, die die Map nicht kennt."""
+    assert l.kubeconfigReadRef({vaultSecretName = "vault-infra", providerConfigRef = "sonderfall"}) == "sonderfall"
+    assert l.kubeconfigReadRef({providerConfigRef = "sonderfall"}) == "sonderfall"
+}
+
+test_unknown_upload_target_falls_back_instead_of_guessing = lambda {
+    """Unbekanntes vaultSecretName -> historischer Default, nicht geraten.
+
+    Weiterraten hiesse, Namen zu erfinden; die XRD lehnt stattdessen die zwei
+    Kombinationen ab, von denen wir wissen, dass sie falsch sind.
+    """
+    assert l.kubeconfigReadRef({vaultSecretName = "vault-irgendwas"}) == "vault-kubeconfigs"
+}
+
+test_access_xr_carries_the_derived_ref = lambda {
+    """Und es kommt auch wirklich an der ClusterAccess-XR an."""
+    _a = l.clusterAccess("c", "default", {clusterName = "c", kubeconfig = {vaultSecretName = "vault-infra"}})
+    assert _a.spec.kubeconfigProviderConfigRef == "vault-kubeconfigs-infra"
+}


### PR DESCRIPTION
Erste Hälfte von crossplane-configurations#336. Die XRD-Seite (Default entfernen, Validierung) folgt im Configuration-Repo.

## Das Problem

```
vaultSecretName    → wohin die kubeconfig-Stufe HOCHLÄDT
providerConfigRef  → woher der RemoteCluster sie LIEST
```

Zwei getrennte Felder, die denselben Vault meinen müssen — und nichts erzwang das. Die Defaults `vault` / `vault-kubeconfigs` passten nur **zufällig** zusammen. Sobald `vaultSecretName: vault-infra` gesetzt wird, was der ArgoCD-Weg verlangt, fällt das Paar auseinander:

```
cannot read kubeconfig from Vault: secret not found: at kubeconfigs/data/<cluster>
```

Der teure Teil ist, dass niemand darüber einen Fehler meldet: der ClusterStack steht auf `Ready=True`, weil ohne fertigen `ClusterAccess` der Platform-Zweig gar nicht erst emittiert wird — es fehlt also nichts, worauf gewartet werden könnte. An `argoplatform-test2` am 2026-08-19 gemessen: 40 Minuten.

## Die Änderung

```python
kubeconfigVaultPairs: {str:str} = {
    "vault" = "vault-kubeconfigs"
    "vault-infra" = "vault-kubeconfigs-infra"
}

kubeconfigReadRef = lambda kc: {str:} -> str {
    _upload = kc?.vaultSecretName or "vault"
    kc?.providerConfigRef or kubeconfigVaultPairs[_upload] or "vault-kubeconfigs"
}
```

Drei Eigenschaften, jede mit einem Test:

**Explizit gewinnt.** Der Notausgang bleibt — für eine Vault-Paarung, die die Map nicht kennt. Er ist nur nicht mehr nötig, um das Offensichtliche hinzuschreiben.

**Unbekanntes Ziel rät nicht.** `vaultSecretName: vault-irgendwas` fällt auf den historischen Default zurück, statt einen Namen zu erfinden. Die XRD lehnt stattdessen die zwei Kombinationen ab, von denen wir *wissen*, dass sie falsch sind — alles andere ist ein Setup, das diese Map nie gesehen hat.

**Der Wert kommt an.** Ein eigener Test prüft die gerenderte ClusterAccess-XR, nicht nur den Helper.

## Tests

`kcl test` **52/52**, vier neue Fälle. Der bestehende Bestand ist unverändert grün.

## Danach

`cluster`-Configuration: `default: vault-kubeconfigs` aus der XRD entfernen (sonst kann die Composition „nicht gesetzt" nie von „bewusst gesetzt" unterscheiden), `x-kubernetes-validations` für die zwei gekreuzten Paarungen, Pin auf 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi