### PR TITLE
feat(management-plane): Katalog 0.3.1 (0.6.1)

### DIFF
--- a/crossplane/xplane-management-plane/kcl.mod
+++ b/crossplane/xplane-management-plane/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-management-plane"
 edition = "v0.12.3"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
-xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.3.0" }
+xplane-crossplane-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-crossplane-catalog", tag = "0.3.1" }

--- a/crossplane/xplane-management-plane/kcl.mod.lock
+++ b/crossplane/xplane-management-plane/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-crossplane-catalog]
     name = "xplane-crossplane-catalog"
-    full_name = "xplane-crossplane-catalog_0.3.0"
-    version = "0.3.0"
-    sum = "oCA22bbtPvqZ8Med0r498PGBeZG1mv+Pf5fH5bIbCDQ="
+    full_name = "xplane-crossplane-catalog_0.3.1"
+    version = "0.3.1"
+    sum = "gsA34MnqZEmw6Vk+i9NXGVpO/TvLV6lf/T7Jo9ZG1L8="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-crossplane-catalog"
-    oci_tag = "0.3.0"
+    oci_tag = "0.3.1"


### PR DESCRIPTION
Zieht [kcl#201](https://github.com/stuttgart-things/kcl/pull/201) nach: `proxmoxvm` v0.12.2 → **v0.13.0** (cloud-init-Datastore per EnvironmentConfig, [crossplane-configurations#350](https://github.com/stuttgart-things/crossplane-configurations/pull/350)).

Reine Dependency-Anhebung, kein Code in diesem Modul. `PASS: 22/22`.

Getrennt von kcl#201, weil der Lock die Katalog-Version erst aufloest, wenn sie publiziert ist.

`0.6.0` → `0.6.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi