### PR TITLE
fix(management-plane): ProviderConfigs erst nach ihrer CRD anlegen (0.5.0)

### DIFF
--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-management-plane"
 edition = "v0.12.3"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-management-plane/logic.k
+++ b/crossplane/xplane-management-plane/logic.k
@@ -94,6 +94,42 @@ providerConfigsOpen = lambda packagesReady: bool, existing: int -> bool {
     packagesReady or existing > 0
 }
 
+# The CRD a ProviderConfig entry needs before it can be applied at all.
+#
+# WHY THIS EXISTS. A provider PACKAGE reports Healthy BEFORE its CRDs are
+# served. Gating the ProviderConfigs on package health therefore opens a window
+# -- two minutes on u26-rke2-1, none on mgmt-test1 -- in which the apply hits a
+# kind the API server does not know yet. That alone would be a hiccup; what
+# makes it permanent is provider-kubernetes: once its first create fails, the
+# Object stays Ready=False/Creating forever, even though every later reconcile
+# succeeds and the resource demonstrably exists. Thirty hours of a false
+# Ready=False on u26-rke2-1-mgmt, and it would block a whole ClusterStack that
+# composes a ManagementPlane. See crossplane-configurations#294.
+#
+# Derived from the ProviderConfig itself, not from the package: the question is
+# "can I create THIS kind", which is a property of its own group -- not of
+# whatever CRDs some package happens to register.
+providerConfigCrd = lambda pc -> str {
+    """CRD name for a ProviderConfig entry, e.g. clusterproviderconfigs.helm.m.crossplane.io.
+
+    Only the kinds we actually emit are mapped. An unmapped kind returns "" and
+    the caller then does NOT gate on it -- guessing a plural is how one ends up
+    waiting forever for a CRD that never had that name.
+    """
+    _group = pc.apiVersion.split("/")[0]
+    _plural = {
+        "ClusterProviderConfig" = "clusterproviderconfigs"
+        "ProviderConfig" = "providerconfigs"
+    }[pc.kind] or ""
+    "{}.{}".format(_plural, _group) if _plural else ""
+}
+
+# Distinct CRDs to wait for, in stable order.
+providerConfigCrds = lambda pcs: [any] -> [str] {
+    _all = [providerConfigCrd(pc) for pc in pcs]
+    sorted({c: "" for c in _all if c})
+}
+
 # --- validation ------------------------------------------------------------
 validate = lambda spec: {str:} -> bool {
     """Rules that must hold before anything is emitted.

--- a/crossplane/xplane-management-plane/logic_test.k
+++ b/crossplane/xplane-management-plane/logic_test.k
@@ -128,3 +128,37 @@ test_provider_config_readiness_is_not_alltrue = lambda {
     assert l.providerConfigReadiness.policy != "AllTrue"
     assert l.providerConfigReadiness.policy != "SuccessfulCreate"
 }
+
+test_crd_name_is_derived_from_the_provider_config = lambda {
+    """Das Gate braucht den CRD-Namen der ProviderConfig, nicht den eines Pakets.
+
+    Ein Provider-Paket meldet Healthy, BEVOR seine CRDs ausgeliefert werden.
+    crossplane-configurations#294.
+    """
+    assert l.providerConfigCrd({apiVersion = "helm.m.crossplane.io/v1beta1", kind = "ClusterProviderConfig"}) == "clusterproviderconfigs.helm.m.crossplane.io"
+    assert l.providerConfigCrd({apiVersion = "kubernetes.m.crossplane.io/v1alpha1", kind = "ClusterProviderConfig"}) == "clusterproviderconfigs.kubernetes.m.crossplane.io"
+    assert l.providerConfigCrd({apiVersion = "opentofu.m.upbound.io/v1beta1", kind = "ClusterProviderConfig"}) == "clusterproviderconfigs.opentofu.m.upbound.io"
+    assert l.providerConfigCrd({apiVersion = "x.example.com/v1", kind = "ProviderConfig"}) == "providerconfigs.x.example.com"
+}
+
+test_unmapped_kind_is_not_gated_instead_of_guessed = lambda {
+    """Ein unbekanntes kind liefert "" — der Aufrufer wartet dann NICHT darauf.
+
+    Einen Plural zu raten ist der Weg, auf eine CRD zu warten, die nie so hiess.
+    """
+    assert l.providerConfigCrd({apiVersion = "x.example.com/v1", kind = "Etwas"}) == ""
+    assert l.providerConfigCrds([{apiVersion = "x.example.com/v1", kind = "Etwas"}]) == []
+}
+
+test_crd_list_is_deduplicated_and_stable = lambda {
+    """Zwei ProviderConfigs derselben Gruppe ergeben EIN Observe-Object."""
+    _pcs = [
+        {apiVersion = "helm.m.crossplane.io/v1beta1", kind = "ClusterProviderConfig"}
+        {apiVersion = "helm.m.crossplane.io/v1beta1", kind = "ClusterProviderConfig"}
+        {apiVersion = "kubernetes.m.crossplane.io/v1alpha1", kind = "ClusterProviderConfig"}
+    ]
+    assert l.providerConfigCrds(_pcs) == [
+        "clusterproviderconfigs.helm.m.crossplane.io"
+        "clusterproviderconfigs.kubernetes.m.crossplane.io"
+    ]
+}

--- a/crossplane/xplane-management-plane/main.k
+++ b/crossplane/xplane-management-plane/main.k
@@ -64,9 +64,54 @@ _pcName = lambda i: int, pc -> str {
 }
 _pcObs = [x for i, pc in _profile.providerConfigs for x in _byName(_pcName(i, pc))]
 
+# --- CRD watch: the gate the ProviderConfigs really need --------------------
+# Observe-only Objects on the CRDs the ProviderConfigs belong to. A package is
+# Healthy before its CRDs are served, so package health alone opens the gate too
+# early -- see logic.providerConfigCrd for what that costs. #294.
+_crds = l.providerConfigCrds(_profile.providerConfigs)
+_crdName = lambda crd: str -> str {
+    "{}-crd-{}".format(_name, crd.split(".")[1])
+}
+_crdObserveObject = lambda crd: str -> any {
+    {
+        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+        kind = "Object"
+        metadata = {
+            name = _crdName(crd)
+            namespace = _xrNs
+            annotations = {"krm.kcl.dev/composition-resource-name" = _crdName(crd)}
+        }
+        spec = {
+            managementPolicies = ["Observe"]
+            providerConfigRef.name = l.kubernetesRef(_spec)
+            # Metadata only, and that survives the verify pipeline for a
+            # reason worth knowing: kubeconform ships NO schema for
+            # CustomResourceDefinition, so with -ignore-missing-schemas it is
+            # Skipped rather than validated. Should a CRD schema ever land in
+            # that set, this would start failing -- CRD v1 requires `spec` --
+            # exactly like the metadata-only Deployment did in xplane-platform
+            # 0.22.0. The fix then is a minimal valid spec here, never dropping
+            # -strict.
+            forProvider.manifest = {
+                apiVersion = "apiextensions.k8s.io/v1"
+                kind = "CustomResourceDefinition"
+                metadata = {name = crd}
+            }
+        }
+    }
+}
+
+# Established, not merely present: a CRD exists for a moment before the API
+# server serves it, and that moment is exactly the window we are closing.
+_crdEstablished = lambda crd: str -> bool {
+    _obs = _byName(_crdName(crd))
+    len([c for o in _obs for c in (o?.status?.atProvider?.manifest?.status?.conditions or []) if c?.type == "Established" and c?.status == "True"]) > 0
+}
+_crdsReady = len([c for c in _crds if _crdEstablished(c)]) == len(_crds)
+
 # --- gates ------------------------------------------------------------------
 _pkgOpen = l.packagesOpen(_coreReady, len(_pkgObs))
-_pcOpen = l.providerConfigsOpen(_pkgReady, len(_pcObs))
+_pcOpen = l.providerConfigsOpen(_pkgReady and _crdsReady, len(_pcObs))
 
 # --- 1) Crossplane core -----------------------------------------------------
 _core = {
@@ -246,4 +291,4 @@ _status = {
     }
 }
 
-items = [_core] + ([_rbac] if l.clusterAdminEnabled(_spec) else []) + ([_packageObject(p) for p in _packages] if _pkgOpen else []) + ([_providerConfigObject(i, pc) for i, pc in _profile.providerConfigs] if _pcOpen else []) + [_status]
+items = [_core] + ([_rbac] if l.clusterAdminEnabled(_spec) else []) + ([_packageObject(p) for p in _packages] if _pkgOpen else []) + ([_crdObserveObject(c) for c in _crds] if _pkgOpen else []) + ([_providerConfigObject(i, pc) for i, pc in _profile.providerConfigs] if _pcOpen else []) + [_status]


### PR DESCRIPTION
Behebt die Ursache aus crossplane-configurations#294, die uns bei jedem **Erstbau** trifft — also genau bei Seed und Machinery-Cluster aus #258.

## Das Problem

Ein Provider-**Paket** meldet `Healthy`, *bevor* seine CRDs ausgeliefert werden. Das Gate wartete auf Paket-Health:

```
mgmt-test1    pc-1 erzeugt 15:59:57 → Ressource sofort   → Ready=True nach 3 s
u26-rke2-1    pc-1 erzeugt 11:35:04 → Ressource 11:37:05 → Ready=False seit 11:37:05
```

Zwei Minuten Fenster. Für sich ein Schluckauf — dauerhaft wird es durch provider-kubernetes: scheitert der erste Create, bleibt das Object **für immer** `Ready=False/Creating`, obwohl jeder spätere Reconcile gelingt und die Ressource nachweislich existiert. 30 Stunden falsches `Ready=False`, und in einer ClusterStack mit `ManagementPlane`-Kind würde es die ganze Stack blockieren.

## Die Änderung

Das Gate wartet jetzt darauf, dass die CRD auf dem **Ziel** `Established` ist — über Observe-only Objects, dasselbe Muster wie das cert-manager-Gate in xplane-platform 0.22.1.

Drei Entwurfsentscheidungen, jede mit einem Test:

**Abgeleitet aus der ProviderConfig, nicht aus einem Paket.** Die Frage ist „kann ich *dieses* kind anlegen", und das ist eine Eigenschaft seiner eigenen Gruppe — nicht davon, welche CRDs irgendein Paket registriert. Der Katalog hat zwar ein `providerCrd`-Feld am `Package`, aber das beantwortet die andere Frage.

**Kein Raten.** Nur `ClusterProviderConfig` und `ProviderConfig` sind gemappt. Ein unbekanntes kind liefert `""` und wird dann **nicht** gegated. Einen Plural zu raten ist der Weg, auf eine CRD zu warten, die nie so hieß.

**`Established`, nicht bloße Existenz.** Eine CRD existiert einen Moment, bevor der API-Server sie ausliefert — und genau dieser Moment ist das Fenster, das wir schließen.

## Warum das metadata-only Manifest die Pipeline passiert

Nachgemessen, nicht angenommen:

```
CRD         → Skipped   "could not find schema for CustomResourceDefinition"
Deployment  → Invalid   "missing property 'spec'"
```

kubeconform kennt **kein** Schema für `CustomResourceDefinition`, es wird mit `-ignore-missing-schemas` also übersprungen statt validiert. Käme je eines dazu, würde es scheitern — CRD v1 verlangt `spec` —, genau wie das metadata-only Deployment in xplane-platform 0.22.0, das mich heute früh einen CI-Durchlauf gekostet hat. Das steht als Kommentar im Code, samt Fix für den Fall.

## Tests

`kcl test` **19/19**, drei neue Fälle. Bestehender Bestand unverändert grün.

## Was das nicht löst

Ursache 2 aus #294 — dass provider-kubernetes `Creating` nie revidiert — bleibt. Das gehört upstream gemeldet. Diese Änderung sorgt dafür, dass wir nicht mehr hineinlaufen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi