### PR TITLE
feat(cluster): HarvesterVM als dritter Provider (0.10.0)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.9.0"
+version = "0.10.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -128,11 +128,50 @@ vmChild = lambda name: str, ns: str, spec: {str:any}, size: any -> {str:any} {
         }
     }
 
-    # The ONLY place the two providers differ: field names. Staging, gating and
+    # vsphere and proxmox differ only in FIELD NAMES; staging, gating and
     # everything downstream are identical (crossplane-configurations#168,
-    # option A).
+    # option A). Harvester breaks that symmetry and is therefore written out in
+    # full rather than folded into the others:
+    #
+    #   - the boot disk is a PVC of its own (`volume`), not a `disk` field
+    #   - cpu is an OBJECT (cores/sockets/threads), and the scheduler wants a
+    #     separate `resources.cpu` string on top of it
+    #   - memory is a quantity string, not a number of MiB
+    #   - cloud-init is a first-class block with a REQUIRED vmName/hostname
+    #   - ansible.enabled defaults to FALSE there, so the base-OS stage has to
+    #     be switched on explicitly or the cluster never gets provisioned
+    #
+    # Sizes are strings in the catalog (cpu "4", memory "8192" MiB, disk "64"
+    # GiB); the suffixes below are what turns them into Kubernetes quantities.
     _res = {
-        if _provider == "vsphere":
+        if _provider == "harvester":
+            apiVersion = "resources.stuttgart-things.com/v1alpha1"
+            kind = "HarvesterVM"
+            spec = {
+                environmentConfig = spec?.environmentConfig or "labul"
+                volume = {
+                    pvcName = "{}-disk-0".format(_cluster)
+                    storage = "{}Gi".format(size.disk)
+                    if _vm?.imageId:
+                        imageId = _vm.imageId
+                }
+                cloudInit = {
+                    vmName = _cluster
+                    hostname = _cluster
+                }
+                vm = {
+                    cpu.cores = int(size.cpu)
+                    resources = {
+                        cpu = size.cpu
+                        memory = "{}Mi".format(size.memory)
+                    }
+                }
+                # NOT optional: the XRD defaults this to false, and without it
+                # the VM comes up bare -- no base OS, no kubernetes, and the
+                # ClusterStack waits forever on a stage that was never emitted.
+                ansible = _ansible | {enabled = True}
+            }
+        elif _provider == "vsphere":
             apiVersion = "resources.stuttgart-things.com/v1alpha1"
             kind = "NativeVsphereVM"
             spec = {
@@ -461,7 +500,12 @@ usage = lambda ofKind: str, ofName: str, byKind: str, byName: str, label: str, r
         spec = {
             replayDeletion = replay
             of = {
-                apiVersion = "resources.stuttgart-things.com/v1alpha1" if ofKind in ["NativeProxmoxVM", "NativeVsphereVM"] else "config.stuttgart-things.com/v1alpha1"
+                # HarvesterVM lives in the same group as the two native VMs.
+                # Forgetting it here does not fail loudly -- it emits a Usage
+                # pointing at config.stuttgart-things.com/HarvesterVM, a kind
+                # that does not exist, and the protection silently guards
+                # nothing.
+                apiVersion = "resources.stuttgart-things.com/v1alpha1" if ofKind in ["NativeProxmoxVM", "NativeVsphereVM", "HarvesterVM"] else "config.stuttgart-things.com/v1alpha1"
                 kind = ofKind
                 resourceRef.name = ofName
             }

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -578,3 +578,48 @@ test_access_xr_carries_the_derived_ref = lambda {
     _a = l.clusterAccess("c", "default", {clusterName = "c", kubeconfig = {vaultSecretName = "vault-infra"}})
     assert _a.spec.kubeconfigProviderConfigRef == "vault-kubeconfigs-infra"
 }
+
+test_harvester_vm_is_composed_with_its_own_shape = lambda {
+    """Harvester ist nicht nur ein anderer Name — die Form ist anders.
+
+    Boot-Disk als eigenes PVC, cpu als Objekt, Speicher als Quantity-String,
+    cloud-init mit Pflichtfeldern. crossplane-configurations#258 Block B.
+    """
+    _v = l.vmChild("c1", "default", {provider = "harvester", clusterName = "c1"}, cat.getSize("medium"))
+    assert _v.kind == "HarvesterVM"
+    assert _v.apiVersion == "resources.stuttgart-things.com/v1alpha1"
+    assert _v.spec.volume.pvcName == "c1-disk-0"
+    assert _v.spec.volume.storage == "64Gi"
+    assert _v.spec.vm.cpu.cores == 4
+    assert _v.spec.vm.resources.cpu == "4"
+    assert _v.spec.vm.resources.memory == "8192Mi"
+    assert _v.spec.cloudInit.vmName == "c1"
+    assert _v.spec.cloudInit.hostname == "c1"
+}
+
+test_harvester_switches_ansible_on = lambda {
+    """ansible.enabled ist bei HarvesterVM per Default FALSE.
+
+    Bliebe es aus, kaeme die VM nackt hoch — kein Base-OS, kein Kubernetes —
+    und der ClusterStack wartete ewig auf eine Stufe, die nie emittiert wurde.
+    """
+    _v = l.vmChild("c1", "default", {provider = "harvester", clusterName = "c1"}, cat.getSize("medium"))
+    assert _v.spec.ansible.enabled == True
+}
+
+test_harvester_usage_points_at_the_right_group = lambda {
+    """Die Usage muss resources.* sagen, nicht config.*.
+
+    Ein falscher apiVersion faellt nicht auf: die Usage entsteht, zeigt auf ein
+    kind, das es nicht gibt, und schuetzt still gar nichts.
+    """
+    _u = l.usage("HarvesterVM", "c1-vm", "ClusterAccess", "c1-access", "access-uses-vm", True, "c1")
+    assert _u.spec.of.apiVersion == "resources.stuttgart-things.com/v1alpha1"
+    assert _u.spec.of.kind == "HarvesterVM"
+}
+
+test_proxmox_stays_the_default = lambda {
+    """Ein unbekannter oder fehlender provider bleibt proxmox."""
+    _v = l.vmChild("c1", "default", {clusterName = "c1"}, cat.getSize("small"))
+    assert _v.kind == "NativeProxmoxVM"
+}

--- a/crossplane/xplane-cluster/main.k
+++ b/crossplane/xplane-cluster/main.k
@@ -63,7 +63,11 @@ _byName = lambda name: str -> [any] {
     [v.Resource for _, v in _ocds if v?.Resource?.metadata?.name == name]
 }
 
-_vmKind = "NativeVsphereVM" if (_spec?.provider or "proxmox") == "vsphere" else "NativeProxmoxVM"
+_provider = _spec?.provider or "proxmox"
+_vmKind = {
+    "vsphere" = "NativeVsphereVM"
+    "harvester" = "HarvesterVM"
+}[_provider] or "NativeProxmoxVM"
 _vmObs = _byKind(_vmKind)
 _vm = _vmObs[0] if _vmObs else {}
 _vmShare = _vm?.status?.share or {}


### PR DESCRIPTION
crossplane-configurations#258 Block B: ein `ClusterStack` soll auf Harvester bauen können. Die `harvester-vm` Configuration gibt es seit v0.1.9 — der ClusterStack kannte sie nur nicht.

## Harvester bricht die Symmetrie

Der Kommentar im Code sagte bisher *„The ONLY place the two providers differ: field names"* — und das stimmte für vsphere und proxmox. Für Harvester nicht:

```
volume     (Pflicht)   Boot-Disk als eigenes PVC, kein `disk`-Feld
vm.cpu     Objekt      cores/sockets/threads statt einer Zahl
vm.resources           zusätzlich cpu-String und memory als Quantity
cloudInit  (Pflicht)   eigener Block mit Pflichtfeldern vmName/hostname
ansible.enabled        Default FALSE
```

Deshalb ist der Zweig ausgeschrieben statt in die anderen gefaltet — der Kommentar sagt jetzt auch, warum.

**Der letzte Punkt ist der gefährliche.** Bliebe `ansible.enabled` aus, käme die VM nackt hoch: kein Base-OS, kein Kubernetes — und der ClusterStack wartete ewig auf eine Stufe, die nie emittiert wurde. Genau die Sorte Fehler, die nichts meldet. Der Zweig setzt ihn explizit, mit eigenem Test.

Größen sind im Katalog Strings (`cpu "4"`, `memory "8192"` MiB, `disk "64"` GiB); die Suffixe im Zweig machen daraus Kubernetes-Quantities:

```
size.cpu    "4"     → vm.cpu.cores 4  +  vm.resources.cpu "4"
size.memory "8192"  → vm.resources.memory "8192Mi"
size.disk   "64"    → volume.storage "64Gi"
```

## Eine Stelle, die man leicht übersieht

`HarvesterVM` liegt in derselben API-Gruppe wie die beiden nativen VMs. Die Usage-Funktion leitet den `apiVersion` aus einer Liste ab, die nur die beiden kannte:

```diff
-if ofKind in ["NativeProxmoxVM", "NativeVsphereVM"]
+if ofKind in ["NativeProxmoxVM", "NativeVsphereVM", "HarvesterVM"]
```

Ohne das entsteht eine Usage auf `config.stuttgart-things.com/HarvesterVM` — ein kind, das es nicht gibt. Die Usage wäre da, sähe richtig aus und schützte still gar nichts. Eigener Test dafür.

## Tests

`kcl test` **56/56**, vier neue Fälle: die Form, das eingeschaltete `ansible`, die Usage-Gruppe, und dass `proxmox` der Default bleibt.

## Danach

Die `cluster`-XRD muss `harvester` ins `provider`-Enum aufnehmen, sonst lehnt die Admission es ab — folgt im Configuration-Repo. Und ein `EnvironmentConfig` für die Platzierung, analog zu `proxmoxvm-labul`; ohne den weiß Harvester nicht, welche StorageClass und welches Image gemeint sind. Beides ist noch nicht gegen echte Hardware geprüft — das HW-Lab steht dafür noch aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi