### PR TITLE
feat(management-plane): Katalog 0.3.0 (0.6.0)

### DIFF
--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-management-plane"
 edition = "v0.12.3"
-version = "0.5.1"
+version = "0.6.0"
 
 [dependencies]
-xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.2.0" }
+xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.3.0" }

--- a/crossplane/xplane-management-plane/kcl.mod.lock
+++ b/crossplane/xplane-management-plane/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-crossplane-catalog]
     name = "xplane-crossplane-catalog"
-    full_name = "xplane-crossplane-catalog_0.2.0"
-    version = "0.2.0"
-    sum = "m3nTr7+8Gk3KYoTzMlmL+zZitNgdkuoDChpoYfYz5YI="
+    full_name = "xplane-crossplane-catalog_0.3.0"
+    version = "0.3.0"
+    sum = "oCA22bbtPvqZ8Med0r498PGBeZG1mv+Pf5fH5bIbCDQ="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-crossplane-catalog"
-    oci_tag = "0.2.0"
+    oci_tag = "0.3.0"


### PR DESCRIPTION
Zieht das aktualisierte `machinery`-Profil aus [kcl#197](https://github.com/stuttgart-things/kcl/pull/197) nach:

| | |
|---|---|
| `platform` | v0.3.11 → v0.6.2 |
| `cluster` | v0.4.0 → v0.6.1 |
| `proxmoxvm` | v0.11.0 → v0.12.2 |
| `vspherevm` | v0.9.0 → v0.9.2 |
| `harvester-vm` | neu, v0.1.9 |

Der Anlass steht ausfuehrlich in kcl#197. Kurz: ein Seed auf `cluster:v0.4.0` kennt weder `harvester` im Provider-Enum noch das Vault-Paar `vault-labda` → `vault-kubeconfigs-labda`, koennte also genau die LabDA-Cluster nicht bauen, fuer die er aufgestellt wird — aufgefallen beim ersten LabDA-Seed ([crossplane-configurations#258](https://github.com/stuttgart-things/crossplane-configurations/issues/258)).

Reine Dependency-Anhebung, kein Code in diesem Modul. `PASS: 22/22`.

Getrennt von kcl#197, weil der Lock die Katalog-Version erst aufloest, wenn sie publiziert ist.

Naechster Schritt: `management-plane` Configuration v0.3.1 → v0.3.2 mit diesem Modul-Pin, dann Rollout.

`0.5.1` → `0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi