### PR TITLE
feat(ci): catalog-parity — existieren die gepinnten Versionen ueberhaupt?

### DIFF
--- a/.github/workflows/catalog-parity.yaml
+++ b/.github/workflows/catalog-parity.yaml
@@ -1,0 +1,57 @@
+# Does every version the package catalog pins actually exist in its registry?
+#
+# SCHEDULED, NOT ONLY ON CHANGES — that is the whole design.
+#
+# The catalog drifts without anyone touching it. Its pins name packages built in
+# other repositories; every release there moves the fleet forward and leaves the
+# profile where it was. A workflow gated on catalog paths would never fire on the
+# failure it exists for.
+#
+# Measured 2026-08-20: the machinery profile had fallen four Configurations
+# behind the reference cluster and carried no harvester-vm at all. Nobody noticed
+# for weeks. It surfaced only when a freshly built LabDA seed came up on
+# cluster v0.4.0 — which knows neither `harvester` in the provider enum nor the
+# vault-labda mapping, and therefore could not build the clusters it had been
+# stood up for.
+name: Catalog Parity
+
+on:
+  schedule:
+    # Daily, early enough that the drift table is in the inbox before anyone
+    # pins a version by hand.
+    - cron: '0 6 * * *'
+  pull_request:
+    paths:
+      - 'crossplane/xplane-crossplane-catalog/**'
+      - 'tests/lint/catalog-parity.py'
+      - '.github/workflows/catalog-parity.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  catalog-parity:
+    name: Catalog pins exist in their registries
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install KCL
+        # The pins are read through `kcl run`, not by regexing the .k source: a
+        # profile that builds its package list some other way still gets checked.
+        run: |
+          set -euo pipefail
+          curl -sSL https://kcl-lang.io/script/install-cli.sh | /bin/bash
+          kcl --version
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      # No --strict: "behind newest" is a WARNING by design. Pinning is the
+      # point of a catalog, and being behind is often correct. What is not
+      # acceptable is being behind WITHOUT KNOWING — so the table is printed on
+      # every run and only a pin that CANNOT BE PULLED fails the job.
+      - run: python3 tests/lint/catalog-parity.py

--- a/tests/lint/catalog-parity.py
+++ b/tests/lint/catalog-parity.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Does every version the package catalog pins actually exist in its registry?
+
+The catalog profiles are the fleet's answer to "what IS a machinery cluster".
+They are unit-tested for shape (xplane-crossplane-catalog/catalog_test.k) — but
+a unit test cannot know whether `cluster:v0.6.1` can be pulled. Nothing here
+can: the pin is a string, and a string is always well-formed.
+
+WHY THIS RUNS ON A SCHEDULE AND NOT ONLY ON CHANGES.
+
+The catalog drifts WITHOUT ANYONE TOUCHING IT. Its pins name packages built in
+other repositories; every release there moves the fleet forward and leaves the
+profile where it was. A check gated on catalog changes would therefore never
+fire on the failure it exists for.
+
+Measured, not assumed (2026-08-20): the machinery profile had fallen four
+Configurations behind the reference cluster — cluster v0.4.0 vs v0.6.1, platform
+v0.3.11 vs v0.6.2, proxmoxvm v0.11.0 vs v0.12.2, vspherevm v0.9.0 vs v0.9.2 —
+and carried no harvester-vm at all. Nobody noticed for weeks. It surfaced only
+when a freshly built LabDA seed came up on cluster v0.4.0, which knows neither
+`harvester` in the provider enum nor the vault-labda mapping, and therefore
+could not build the very clusters it had been stood up for.
+
+TWO SEVERITIES, AND THE SPLIT IS DELIBERATE.
+
+  pin does not exist        ERROR    A machinery cluster built from this profile
+                                     cannot come up. The package manager will
+                                     sit on ErrImagePull and every XRD the
+                                     package carries is simply absent.
+
+  pin behind newest         WARNING  Pinning IS the point of a catalog; being
+                                     behind is legitimate and often correct.
+                                     What is not acceptable is being behind
+                                     WITHOUT KNOWING, which is exactly what
+                                     happened. So this prints a table on every
+                                     run — the delta is meant to be read, not
+                                     to fail a build.
+
+An unreachable registry is SKIPPED, never reported. A check that goes red when
+a registry has a bad day gets switched off, and then it checks nothing at all.
+
+Usage:
+    python3 tests/lint/catalog-parity.py [--catalog crossplane/xplane-crossplane-catalog]
+    python3 tests/lint/catalog-parity.py --strict   # behind-newest fails too
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+TIMEOUT = 10
+SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+# Emitted into the catalog module so `kcl run` resolves its own imports. Reading
+# the pins through KCL rather than regexing the .k source means a profile that
+# builds its package list any other way still gets checked.
+DUMP = """import main as c
+
+out = [
+    {profile = n, name = p.name, kind = p.kind, package = p.package}
+    for n in c.names for p in c.catalog[n].packages
+]
+"""
+
+
+def parse_semver(tag: str):
+    m = SEMVER.match(tag)
+    return tuple(int(g) for g in m.groups()) if m else None
+
+
+def load_pins(catalog: Path) -> list[dict]:
+    """Every (profile, package) pin, via `kcl run` rather than text parsing."""
+    with tempfile.NamedTemporaryFile("w", suffix=".k", dir=catalog,
+                                     delete=False) as fh:
+        fh.write(DUMP)
+        tmp = Path(fh.name)
+    try:
+        proc = subprocess.run(["kcl", "run", tmp.name, "--format", "json"],
+                              cwd=catalog, capture_output=True, text=True)
+        if proc.returncode != 0:
+            print(proc.stderr.strip(), file=sys.stderr)
+            raise SystemExit("catalog-parity: `kcl run` failed — cannot read pins")
+        return json.loads(proc.stdout)["out"]
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def split_ref(ref: str) -> tuple[str, str, str] | None:
+    """`host/path:tag` -> (host, path, tag). None if it is not that shape."""
+    if ":" not in ref or "/" not in ref:
+        return None
+    path, _, tag = ref.rpartition(":")
+    host, _, repo = path.partition("/")
+    if "." not in host or not repo:
+        return None
+    return host, repo, tag
+
+
+def _token(host: str, challenge: str) -> str | None:
+    """Bearer token from a WWW-Authenticate challenge (the standard OCI dance).
+
+    Doing this generically rather than special-casing ghcr.io is what lets the
+    check cover the Functions and Providers too: those live on xpkg.upbound.io
+    and xpkg.crossplane.io, and a Function pinned to a version that was never
+    released breaks a cluster exactly as thoroughly as one of ours.
+    """
+    parts = dict(re.findall(r'(\w+)="([^"]*)"', challenge))
+    realm = parts.pop("realm", None)
+    if not realm:
+        return None
+    query = "&".join(f"{k}={v}" for k, v in parts.items())
+    try:
+        with urllib.request.urlopen(f"{realm}?{query}" if query else realm,
+                                    timeout=TIMEOUT) as r:
+            body = json.load(r)
+        return body.get("token") or body.get("access_token")
+    except Exception:
+        return None
+
+
+# `Link: </v2/…/tags/list?last=…>; rel="next"` — the OCI distribution spec's
+# pagination cursor.
+NEXT_PAGE = re.compile(r'<([^>]+)>\s*;\s*rel="next"')
+
+# Backstop for a registry that never stops handing out cursors. 50 pages is
+# 5000 tags; no package here is near that, and looping forever inside CI is a
+# worse failure than an incomplete answer.
+MAX_PAGES = 50
+
+
+def fetch_tags(host: str, repo: str) -> list[str] | None:
+    """Published tags, [] if the repository has none/does not exist, None if the
+    registry declined to answer.
+
+    None and [] must stay distinguishable: a timeout reported as "never
+    published" would accuse every pin in the catalog the moment a registry
+    hiccups.
+
+    PAGINATED, AND THAT IS NOT OPTIONAL. Registries cap a tag list — xpkg.
+    crossplane.io returns exactly 100 with a `Link: rel="next"` — and the cap
+    bites hardest on the packages with the most releases, which are the
+    crossplane-contrib Functions. Reading only the first page reported
+    function-auto-ready v0.6.5, function-go-templating v0.12.2 and
+    function-environment-configs v0.7.2 as "does not exist" while all three were
+    running on the reference cluster. A check that fails CI on three correct
+    pins is worse than no check; found while writing this one.
+    """
+    url = f"https://{host}/v2/{repo}/tags/list"
+    token: str | None = None
+    tags: list[str] = []
+    try:
+        for _ in range(MAX_PAGES):
+            headers = {"Authorization": f"Bearer {token}"} if token else {}
+            try:
+                r = urllib.request.urlopen(
+                    urllib.request.Request(url, headers=headers), timeout=TIMEOUT)
+            except urllib.error.HTTPError as e:
+                if e.code != 401 or token is not None:
+                    raise
+                token = _token(host, e.headers.get("WWW-Authenticate", ""))
+                if not token:
+                    return None
+                continue
+            with r:
+                tags.extend(json.load(r).get("tags") or [])
+                link = NEXT_PAGE.search(r.headers.get("Link", "") or "")
+            if not link:
+                return tags
+            nxt = link.group(1)
+            url = nxt if nxt.startswith("http") else f"https://{host}{nxt}"
+        return tags
+    except urllib.error.HTTPError as e:
+        # 403/404 are ANSWERS: no public artifact under this name. GHCR in
+        # particular does not 404 for a package that was never pushed — it
+        # answers 403 at the token step. Folding a private package in here is
+        # intentional: a package Crossplane cannot pull anonymously is broken
+        # for this fleet either way.
+        return [] if e.code in (403, 404) else None
+    except Exception:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--catalog", default="crossplane/xplane-crossplane-catalog",
+                    help="path to the catalog module")
+    ap.add_argument("--strict", action="store_true",
+                    help="treat 'behind newest' as an error too")
+    args = ap.parse_args()
+
+    catalog = Path(args.catalog).resolve()
+    if not (catalog / "kcl.mod").exists():
+        print(f"catalog-parity: no kcl.mod under {catalog}", file=sys.stderr)
+        return 1
+
+    pins = load_pins(catalog)
+    errors: list[str] = []
+    behind: list[tuple[str, str, str, str]] = []
+    skipped: list[str] = []
+
+    for pin in pins:
+        ref = pin["package"]
+        parts = split_ref(ref)
+        if parts is None:
+            errors.append(f"{pin['profile']}/{pin['name']}: "
+                          f"{ref!r} is not host/path:tag")
+            continue
+        host, repo, tag = parts
+
+        tags = fetch_tags(host, repo)
+        if tags is None:
+            skipped.append(f"{host}/{repo}")
+            continue
+
+        if tag not in tags:
+            published = sorted(filter(None, (parse_semver(t) for t in tags)))
+            newest = "v" + ".".join(map(str, published[-1])) if published else "none"
+            errors.append(
+                f"{pin['profile']}/{pin['name']}: pinned {tag} does not exist in "
+                f"{host} (newest published: {newest}) — a cluster built from this "
+                f"profile cannot pull it")
+            continue
+
+        pinned = parse_semver(tag)
+        published = sorted(filter(None, (parse_semver(t) for t in tags)))
+        if pinned and published and published[-1] > pinned:
+            newest = "v" + ".".join(map(str, published[-1]))
+            behind.append((pin["profile"], pin["name"], tag, newest))
+
+    if behind:
+        print("Pins behind the newest published version:")
+        width = max(len(f"{p}/{n}") for p, n, _, _ in behind)
+        for profile, name, tag, newest in behind:
+            print(f"  {f'{profile}/{name}':<{width}}  {tag:>10}  ->  {newest}")
+        print()
+
+    for e in errors:
+        print(f"ERROR {e}")
+
+    if skipped:
+        print(f"note: skipped {len(skipped)} repo(s), registry unreachable: "
+              f"{', '.join(sorted(set(skipped)))}", file=sys.stderr)
+
+    print(f"catalog-parity: {len(pins)} pin(s), {len(errors)} error(s), "
+          f"{len(behind)} behind newest")
+
+    return 1 if errors or (args.strict and behind) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Die Katalog-Profile sind die Antwort des Fleets auf „was **ist** ein Machinery-Cluster". `catalog_test.k` prueft ihre Form — aber kein Unit-Test kann wissen, ob `cluster:v0.6.1` ziehbar ist. Ein Pin ist ein String, und ein String ist immer wohlgeformt.

## Laeuft auf einem Zeitplan, nicht nur bei Aenderungen

Das ist der Kern, nicht ein Detail: **der Katalog driftet, ohne dass ihn jemand anfasst.** Seine Pins benennen Pakete aus anderen Repos; jedes Release dort bewegt das Fleet weiter und laesst das Profil stehen. Ein Workflow mit Pfad-Trigger wuerde nie bei dem Fehler feuern, fuer den er da ist.

Gemessen, nicht angenommen (2026-08-20): das `machinery`-Profil war **vier Configurations** hinter dem Referenz-Cluster und trug `harvester-vm` gar nicht. Wochenlang unbemerkt. Aufgefallen erst, als ein frisch gebauter LabDA-Seed auf `cluster:v0.4.0` hochkam — das weder `harvester` im Provider-Enum noch das `vault-labda`-Mapping kennt und damit genau die Cluster nicht bauen konnte, fuer die es aufgestellt wurde.

## Zwei Schweregrade

| Lage | Grad | |
|---|---|---|
| Pin existiert nicht | **ERROR** | Ein Cluster aus diesem Profil kommt nicht hoch: `ErrImagePull`, und jede XRD des Pakets fehlt schlicht |
| Pin hinter neuester | **WARNING** | Pinnen *ist* der Sinn eines Katalogs; hinterher zu sein ist legitim. Nicht akzeptabel ist, hinterher zu sein **ohne es zu wissen** |

Deshalb druckt der Check bei jedem Lauf eine Tabelle, die gelesen werden soll — statt einen Build zu brechen:

```
Pins behind the newest published version:
  machinery/crossplane-contrib-provider-helm                            v1.3.0  ->  v1.4.0
  machinery/upbound-provider-opentofu                                   v1.1.4  ->  v1.1.6
  machinery/stuttgart-things-provider-kubeconfig-xpkg                  v0.13.1  ->  v0.13.2
  machinery/function-kcl                                               v0.12.1  ->  v0.12.2
  machinery/function-auto-ready                                         v0.6.5  ->  v0.7.0
  machinery/function-go-templating                                     v0.12.2  ->  v0.12.3
  machinery/function-environment-configs                                v0.7.2  ->  v0.7.3
  machinery/function-patch-and-transform                               v0.10.7  ->  v0.10.9
  machinery/stuttgart-things-crossplane-configurations-cluster-backup   v0.1.0  ->  v0.2.0

catalog-parity: 21 pin(s), 0 error(s), 9 behind newest
```

## Zwei Entwurfsentscheidungen

**Pins werden ueber `kcl run` gelesen**, nicht per Regex aus der `.k`-Quelle. Ein Profil, das seine Paketliste anders baut, wird trotzdem geprueft.

**Der Token-Tanz ist generisch ueber `WWW-Authenticate`** statt ghcr-spezifisch. Damit deckt der Check auch die Functions und Provider auf `xpkg.upbound.io` und `xpkg.crossplane.io` ab — eine Function mit einer nie veroeffentlichten Version zerlegt einen Cluster genauso gruendlich wie eine unserer Configurations.

## Tag-Listen sind paginiert, und das ist fast schiefgegangen

`xpkg.crossplane.io` liefert **exakt 100 Tags** plus `Link: …; rel="next"`. Die erste Fassung las nur die erste Seite und meldete:

```
ERROR machinery/function-auto-ready: pinned v0.6.5 does not exist …
ERROR machinery/function-go-templating: pinned v0.12.2 does not exist …
ERROR machinery/function-environment-configs: pinned v0.7.2 does not exist …
```

Alle drei laufen auf dem Referenz-Cluster. Der Deckel beisst ausgerechnet bei den Paketen mit den meisten Releases. Ein Check, der bei drei korrekten Pins die CI rot macht, ist schlimmer als keiner — der Cursor wird jetzt verfolgt.

Derselbe Defekt lag latent im Schwester-Check in [crossplane-configurations#353](https://github.com/stuttgart-things/crossplane-configurations/pull/353) und ist dort mitkorrigiert. Dort ist heute kein Paket in der Naehe des Limits; genau deshalb waere es unbemerkt geblieben, bis eines dort ist.

Eine unerreichbare Registry wird uebersprungen, nicht gemeldet.

Refs [crossplane-configurations#345](https://github.com/stuttgart-things/crossplane-configurations/issues/345)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi