### PR TITLE
feat(catalog): machinery-Profil auf den Fleet-Stand (0.3.0)

### DIFF
--- a/crossplane/xplane-crossplane-catalog/catalog_test.k
+++ b/crossplane/xplane-crossplane-catalog/catalog_test.k
@@ -130,10 +130,43 @@ test_get_rejects_an_unknown_profile = lambda {
 # A management cluster must be able to build FURTHER management clusters — that
 # is what makes the seed disposable rather than load-bearing forever. It needs
 # cluster >=v0.4.0 (spec.managementPlaneEnabled) and management-plane behind it.
+#
+# UNTERGRENZE, KEIN EXAKTER PIN. Bis 2026-08-20 stand hier
+# `endswith(":v0.4.0")`, und das hat die Aussage des Tests verdreht: gepruefte
+# Absicht ist "kann Control Planes bauen", nicht "traegt genau diesen Tag". Ein
+# Bump des Katalogs liess den Test rot werden, obwohl die Faehigkeit erhalten
+# blieb — ein Test, der beim Richtigmachen bricht, wird irgendwann angepasst
+# statt gelesen.
 test_the_profile_can_build_control_planes = lambda {
     _p = c.get("machinery")
     _cl = [x for x in _p.packages if x.name.endswith("-cluster")][0]
-    assert _cl.package.endswith(":v0.4.0")
+    _v = [int(n) for n in _cl.package.split(":v")[1].split(".")]
+    assert _v[0] > 0 or _v[1] >= 4, "cluster muss >= v0.4.0 sein (spec.managementPlaneEnabled)"
     assert "management-plane" in _cl.pulls
     assert "management-plane" in c.transitive(_p)
+}
+
+# Die zweite Untergrenze, und der Grund, warum der Katalog am 2026-08-20
+# ueberhaupt angefasst wurde: erst cluster v0.6.0 kennt `harvester` im
+# Provider-Enum und erst v0.6.1 das Vault-Paar vault-labda ->
+# vault-kubeconfigs-labda. Ein Seed unterhalb davon kann die LabDA-Cluster
+# nicht bauen, fuer die er aufgestellt wird (crossplane-configurations#258).
+test_the_profile_can_build_in_labda = lambda {
+    _p = c.get("machinery")
+    _cl = [x for x in _p.packages if x.name.endswith("-cluster")][0]
+    _v = [int(n) for n in _cl.package.split(":v")[1].split(".")]
+    assert _v[0] > 0 or _v[1] > 6 or (_v[1] == 6 and _v[2] >= 1), "cluster muss >= v0.6.1 sein (vault-labda, harvester)"
+}
+
+# harvester-vm gehoert ins Profil, weil das machinery-Playbook es auf jeden
+# Machinery-Cluster legt. Fehlte bis 2026-08-20 — der Katalog beschrieb eine
+# Machinery, die es so nicht gibt.
+test_harvester_is_part_of_a_machinery = lambda {
+    _p = c.get("machinery")
+    _hv = [x for x in _p.packages if x.name.endswith("-harvester-vm")]
+    assert len(_hv) == 1, "harvester-vm fehlt im machinery-Profil"
+    # Kein providerCrd: rendert ueber provider-kubernetes, registriert keinen
+    # eigenen Provider. Ein gesetztes Feld hier waere ein Wartefehler beim
+    # Bootstrap.
+    assert not _hv[0]?.providerCrd
 }

--- a/crossplane/xplane-crossplane-catalog/catalog_test.k
+++ b/crossplane/xplane-crossplane-catalog/catalog_test.k
@@ -165,6 +165,7 @@ test_harvester_is_part_of_a_machinery = lambda {
     _p = c.get("machinery")
     _hv = [x for x in _p.packages if x.name.endswith("-harvester-vm")]
     assert len(_hv) == 1, "harvester-vm fehlt im machinery-Profil"
+
     # Kein providerCrd: rendert ueber provider-kubernetes, registriert keinen
     # eigenen Provider. Ein gesetztes Feld hier waere ein Wartefehler beim
     # Bootstrap.

--- a/crossplane/xplane-crossplane-catalog/kcl.mod
+++ b/crossplane/xplane-crossplane-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-crossplane-catalog"
 edition = "v0.12.3"
-version = "0.2.0"
+version = "0.3.0"

--- a/crossplane/xplane-crossplane-catalog/profiles/machinery.k
+++ b/crossplane/xplane-crossplane-catalog/profiles/machinery.k
@@ -96,7 +96,11 @@ machinery: s.Profile = {
         s.Package {
             kind = "Configuration"
             name = "stuttgart-things-crossplane-configurations-platform"
-            package = "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.11"
+            # v0.6.2, nicht v0.3.11: der Katalog war gegenueber dem
+            # Referenz-Cluster u26-kind3 vier Configurations weit
+            # zurueckgefallen (2026-08-20 abgeglichen). Ein Profil, das
+            # beschreibt, was eine Machinery IST, darf das nicht.
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.6.2"
             pulls = ["cni", "flux-init", "flux-apps", "ip-reservation", "vault-auth", "vault-pki-secrets"]
         }
         s.Package {
@@ -105,21 +109,51 @@ machinery: s.Profile = {
             # >=v0.4.0 carries spec.managementPlaneEnabled — without it a
             # management cluster built from this profile cannot build further
             # management clusters, only workload ones.
-            package = "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.4.0"
+            #
+            # v0.6.1 ist aus demselben Grund ein Muss, eine Ebene weiter: erst
+            # v0.6.0 kennt `harvester` im Provider-Enum und erst v0.6.1 das
+            # Vault-Paar vault-labda -> vault-kubeconfigs-labda. Ein Seed auf
+            # v0.4.0 kann also genau die LabDA-Cluster NICHT bauen, fuer die er
+            # aufgestellt wird — aufgefallen beim ersten LabDA-Seed
+            # (crossplane-configurations#258, 2026-08-20).
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/cluster:v0.6.1"
             pulls = ["platform", "remote-cluster", "vspherevm", "proxmoxvm", "ansible-run", "management-plane"]
         }
         s.Package {
             kind = "Configuration"
             name = "stuttgart-things-crossplane-configurations-vspherevm"
-            package = "ghcr.io/stuttgart-things/crossplane-configurations/vspherevm:v0.9.0"
+            # v0.9.2 NICHT v0.9.0: v0.9.0 reicht spec.environmentConfig an die
+            # emittierte AnsibleRun durch. Das benennt eine Hypervisor-Env, die
+            # ansible-run gegen sein EIGENES Label aufloest, wo es sie nicht
+            # gibt — jeder ansible-run-Default faellt still weg,
+            # ansibleExtraCollections eingeschlossen, und der Base-OS-Lauf
+            # scheitert an einer Collection-Version. crossplane-configurations#347.
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/vspherevm:v0.9.2"
             providerCrd = "clusterproviderconfigs.vspherevm.m.stuttgart-things.com"
             pulls = ["ansible-run"]
         }
         s.Package {
             kind = "Configuration"
             name = "stuttgart-things-crossplane-configurations-proxmoxvm"
-            package = "ghcr.io/stuttgart-things/crossplane-configurations/proxmoxvm:v0.11.0"
+            # v0.12.2: v0.12.0 trennt templateNode vom Ziel-Node, v0.12.2 nimmt
+            # denselben environmentConfig-Durchreicher heraus wie vspherevm
+            # v0.9.2 oben (crossplane-configurations#347).
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/proxmoxvm:v0.12.2"
             pulls = ["ansible-run"]
+        }
+        # Dritter Hypervisor neben vSphere und Proxmox. Stand im Profil bisher
+        # gar nicht, obwohl das machinery-Playbook ihn auf jeden Machinery-
+        # Cluster legt — der Katalog beschrieb also eine Machinery, die es so
+        # nicht gibt.
+        #
+        # KEIN providerCrd, und das ist kein Versehen: harvester-vm rendert eine
+        # KubeVirt VirtualMachine ueber provider-kubernetes und registriert
+        # keinen eigenen Provider.
+        s.Package {
+            kind = "Configuration"
+            name = "stuttgart-things-crossplane-configurations-harvester-vm"
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/harvester-vm:v0.1.9"
+            pulls = ["volume-claim", "cloud-config", "ansible-run"]
         }
         s.Package {
             kind = "Configuration"


### PR DESCRIPTION
Das `machinery`-Profil war gegenueber dem Referenz-Cluster u26-kind3 vier Configurations weit zurueckgefallen und trug eine fuenfte gar nicht:

| Configuration | Katalog | live kind3 | |
|---|---|---|---|
| `platform` | v0.3.11 | v0.6.2 | → **v0.6.2** |
| `cluster` | v0.4.0 | v0.6.1 | → **v0.6.1** |
| `proxmoxvm` | v0.11.0 | v0.12.2 | → **v0.12.2** |
| `vspherevm` | v0.9.0 | v0.9.2 | → **v0.9.2** |
| `harvester-vm` | — | v0.1.9 | → **neu** |

Die uebrigen sieben stimmten.

## Wie es aufgefallen ist

Beim ersten LabDA-Seed ([crossplane-configurations#258](https://github.com/stuttgart-things/crossplane-configurations/issues/258)). Der Cluster kam mit `cluster:v0.4.0` hoch — also **ohne** `harvester` im Provider-Enum und **ohne** das Vault-Paar `vault-labda` → `vault-kubeconfigs-labda`. Er haette damit genau die LabDA-Cluster nicht bauen koennen, fuer die er aufgestellt wurde.

`vspherevm:v0.9.0` traegt zusaetzlich den `environmentConfig`-Durchreicher aus [crossplane-configurations#347](https://github.com/stuttgart-things/crossplane-configurations/pull/347): die emittierte `AnsibleRun` bekommt eine Hypervisor-Env, die `ansible-run` gegen sein eigenes Label aufloest, wo es sie nicht gibt — jeder ansible-run-Default faellt still weg, `ansibleExtraCollections` eingeschlossen, und der Base-OS-Lauf stirbt an einer Collection-Version.

`harvester-vm` fehlte ganz, obwohl das machinery-Playbook es auf jeden Machinery-Cluster legt. Der Katalog beschrieb also eine Machinery, die es so nicht gibt. Kein `providerCrd`, und das ist Absicht: harvester-vm rendert eine KubeVirt `VirtualMachine` ueber provider-kubernetes und registriert keinen eigenen Provider — ein gesetztes Feld waere ein Wartefehler beim Bootstrap.

## Ein Test, der beim Richtigmachen brach

`test_the_profile_can_build_control_planes` pinnte hart:

```kcl
assert _cl.package.endswith(":v0.4.0")
```

Das verdreht die Aussage des Tests. Sein eigener Kommentar sagt, geprueft werde „a management cluster must be able to build FURTHER management clusters … needs cluster >=v0.4.0" — also eine **Untergrenze**, keine Gleichheit. So geschrieben wird der Test bei jedem Katalog-Bump rot, obwohl die Faehigkeit erhalten bleibt; und ein Test, der beim Richtigmachen bricht, wird irgendwann angepasst statt gelesen. Jetzt vergleicht er die Version.

Zwei Tests dazu:
- `test_the_profile_can_build_in_labda` — `cluster >= v0.6.1`, die zweite Untergrenze und der eigentliche Anlass
- `test_harvester_is_part_of_a_machinery` — harvester-vm im Profil, und dass es kein `providerCrd` traegt

`PASS: 16/16`.

## Folgeschritte (getrennt, weil der Lock erst aufloest, wenn das hier publiziert ist)

1. `xplane-management-plane` 0.5.1 → 0.6.0 (Katalog-Dependency auf 0.3.0)
2. `management-plane` Configuration v0.3.1 → v0.3.2
3. Rollout auf kind3

**Blast radius, bewusst so entschieden:** `u26-rke2-1-mgmt` laeuft mit `compositionUpdatePolicy: Automatic` und zieht mit hoch. Sein `ClusterStack` ist zwar pausiert, das eigenstaendige `ManagementPlane`-XR aber nicht. Das ist gewollt — die Drift verschwindet, statt sich zu verfestigen.

`0.2.0` → `0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi