### PR TITLE
fix(management-plane): CRD-Observe braucht providerConfigRef.kind (0.5.1)

### DIFF
--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-management-plane"
 edition = "v0.12.3"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.2.0" }

--- a/crossplane/xplane-management-plane/logic.k
+++ b/crossplane/xplane-management-plane/logic.k
@@ -124,6 +124,44 @@ providerConfigCrd = lambda pc -> str {
     "{}.{}".format(_plural, _group) if _plural else ""
 }
 
+# The Observe-only Object that watches one CRD on the target.
+#
+# Lives here, not in main.k, so its SHAPE is testable. It was not, and the first
+# version shipped without providerConfigRef.kind: provider-kubernetes then looked
+# for a namespaced ProviderConfig, found none, and never created the Object at
+# all -- while the XR dutifully listed it in resourceRefs and reported "Unsynced
+# resources" for something that did not exist. Every unit test was green.
+crdObserveObject = lambda name: str, ns: str, crd: str, pcRef: str -> any {
+    {
+        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+        kind = "Object"
+        metadata = {
+            name = name
+            namespace = ns
+            annotations = {"krm.kcl.dev/composition-resource-name" = name}
+        }
+        spec = {
+            managementPolicies = ["Observe"]
+            # kind is NOT optional -- see above.
+            providerConfigRef = {
+                name = pcRef
+                kind = "ClusterProviderConfig"
+            }
+            # Metadata only, and that survives the verify pipeline for a reason
+            # worth knowing: kubeconform ships NO schema for
+            # CustomResourceDefinition, so with -ignore-missing-schemas it is
+            # Skipped rather than validated. Should a CRD schema ever land in
+            # that set this would start failing -- CRD v1 requires `spec` --
+            # exactly like the metadata-only Deployment in xplane-platform 0.22.0.
+            forProvider.manifest = {
+                apiVersion = "apiextensions.k8s.io/v1"
+                kind = "CustomResourceDefinition"
+                metadata = {name = crd}
+            }
+        }
+    }
+}
+
 # Distinct CRDs to wait for, in stable order.
 providerConfigCrds = lambda pcs: [any] -> [str] {
     _all = [providerConfigCrd(pc) for pc in pcs]

--- a/crossplane/xplane-management-plane/logic_test.k
+++ b/crossplane/xplane-management-plane/logic_test.k
@@ -162,3 +162,38 @@ test_crd_list_is_deduplicated_and_stable = lambda {
         "clusterproviderconfigs.kubernetes.m.crossplane.io"
     ]
 }
+
+test_crd_observe_object_names_a_cluster_provider_config = lambda {
+    """providerConfigRef.kind darf NICHT fehlen.
+
+    Ohne kind sucht provider-kubernetes eine NAMESPACED ProviderConfig, findet
+    keine und legt das Object gar nicht erst an — waehrend die XR es brav in
+    resourceRefs fuehrt und "Unsynced resources" fuer etwas meldet, das es nicht
+    gibt. Genau so ist 0.5.0 ausgeliefert worden, mit gruenen Unit-Tests.
+    """
+    _o = l.crdObserveObject("x-crd-helm", "default", "clusterproviderconfigs.helm.m.crossplane.io", "ziel-kubernetes")
+    assert _o.spec.providerConfigRef.kind == "ClusterProviderConfig"
+    assert _o.spec.providerConfigRef.name == "ziel-kubernetes"
+}
+
+test_crd_observe_object_observes_and_never_writes = lambda {
+    """Observe-only, und das Manifest identifiziert nur — es beschreibt nicht.
+
+    Eine managementPolicy, die schreiben darf, wuerde hier eine echte CRD auf
+    dem Ziel mit einem leeren Manifest ueberschreiben.
+    """
+    _o = l.crdObserveObject("x-crd-helm", "default", "clusterproviderconfigs.helm.m.crossplane.io", "ziel-kubernetes")
+    assert _o.spec.managementPolicies == ["Observe"]
+    _m = _o.spec.forProvider.manifest
+    assert _m.apiVersion == "apiextensions.k8s.io/v1"
+    assert _m.kind == "CustomResourceDefinition"
+    assert _m.metadata.name == "clusterproviderconfigs.helm.m.crossplane.io"
+    assert "spec" not in _m
+}
+
+test_crd_observe_object_carries_the_composition_resource_name = lambda {
+    """Ohne die Annotation ordnet Crossplane das Object bei jedem Render neu zu."""
+    _o = l.crdObserveObject("x-crd-helm", "default", "c.helm.m.crossplane.io", "ziel")
+    assert _o.metadata.annotations["krm.kcl.dev/composition-resource-name"] == "x-crd-helm"
+    assert _o.metadata.namespace == "default"
+}

--- a/crossplane/xplane-management-plane/main.k
+++ b/crossplane/xplane-management-plane/main.k
@@ -73,32 +73,7 @@ _crdName = lambda crd: str -> str {
     "{}-crd-{}".format(_name, crd.split(".")[1])
 }
 _crdObserveObject = lambda crd: str -> any {
-    {
-        apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
-        kind = "Object"
-        metadata = {
-            name = _crdName(crd)
-            namespace = _xrNs
-            annotations = {"krm.kcl.dev/composition-resource-name" = _crdName(crd)}
-        }
-        spec = {
-            managementPolicies = ["Observe"]
-            providerConfigRef.name = l.kubernetesRef(_spec)
-            # Metadata only, and that survives the verify pipeline for a
-            # reason worth knowing: kubeconform ships NO schema for
-            # CustomResourceDefinition, so with -ignore-missing-schemas it is
-            # Skipped rather than validated. Should a CRD schema ever land in
-            # that set, this would start failing -- CRD v1 requires `spec` --
-            # exactly like the metadata-only Deployment did in xplane-platform
-            # 0.22.0. The fix then is a minimal valid spec here, never dropping
-            # -strict.
-            forProvider.manifest = {
-                apiVersion = "apiextensions.k8s.io/v1"
-                kind = "CustomResourceDefinition"
-                metadata = {name = crd}
-            }
-        }
-    }
+    l.crdObserveObject(_crdName(crd), _xrNs, crd, _k8sPcr)
 }
 
 # Established, not merely present: a CRD exists for a moment before the API


### PR DESCRIPTION
Repariert einen Fehler aus **kcl#191** (0.5.0), der beim Ausrollen auf kind3 sofort aufgeschlagen ist.

## Was schiefging

Das neue Observe-Object wurde ohne `providerConfigRef.kind` gerendert. provider-kubernetes sucht dann eine **namespaced** ProviderConfig, findet keine — und legt das Object gar nicht erst an. Die XR führt es trotzdem in `resourceRefs` und meldet:

```
Unsynced resources: u26-rke2-1-mgmt-crd-helm, u26-rke2-1-mgmt-crd-kubernetes,
                    u26-rke2-1-mgmt-crd-opentofu
```

Drei Objekte, die nicht existieren. `u26-rke2-1-mgmt` stand danach auf `Synced=False / Ready=False`.

```diff
-providerConfigRef.name = _k8sPcr
+providerConfigRef = {
+    name = _k8sPcr
+    kind = "ClusterProviderConfig"
+}
```

Die bestehenden ProviderConfig-Objects im selben Modul setzen `kind` seit jeher — ich habe die Form nicht abgeglichen.

## Der eigentliche Befund

**Alle 19 Unit-Tests waren grün, während das Modul kaputt war.** `main_test.k` ist leer (0 Bytes); getestet wurden nur die Helfer in `logic.k`, nie die gerenderte Form.

Der Objektbau wandert deshalb nach `logic.k`, wo er prüfbar ist, und bekommt drei Tests:

| Test | prüft |
|---|---|
| `..._names_a_cluster_provider_config` | `providerConfigRef.kind` ist gesetzt |
| `..._observes_and_never_writes` | `managementPolicies == ["Observe"]`, Manifest ohne `spec` |
| `..._carries_the_composition_resource_name` | die Annotation, ohne die Crossplane bei jedem Render neu zuordnet |

## Gegenprobe

Nicht behauptet, sondern ausprobiert — mit dem Bau aus 0.5.0:

```
test_crd_observe_object_names_a_cluster_provider_config: FAIL
PASS: 21/22
```

Mit dem Fix: **22/22**.

Der zweite Test ist der, der mir am wichtigsten ist: eine `managementPolicy`, die schreiben darf, würde hier eine echte CRD auf dem Zielcluster mit einem leeren Manifest überschreiben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi