### PR TITLE
feat(catalog): CVE-Runde plus provider-helm v1.4.0 (0.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,7 @@ _kcl_test.k
 # dependencies here. It is a rebuildable cache, not source — and committing it
 # makes CI lint-test the vendored copy as if it were a module of this repo.
 **/oci/ghcr.io/
+
+### Python ###
+__pycache__/
+*.py[cod]

--- a/crossplane/xplane-crossplane-catalog/catalog_test.k
+++ b/crossplane/xplane-crossplane-catalog/catalog_test.k
@@ -30,7 +30,7 @@ test_providers_and_configurations_use_derived_names = lambda {
 # path and our four-segment ghcr one. Pinned because everything above rests on
 # it matching what Crossplane actually does.
 test_derived_name_matches_crossplane = lambda {
-    assert c.derivedName("xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.3.0") == "crossplane-contrib-provider-helm"
+    assert c.derivedName("xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.4.0") == "crossplane-contrib-provider-helm"
     assert c.derivedName("ghcr.io/stuttgart-things/crossplane-configurations/platform:v0.3.11") == "stuttgart-things-crossplane-configurations-platform"
     assert c.derivedName("ghcr.io/stuttgart-things/provider-clusterbook-xpkg:v0.4.2") == "stuttgart-things-provider-clusterbook-xpkg"
 }
@@ -86,12 +86,24 @@ test_function_kcl_stays_on_the_other_mirror = lambda {
     assert _k[0].package.startswith("xpkg.upbound.io/")
 }
 
-# function-auto-ready v0.7.0 makes Configurations report Unhealthy, which times
-# out the install wait. The ceiling is a fleet fact, not a preference.
+# Die Decke, und zwar als Decke geprueft statt als eine erlaubte Version.
+#
+# 30 dependsOn-Eintraege in crossplane-configurations verlangen
+# >=v0.6.5,<v0.7.0; mit v0.7.0 melden die Package-Revisions "incompatible
+# dependencies" und der Install-Wait laeuft in den Timeout. Das ist eine
+# Fleet-Tatsache, keine Vorliebe.
+#
+# Vorher stand hier `endswith(":v0.6.5")`. Das ist derselbe Fehler, der
+# test_the_profile_can_build_control_planes einmal auf v0.4.0 festgenagelt
+# hat: eine Untergrenze/Obergrenze als Gleichheit geschrieben. Der Test war
+# dadurch gegen genau die Bumps rot, die er erlauben soll — v0.6.6 und v0.6.7
+# sind reine CVE-Backports UNTERHALB der Decke.
 test_function_auto_ready_stays_below_070 = lambda {
     _a = [p for p in c.byKind(c.get("machinery"), "Function") if p.name == "function-auto-ready"]
     assert len(_a) == 1
-    assert _a[0].package.endswith(":v0.6.5")
+    _v = [int(n) for n in _a[0].package.split(":v")[1].split(".")]
+    assert _v[0] == 0 and _v[1] == 6, "function-auto-ready muss auf der 0.6er-Linie bleiben (dependsOn <v0.7.0)"
+    assert _v[2] >= 5, "unterhalb v0.6.5 verletzt die untere Grenze der dependsOn-Spanne"
 }
 
 # provider-kubernetes must NOT be an entry: every Configuration pulls it, so

--- a/crossplane/xplane-crossplane-catalog/kcl.mod
+++ b/crossplane/xplane-crossplane-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-crossplane-catalog"
 edition = "v0.12.3"
-version = "0.3.1"
+version = "0.4.0"

--- a/crossplane/xplane-crossplane-catalog/profiles/machinery.k
+++ b/crossplane/xplane-crossplane-catalog/profiles/machinery.k
@@ -24,19 +24,25 @@ machinery: s.Profile = {
         s.Package {
             kind = "Provider"
             name = "crossplane-contrib-provider-helm"
-            package = "xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.3.0"
+            # v1.4.0 hebt das eingebettete Helm-SDK von v3 auf v4. Die
+            # Release-API ist unveraendert, das Laufzeitverhalten nicht:
+            # Server-Side-Apply ist fuer NEU installierte Releases der Default
+            # und `wait` haengt jetzt an kstatus. Durch Release-Objekte geht
+            # jede Platform-App (cert-manager, openebs, cni, flux-init) — ein
+            # Upgrade hier ist deshalb nie Teil einer reinen CVE-Runde.
+            package = "xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.4.0"
             clusterRole = "cluster-admin"
         }
         s.Package {
             kind = "Provider"
             name = "upbound-provider-opentofu"
-            package = "xpkg.upbound.io/upbound/provider-opentofu:v1.1.4"
+            package = "xpkg.upbound.io/upbound/provider-opentofu:v1.1.6"
             clusterRole = "cluster-admin"
         }
         s.Package {
             kind = "Provider"
             name = "stuttgart-things-provider-kubeconfig-xpkg"
-            package = "ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:v0.13.1"
+            package = "ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:v0.13.2"
         }
         # Not pulled by anything: ip-reservation classes clusterbook as a
         # cluster precondition rather than a package dependency, so without this
@@ -62,33 +68,44 @@ machinery: s.Profile = {
             # CR from it. Two nodes, two distinct sources — healthy. Aligning
             # the mirrors gives two nodes with an IDENTICAL source and freezes
             # the resolver for every package on the cluster.
-            package = "xpkg.upbound.io/crossplane-contrib/function-kcl:v0.12.1"
+            package = "xpkg.upbound.io/crossplane-contrib/function-kcl:v0.12.2"
             apiVersion = "pkg.crossplane.io/v1"
         }
         s.Package {
             kind = "Function"
             name = "function-auto-ready"
-            # <v0.7.0 is a hard ceiling: v0.7.0 makes Configurations report
-            # Unhealthy and the deploy-crossplane wait times out.
-            package = "xpkg.crossplane.io/crossplane-contrib/function-auto-ready:v0.6.5"
+            # <v0.7.0 bleibt eine harte Decke, und der Grund ist praeziser
+            # als "v0.7.0 ist kaputt": 30 Stellen in crossplane-configurations
+            # deklarieren dependsOn function-auto-ready >=v0.6.5,<v0.7.0. Mit
+            # v0.7.0 melden diese Package-Revisions "incompatible dependencies"
+            # und der deploy-crossplane-Wait laeuft in den Timeout. Erst
+            # anheben, wenn die Configurations die Spanne weiten.
+            #
+            # v0.6.7 statt v0.6.5 (2026-08-21): die 0.6er-Linie lebt WEITER,
+            # v0.6.6 und v0.6.7 sind NACH v0.7.0 erschienen und sind reine
+            # CVE-Backports (Go 1.25.12, x/net, x/text, grpc). Unter der Decke
+            # zu bleiben heisst also nicht, auf Sicherheitsfixes zu verzichten.
+            # Der catalog-parity-Check sieht das nicht: er vergleicht gegen das
+            # hoechste Semver und zeigte deshalb auf das verbotene v0.7.0.
+            package = "xpkg.crossplane.io/crossplane-contrib/function-auto-ready:v0.6.7"
             apiVersion = "pkg.crossplane.io/v1beta1"
         }
         s.Package {
             kind = "Function"
             name = "function-go-templating"
-            package = "xpkg.crossplane.io/crossplane-contrib/function-go-templating:v0.12.2"
+            package = "xpkg.crossplane.io/crossplane-contrib/function-go-templating:v0.12.3"
             apiVersion = "pkg.crossplane.io/v1beta1"
         }
         s.Package {
             kind = "Function"
             name = "function-environment-configs"
-            package = "xpkg.crossplane.io/crossplane-contrib/function-environment-configs:v0.7.2"
+            package = "xpkg.crossplane.io/crossplane-contrib/function-environment-configs:v0.7.3"
             apiVersion = "pkg.crossplane.io/v1"
         }
         s.Package {
             kind = "Function"
             name = "function-patch-and-transform"
-            package = "xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.10.7"
+            package = "xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.10.9"
             apiVersion = "pkg.crossplane.io/v1beta1"
         }
 


### PR DESCRIPTION
Acht Pins des `machinery`-Profils angehoben. Ausgeloest vom ersten planmaessigen `catalog-parity`-Cron-Lauf (2026-08-21 06:38 UTC), der neun Rueckstaende meldete.

| Pin | von | nach | Inhalt |
|---|---|---|---|
| provider-helm | v1.3.0 | **v1.4.0** | **Helm-SDK v3 -> v4** |
| provider-opentofu | v1.1.4 | v1.1.6 | CVE |
| provider-kubeconfig-xpkg | v0.13.1 | v0.13.2 | deps |
| function-kcl | v0.12.1 | v0.12.2 | Features, laeuft schon |
| function-auto-ready | v0.6.5 | v0.6.7 | CVE-Backport |
| function-go-templating | v0.12.2 | v0.12.3 | CVE |
| function-environment-configs | v0.7.2 | v0.7.3 | CVE |
| function-patch-and-transform | v0.10.7 | v0.10.9 | CVE |

## function-auto-ready: nicht v0.7.0, und das ist der Punkt

Der Check zeigte auf `v0.7.0` — ausgerechnet die Version, die 30 `dependsOn`-Eintraege in `crossplane-configurations` per `>=v0.6.5,<v0.7.0` ausschliessen. Er vergleicht gegen das hoechste Semver und kann eine Decke nicht kennen, die nur als Kommentar existiert.

Dabei uebersehen: die 0.6er-Linie lebt weiter. **v0.6.6 (2026-06-16) und v0.6.7 (2026-07-25) sind nach v0.7.0 erschienen** und sind reine CVE-Backports. Unter der Decke bleiben kostet hier also keine Sicherheitsfixes.

Der Test `test_function_auto_ready_stays_below_070` prueft jetzt eine Decke statt einer Gleichheit (vorher `endswith(":v0.6.5")`, also rot gegen genau die Bumps, die er erlauben soll). Negativ geprueft: v0.7.0 -> FAIL, v0.6.7 -> PASS.

## provider-helm v1.4.0

Helm-SDK v3 -> v4. Release-API unveraendert, Laufzeitverhalten nicht: SSA wird Default fuer **neu installierte** Releases, `wait` laeuft ueber kstatus, bestehende Releases behalten ihre Apply-Methode. Hier geht jede Platform-App durch (cert-manager, openebs, cni, flux-init) — deshalb steht die Begruendung im Profil.

## Ergebnis

```
vorher:  21 pin(s), 0 error(s), 9 behind newest
nachher: 21 pin(s), 0 error(s), 2 behind newest
kcl test: 16/16 PASS
```

Die zwei Reste sind erklaert: auto-ready ist bewusst gedeckelt, `cluster-backup` v0.1.0/v0.2.0 haben denselben Digest.

Gehoert zusammen mit der Installationsseite in `stuttgart-things/helm` — der Katalog beschreibt, die Helmfiles installieren.

Refs stuttgart-things/crossplane-configurations#258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi