### PR TITLE
feat(cluster): vault-labda ins kubeconfig-Vault-Mapping (0.11.0)

### DIFF
--- a/crossplane/xplane-cluster/kcl.mod
+++ b/crossplane/xplane-cluster/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-cluster"
 edition = "v0.12.3"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
 xplane-cluster-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-cluster-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-cluster/logic.k
+++ b/crossplane/xplane-cluster/logic.k
@@ -353,6 +353,12 @@ kubeconfigRun = lambda name: str, ns: str, spec: {str:any}, ip: str -> {str:any}
 kubeconfigVaultPairs: {str:str} = {
     "vault" = "vault-kubeconfigs"
     "vault-infra" = "vault-kubeconfigs-infra"
+    # LabDA, 2026-08-20. Eigener Vault (vault-vsphere.tiab.labda.sva.de), NICHT
+    # einer der beiden LabUL-Vaults: LabUL-vSphere wird abgeschaltet, und ein
+    # LabDA-Cluster soll seinen kubeconfig nicht dort ablegen. Der Eintrag hier
+    # ist das, was den Aufrufer davon befreit, kubeconfig.providerConfigRef von
+    # Hand zu setzen -- und genau dieses Handsetzen ist in #336 schiefgegangen.
+    "vault-labda" = "vault-kubeconfigs-labda"
 }
 
 kubeconfigReadRef = lambda kc: {str:} -> str {

--- a/crossplane/xplane-cluster/logic_test.k
+++ b/crossplane/xplane-cluster/logic_test.k
@@ -556,6 +556,21 @@ test_read_ref_is_derived_from_the_upload_target = lambda {
     assert l.kubeconfigReadRef({}) == "vault-kubeconfigs"
     assert l.kubeconfigReadRef({vaultSecretName = "vault"}) == "vault-kubeconfigs"
     assert l.kubeconfigReadRef({vaultSecretName = "vault-infra"}) == "vault-kubeconfigs-infra"
+    assert l.kubeconfigReadRef({vaultSecretName = "vault-labda"}) == "vault-kubeconfigs-labda"
+}
+
+test_labda_pair_needs_no_explicit_ref = lambda {
+    """LabDA ohne providerConfigRef von Hand.
+
+    Der Punkt des Map-Eintrags: ein LabDA-ClusterStack nennt nur
+    vaultSecretName, und die Leseseite folgt. Wer hier von Hand nachhelfen
+    muesste, koennte die beiden Seiten wieder auseinanderlaufen lassen -- der
+    Fehler aus #336, der 40 Minuten gekostet hat, weil der ClusterStack dabei
+    Ready=True bleibt.
+    """
+    _spec = {clusterName = "seed", kubeconfig = {vaultSecretName = "vault-labda"}}
+    _a = l.clusterAccess("seed", "crossplane-system", _spec)
+    assert _a.spec.kubeconfigProviderConfigRef == "vault-kubeconfigs-labda"
 }
 
 test_explicit_read_ref_still_wins = lambda {


### PR DESCRIPTION
LabDA bekommt eigene Cluster ([crossplane-configurations#258](https://github.com/stuttgart-things/crossplane-configurations/issues/258)) und einen **eigenen kubeconfig-Vault**: `vault-vsphere.tiab.labda.sva.de`.

Ohne Eintrag in `kubeconfigVaultPairs` muesste jeder LabDA-`ClusterStack` `kubeconfig.providerConfigRef` von Hand setzen — und genau dieses Handsetzen ist in [#336](https://github.com/stuttgart-things/crossplane-configurations/issues/336) auseinandergelaufen: Upload-Seite auf den einen Vault, Leseseite auf den anderen, der `RemoteCluster` fand nichts, und der `ClusterStack` blieb dabei `Ready=True`, weil ohne fertige `ClusterAccess` der Platform-Zweig gar nicht erst emittiert wird. 40 Minuten Suche.

**Warum ein eigener Vault** und nicht einer der beiden LabUL-Vaults: LabUL-vSphere wird in den naechsten Wochen abgeschaltet. Ein LabDA-Cluster soll seinen kubeconfig nicht in etwas Sterbendem ablegen.

**Vorab geprueft, nicht angenommen:**

- AppRole-Login gegen `vault-vsphere.tiab.labda.sva.de:8200` — OK, Policy `superuser`
- Mount `kubeconfigs/` vorhanden
- Port 8200 erreichbar

**Tests:** zwei neue — das Mapping selbst, und die Probe, dass der abgeleitete Wert auch wirklich an der `ClusterAccess`-XR ankommt. `PASS: 57/57`.

Gegenstueck im Chart `provider-kubeconfig-vault` (additionalVaults + CA-Bundle) und in der `cluster`-Configuration (CEL-Regel) folgt getrennt.

`0.10.0` → `0.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi