### PR TITLE
feat(capability): komponierte Objectnamen mit clusterName praefixen (0.5.0)

### DIFF
--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-capability"
 edition = "v0.12.3"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-capability/logic.k
+++ b/crossplane/xplane-capability/logic.k
@@ -107,3 +107,30 @@ credentialsNamespace = lambda capName: str, placementOf: {str:}, providerNs: str
     _f = cat.get(capName)?.credentialsNamespaceField
     str(placementOf[_f]) if _f else providerNs
 }
+
+# Der Name der komponierten Object-Ressource AUF DEM MANAGEMENT-CLUSTER — nicht
+# zu verwechseln mit dem Namen der Ressource auf dem ZIELCLUSTER, der aus
+# Capability + Environment gebildet wird.
+#
+# clusterName MUSS hinein. Ohne das Praefix heisst das Object nur nach der
+# Capability ("ansible-run-secret-store"), und zwei Capability-XRs im selben
+# Namespace kollidieren zwangslaeufig auf jeder Capability, die beide aktiviert
+# haben. Am 2026-08-20 auf kind3 passiert: u26-rke2-1-capability hielt die
+# ansible-run-Namen, ein neues seed-labda-1-capability fuehrte dieselben Objects
+# in seinen resourceRefs und blieb auf Ready=False stehen — waehrend seine
+# vspherevm-Haelfte durchlief, weil u26 zufaellig proxmoxvm faehrt.
+#
+# Ueberschrieben wurde nichts: Crossplane beansprucht keine Ressource, die
+# bereits das crossplane.io/composite-Label eines anderen Composites traegt.
+# Darauf zu bauen waere aber falsch — die beiden XRs zeigten auf verschiedene
+# Cluster UND verschiedene Vaults, und ohne diese Sicherung haette das neue XR
+# den Store des anderen Clusters auf den falschen Vault umgebogen, still und
+# ohne Meldung. Siehe crossplane-configurations#356.
+#
+# Hier statt inline in main.k, weil ein Fehler hier nicht bricht sondern
+# verwechselt: ein falsches Praefix erzeugt eine Kollision, die erst auf einem
+# zweiten Cluster sichtbar wird.
+resourceName = lambda clusterName: str, suffix: str -> str {
+    assert clusterName, "clusterName is required — composed object names must be unique per cluster"
+    clusterName + "-" + suffix
+}

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -159,3 +159,20 @@ test_credentials_land_where_their_consumer_reads_them = lambda {
     _pp = logic.placement("proxmoxvm", _full)
     assert logic.credentialsNamespace("proxmoxvm", _pp, "crossplane-system") == "crossplane-system"
 }
+
+# Ein fehlendes Cluster-Praefix bricht nichts — es erzeugt eine Kollision, die
+# erst auf einem ZWEITEN Cluster im selben Namespace sichtbar wird, und dort als
+# "Unready resources" statt als Namensproblem. Deshalb hier festgenagelt.
+# Siehe crossplane-configurations#356.
+test_composed_object_names_carry_the_cluster = lambda {
+    assert logic.resourceName("seed-labda-1", "vspherevm-secret-store") == "seed-labda-1-vspherevm-secret-store"
+    assert logic.resourceName("u26-rke2-1", "ansible-run-credentials") == "u26-rke2-1-ansible-run-credentials"
+}
+
+# Der Punkt der Uebung: dieselbe Capability auf zwei Clustern darf sich im
+# selben Namespace nicht auf einen Namen einigen.
+test_two_clusters_do_not_collide_on_one_name = lambda {
+    _a = logic.resourceName("u26-rke2-1", "ansible-run-secret-store")
+    _b = logic.resourceName("seed-labda-1", "ansible-run-secret-store")
+    assert _a != _b, "two clusters produced the same composed object name: " + _a
+}

--- a/crossplane/xplane-capability/main.k
+++ b/crossplane/xplane-capability/main.k
@@ -95,6 +95,12 @@ _objName = lambda capName: str -> str {
     capName + "-" + _environment
 }
 
+# Praefixt die komponierten Object-Namen mit clusterName. Die Regel samt
+# Begruendung liegt in logic.k, damit sie testbar ist.
+_resNameFor = lambda suffix: str -> str {
+    logic.resourceName(_clusterName, suffix)
+}
+
 # `<capability>-creds-<env>` — NOT the charts' `proxmox-creds-<env>`. The
 # difference is deliberate: on a cluster that still has the chart installed,
 # colliding on the Secret name would give two owners to one object, and the ESO
@@ -199,7 +205,7 @@ _object = lambda resName: str, manifest: {str:}, readiness: {str:str} = _readyFr
 _externalSecret = lambda capName: str -> {str:} {
     _c = cat.get(capName)
     _v = _capSpec(capName)?.vault or {}
-    _resName = capName + "-credentials"
+    _resName = _resNameFor(capName + "-credentials")
     _object(_resName, {
         apiVersion = "external-secrets.io/v1"
         kind = "ExternalSecret"
@@ -243,7 +249,7 @@ _externalSecret = lambda capName: str -> {str:} {
 _workloadSecret = lambda capName: str, w: capschema.WorkloadSecret, idx: int -> {str:} {
     _v = _capSpec(capName)?.vault or {}
     _secretName = capName + "-" + w.nameSuffix
-    _resName = capName + "-" + w.nameSuffix + "-secret"
+    _resName = _resNameFor(capName + "-" + w.nameSuffix + "-secret")
     _object(_resName, {
         apiVersion = "external-secrets.io/v1"
         kind = "ExternalSecret"
@@ -285,7 +291,7 @@ _workloadSecretNames = lambda capName: str -> {str:str} {
 
 _secretStore = lambda capName: str -> {str:} {
     _v = _vaultOf(capName)
-    _resName = capName + "-secret-store"
+    _resName = _resNameFor(capName + "-secret-store")
 
     # Cluster-scoped: a ClusterSecretStore has no namespace, and an
     # ExternalSecret in any namespace may reference it — which is what the
@@ -325,7 +331,7 @@ _secretStore = lambda capName: str -> {str:} {
 _providerConfig = lambda capName: str -> {str:} {
     _c = cat.get(capName)
     _pc = _c.providerConfig
-    _resName = capName + "-provider-config"
+    _resName = _resNameFor(capName + "-provider-config")
     _object(_resName, {
         apiVersion = _pc.apiVersion
         kind = _pc.kind
@@ -345,7 +351,7 @@ _providerConfig = lambda capName: str -> {str:} {
 
 _environmentConfig = lambda capName: str -> {str:} {
     _c = cat.get(capName)
-    _resName = capName + "-environment-config"
+    _resName = _resNameFor(capName + "-environment-config")
 
     # providerConfigName/-Kind are DERIVED, never taken from the XR: they name
     # the object rendered two functions up, and letting an XR state them makes


### PR DESCRIPTION
## Was

`xplane-capability` 0.4.1 → **0.5.0**. Die komponierten `Object`-Namen auf dem Management-Cluster tragen jetzt den Cluster als Präfix:

```
ansible-run-secret-store   →   seed-labda-1-ansible-run-secret-store
```

## Warum

Bisher hießen sie nur nach der Capability. Zwei `Capability`-XRs im selben Namespace kollidieren damit zwangsläufig auf jeder Capability, die beide aktiviert haben.

**Am 2026-08-20 auf kind3 passiert:** `u26-rke2-1-capability` (ns `default`) hielt die `ansible-run-*`-Namen; ein neues `seed-labda-1-capability` führte dieselben Objects in seinen `resourceRefs` und blieb auf `Ready=False` stehen. Die `vspherevm`-Hälfte lief durch — reiner Zufall, u26 fährt `proxmoxvm`.

Überschrieben wurde nichts: Crossplane beansprucht keine Ressource, die bereits das `crossplane.io/composite`-Label eines anderen Composites trägt. **Darauf zu bauen wäre aber falsch** — die beiden XRs zeigten auf verschiedene Cluster *und* verschiedene Vaults, und ohne diese Sicherung hätte das neue XR den Store des anderen Clusters auf den falschen Vault umgebogen, still und ohne Meldung.

## Was NICHT umbenannt wird

Nur `_resName` (Management-Cluster). Die Namen auf dem **Zielcluster** — `_objName`, also `<capability>-<environment>` wie `vspherevm-labda` — bleiben unverändert. XRs referenzieren sie über `spec.environmentConfig`; ein Umbenennen dort wäre ein Bruch.

## Wo die Regel liegt

In `logic.k`, nicht inline in `main.k` — nach demselben Prinzip wie `readinessFor` und `credentialsNamespace`: ein Fehler hier bricht nicht, er *verwechselt*. Ein falsches Präfix erzeugt eine Kollision, die erst auf einem zweiten Cluster sichtbar wird, und dort als „Unready resources" statt als Namensproblem. Zwei Tests nageln es fest:

```
test_composed_object_names_carry_the_cluster: PASS
test_two_clusters_do_not_collide_on_one_name:  PASS
PASS: 19/19
```

## ⚠️ Migrationshinweis für den Konsumenten

Ein Bump der `capability`-Configuration auf dieses Modul **benennt bestehende Objects um**. Crossplane löscht die alten (sie fallen aus dem Desired State) und legt neue an. Auf dem Zielcluster heißt das: EnvironmentConfig, ProviderConfig, ClusterSecretStore und ExternalSecret werden kurz gelöscht und neu erzeugt — die Zielnamen bleiben gleich, aber es gibt ein Fenster. Das `ExternalSecret` trägt `deletionPolicy: Retain`, das abgeleitete Secret überlebt also.

Vor dem Rollout auf einem Cluster mit laufenden VM-XRs entsprechend planen.

Refs: stuttgart-things/crossplane-configurations#356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2id4uBudgng2EcLbEHBmX