### PR TITLE
fix(capability): environment gehoert in den Objectnamen (0.6.0)

### DIFF
--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-capability"
 edition = "v0.12.3"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-capability/logic.k
+++ b/crossplane/xplane-capability/logic.k
@@ -127,10 +127,20 @@ credentialsNamespace = lambda capName: str, placementOf: {str:}, providerNs: str
 # den Store des anderen Clusters auf den falschen Vault umgebogen, still und
 # ohne Meldung. Siehe crossplane-configurations#356.
 #
+# ENVIRONMENT GEHOERT DAZU, nicht nur clusterName. Das XRD sagt zu spec.environment
+# ausdruecklich "Set it when one cluster serves two environments (labda AND
+# labul)" -- der vorgesehene Weg fuer zwei Umgebungen sind also ZWEI
+# Capability-XRs auf demselben Cluster. Praefixt man nur mit clusterName, tragen
+# deren Objects fuer dieselbe Capability wieder denselben Namen, und die
+# Kollision ist zurueck, ausgerechnet im vom XRD vorgesehenen Fall. Fuer
+# VERSCHIEDENE Capabilities (proxmoxvm vs vspherevm) reicht clusterName, weil der
+# Capability-Name im Suffix steckt -- das deckt aber nur die Haelfte ab.
+#
 # Hier statt inline in main.k, weil ein Fehler hier nicht bricht sondern
 # verwechselt: ein falsches Praefix erzeugt eine Kollision, die erst auf einem
-# zweiten Cluster sichtbar wird.
-resourceName = lambda clusterName: str, suffix: str -> str {
+# zweiten Cluster oder in einer zweiten Umgebung sichtbar wird.
+resourceName = lambda clusterName: str, environment: str, suffix: str -> str {
     assert clusterName, "clusterName is required — composed object names must be unique per cluster"
-    clusterName + "-" + suffix
+    assert environment, "environment is required — one cluster may serve two of them"
+    clusterName + "-" + environment + "-" + suffix
 }

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -165,14 +165,24 @@ test_credentials_land_where_their_consumer_reads_them = lambda {
 # "Unready resources" statt als Namensproblem. Deshalb hier festgenagelt.
 # Siehe crossplane-configurations#356.
 test_composed_object_names_carry_the_cluster = lambda {
-    assert logic.resourceName("seed-labda-1", "vspherevm-secret-store") == "seed-labda-1-vspherevm-secret-store"
-    assert logic.resourceName("u26-rke2-1", "ansible-run-credentials") == "u26-rke2-1-ansible-run-credentials"
+    assert logic.resourceName("seed-labda-1", "labda", "vspherevm-secret-store") == "seed-labda-1-labda-vspherevm-secret-store"
+    assert logic.resourceName("u26-rke2-1", "labul", "ansible-run-credentials") == "u26-rke2-1-labul-ansible-run-credentials"
 }
 
 # Der Punkt der Uebung: dieselbe Capability auf zwei Clustern darf sich im
 # selben Namespace nicht auf einen Namen einigen.
 test_two_clusters_do_not_collide_on_one_name = lambda {
-    _a = logic.resourceName("u26-rke2-1", "ansible-run-secret-store")
-    _b = logic.resourceName("seed-labda-1", "ansible-run-secret-store")
+    _a = logic.resourceName("u26-rke2-1", "labul", "ansible-run-secret-store")
+    _b = logic.resourceName("seed-labda-1", "labda", "ansible-run-secret-store")
     assert _a != _b, "two clusters produced the same composed object name: " + _a
+}
+
+# Der Fall, den das XRD ausdruecklich vorsieht: EIN Cluster, ZWEI Umgebungen,
+# also zwei Capability-XRs mit derselben Capability. Ein Praefix aus nur
+# clusterName haette hier wieder denselben Namen erzeugt -- die Kollision waere
+# im vom XRD vorgesehenen Szenario zurueckgewesen.
+test_two_environments_on_one_cluster_do_not_collide = lambda {
+    _a = logic.resourceName("u26-rke2-1", "labul", "vspherevm-secret-store")
+    _b = logic.resourceName("u26-rke2-1", "labda", "vspherevm-secret-store")
+    assert _a != _b, "two environments on one cluster produced the same name: " + _a
 }

--- a/crossplane/xplane-capability/main.k
+++ b/crossplane/xplane-capability/main.k
@@ -98,7 +98,7 @@ _objName = lambda capName: str -> str {
 # Praefixt die komponierten Object-Namen mit clusterName. Die Regel samt
 # Begruendung liegt in logic.k, damit sie testbar ist.
 _resNameFor = lambda suffix: str -> str {
-    logic.resourceName(_clusterName, suffix)
+    logic.resourceName(_clusterName, _environment, suffix)
 }
 
 # `<capability>-creds-<env>` — NOT the charts' `proxmox-creds-<env>`. The


### PR DESCRIPTION
Korrigiert 0.5.0 ([#210](https://github.com/stuttgart-things/kcl/pull/210)), bevor es einen Konsumenten hat.

## Was 0.5.0 übersehen hat

0.5.0 präfixte die komponierten Objectnamen mit `clusterName`. Das XRD sagt zu `spec.environment` aber ausdrücklich:

> Set it when one cluster serves two environments (labda AND labul), so their ClusterProviderConfigs and credential Secrets do not collide.

Der vorgesehene Weg für zwei Umgebungen sind also **zwei Capability-XRs auf demselben Cluster**. Mit einem Präfix aus nur `clusterName` tragen deren Objects für dieselbe Capability wieder denselben Namen — die Kollision wäre zurück, ausgerechnet im vom XRD vorgesehenen Szenario.

Für *verschiedene* Capabilities auf einem Cluster (proxmoxvm vs. vspherevm) reichte `clusterName`, weil der Capability-Name im Suffix steckt. Das deckte aber nur die Hälfte ab.

## Jetzt

```
<clusterName>-<environment>-<capability>-<zweck>
u26-rke2-1-labul-vspherevm-secret-store
u26-rke2-1-labda-vspherevm-secret-store   ← kollidiert nicht mehr
```

Ein dritter Test nagelt genau diesen Fall fest:

```
test_composed_object_names_carry_the_cluster:         PASS
test_two_clusters_do_not_collide_on_one_name:         PASS
test_two_environments_on_one_cluster_do_not_collide:  PASS
PASS: 20/20
```

## Warum minor statt patch

0.5.0 ist auf ghcr, hat aber noch keinen Konsumenten — crossplane-configurations#357 ist offen und wird auf 0.6.0 gezogen. Trotzdem minor: die Namen ändern sich gegenüber 0.5.0 erneut, und ein Patch, der alles umbenennt, liest sich falsch.

Refs: stuttgart-things/crossplane-configurations#356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2id4uBudgng2EcLbEHBmX