### PR TITLE
feat(catalog): proxmoxvm v0.13.0 (0.3.1)

### DIFF
--- a/crossplane/xplane-crossplane-catalog/kcl.mod
+++ b/crossplane/xplane-crossplane-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-crossplane-catalog"
 edition = "v0.12.3"
-version = "0.3.0"
+version = "0.3.1"

--- a/crossplane/xplane-crossplane-catalog/profiles/machinery.k
+++ b/crossplane/xplane-crossplane-catalog/profiles/machinery.k
@@ -135,10 +135,12 @@ machinery: s.Profile = {
         s.Package {
             kind = "Configuration"
             name = "stuttgart-things-crossplane-configurations-proxmoxvm"
-            # v0.12.2: v0.12.0 trennt templateNode vom Ziel-Node, v0.12.2 nimmt
-            # denselben environmentConfig-Durchreicher heraus wie vspherevm
-            # v0.9.2 oben (crossplane-configurations#347).
-            package = "ghcr.io/stuttgart-things/crossplane-configurations/proxmoxvm:v0.12.2"
+            # v0.12.0 trennt templateNode vom Ziel-Node, v0.12.2 nimmt denselben
+            # environmentConfig-Durchreicher heraus wie vspherevm v0.9.2 oben
+            # (crossplane-configurations#347), v0.13.0 macht den
+            # cloud-init-Datastore ueber die EnvironmentConfig setzbar
+            # (crossplane-configurations#350).
+            package = "ghcr.io/stuttgart-things/crossplane-configurations/proxmoxvm:v0.13.0"
             pulls = ["ansible-run"]
         }
         # Dritter Hypervisor neben vSphere und Proxmox. Stand im Profil bisher


### PR DESCRIPTION
[crossplane-configurations#350](https://github.com/stuttgart-things/crossplane-configurations/pull/350) macht den cloud-init-Datastore ueber die `EnvironmentConfig` setzbar.

Gemerged **wenige Minuten** nachdem [#197](https://github.com/stuttgart-things/kcl/pull/197) (0.3.0) das Profil auf v0.12.2 gehoben hatte — der Katalog war also sofort wieder hinterher.

Das ist symptomatisch und nicht durch schnelleres Hinterherbumpen zu loesen: **nichts koppelt das Profil an den Fleet-Stand.** Es driftet still, bis jemand zufaellig vergleicht. Genau so war es bei 0.2.0 vier Configurations weit gekommen (`cluster` v0.4.0 statt v0.6.1, `platform` v0.3.11 statt v0.6.2, …), ohne dass es auffiel — bis ein frischer Seed daran scheiterte und die LabDA-Cluster nicht bauen konnte, fuer die er aufgestellt war.

Der strukturelle Fix ist [crossplane-configurations#345](https://github.com/stuttgart-things/crossplane-configurations/issues/345) (Registry-Parity-Linter). Dieser PR ist die Handarbeit dazwischen.

`PASS: 16/16`

`0.3.0` → `0.3.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi