### PR TITLE
feat(capability): Zielnamespaces anlegen statt voraussetzen (0.7.0)

### DIFF
--- a/crossplane/xplane-capability/README.md
+++ b/crossplane/xplane-capability/README.md
@@ -6,6 +6,7 @@ act on an external system, onto a target cluster, one set per enabled capability
 
 | object | why |
 |---|---|
+| `Namespace` | the ones this module writes into, so they are not a precondition — see below |
 | `ClusterSecretStore` | where the credentials come from — only where a capability names its own KV mount |
 | `ExternalSecret` (credentials) | the provider may log in |
 | `ClusterProviderConfig` | it knows where to connect |
@@ -113,6 +114,40 @@ the symptom is not a missing Secret: cloud-init applies its `lock_passwd`
 default, LOCKS the guest account, and every password-based `AnsibleRun` reports
 the host `UNREACHABLE`.
 
+## The namespaces are created, not assumed
+
+Every namespace in the table above is emitted as a `Namespace` object with
+`managementPolicies: [Observe, Create]` — adopt it if it exists, create it if it
+does not, never modify or delete it.
+
+It has to be this module, because *which* namespace it is comes out of a
+capability's own placement. `ansible-run` puts its credentials in `tekton-ci`
+because a Tekton pipeline reads them there. On `u26-rke2-1` that namespace
+existed, because that cluster's Platform installs the `tekton` app; on
+`seed-labda-1`, which runs only cert-manager, external-secrets and openebs, the
+object sat at
+
+```
+create failed: cannot create object: namespaces "tekton-ci" not found
+```
+
+with the `vspherevm` half of the same XR green — a capability held up by a
+precondition nothing declared.
+
+Two consequences of the policy set:
+
+* **no `Delete`** — the namespace and everything in it survives the capability
+  being torn down. With `Delete`, switching off `ansible-run` would take the
+  cluster's Tekton pipelines with it.
+* **no `Update`** — a namespace that already has an owner (the `tekton` app,
+  another Capability XR, a human) keeps it. Two Capability XRs may name the same
+  namespace and neither writes to it.
+
+No exception list, so `default` and `crossplane-system` are emitted too. They are
+adopted on the first observe and never touched again; a list of "these always
+exist" would be Kubernetes trivia in the module with exactly one hole in it — the
+day someone points `spec.namespace` at something of their own.
+
 ## Failing the render
 
 A capability with a missing or unknown placement field aborts the whole render,
@@ -158,16 +193,21 @@ every field is legitimately absent.
 | `test_an_existing_store_needs_no_vault_facts` | requiring Vault facts from a cluster that reuses a store it already trusts |
 | `test_status_less_objects_do_not_derive_readiness_from_themselves` | an EnvironmentConfig or ClusterProviderConfig stuck at Ready=False forever |
 | `test_secret_objects_derive_readiness_from_themselves` | a capability reporting ready while Vault answers 403 |
+| `test_the_credentials_namespace_is_ensured` | the `tekton-ci` failure above coming back |
+| `test_a_shared_namespace_is_emitted_once` | two capabilities naming one namespace producing two composed objects with the same name — a render error that appears only when someone enables the second capability |
+| `test_namespaces_come_out_in_a_stable_order` | a render that changes with dict iteration, which every differ reads as a change |
+| `test_an_empty_namespace_is_dropped` | `namespace: ""` reaching the API server as an empty `metadata.name` |
 
 ## Readiness
 
-Not one policy for all four objects.
+Not one policy for all of them.
 
 | object | policy | why |
 |---|---|---|
 | `ClusterSecretStore` | `DeriveFromObject` | its `Valid` condition IS the proof that the Vault login works |
 | `ExternalSecret` | `DeriveFromObject` | its `Ready` condition is the only signal that Vault answered — a capability whose credentials 403 must not report ready |
 | `EnvironmentConfig` | `DeriveFromCelQuery` (`true`) | it has no conditions at all |
+| `Namespace` | `DeriveFromCelQuery` (`true`) | same — no conditions, only `status.phase` |
 | `ClusterProviderConfig` | `DeriveFromCelQuery` (`true`) | same, and measured: [#294](https://github.com/stuttgart-things/crossplane-configurations/issues/294) found `SuccessfulCreate` never evaluated and `AllTrue` false on an empty condition list |
 
 Using `DeriveFromObject` everywhere leaves the two status-less objects at

--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-capability"
 edition = "v0.12.3"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.4.0" }

--- a/crossplane/xplane-capability/logic.k
+++ b/crossplane/xplane-capability/logic.k
@@ -95,7 +95,7 @@ schema Readiness:
 # so the choice is testable: both directions are failures that hide rather than
 # break, so nothing else would catch a change.
 readinessFor = lambda kind: str -> Readiness {
-    Readiness {policy = "DeriveFromCelQuery", celQuery = "true"} if kind in ["EnvironmentConfig", "ClusterProviderConfig"] else Readiness {policy = "DeriveFromObject"}
+    Readiness {policy = "DeriveFromCelQuery", celQuery = "true"} if kind in ["EnvironmentConfig", "ClusterProviderConfig", "Namespace"] else Readiness {policy = "DeriveFromObject"}
 }
 
 # Which namespace a capability's credentials Secret belongs in. Beside the
@@ -143,4 +143,34 @@ resourceName = lambda clusterName: str, environment: str, suffix: str -> str {
     assert clusterName, "clusterName is required — composed object names must be unique per cluster"
     assert environment, "environment is required — one cluster may serve two of them"
     clusterName + "-" + environment + "-" + suffix
+}
+
+# Die Namespaces auf dem ZIELCLUSTER, in die dieses Modul schreibt — und die es
+# deshalb selbst sicherstellt, statt sie vorauszusetzen.
+#
+# Am 2026-08-21 auf seed-labda-1 aufgelaufen: die ansible-run-Capability legt
+# ihre Credentials nach `tekton-ci`, weil eine Tekton-Pipeline sie dort liest
+# (siehe credentialsNamespace). Auf u26-rke2-1 existierte der Namespace, weil
+# dessen Platform-XR die tekton-App installiert; seed-labda-1 faehrt nur
+# cert-manager, external-secrets und openebs. Das Object blieb auf
+# `create failed: namespaces "tekton-ci" not found` stehen — die halbe Capability
+# ready, die andere Haelfte an einer Vorbedingung, die nirgends deklariert war.
+#
+# Der Namespace gehoert hierher und nicht in die Plattform-Schicht: WELCHER es
+# ist, weiss nur die Capability (er kommt aus ihrer placement), und eine
+# Capability, die ihn voraussetzt, ist genau dann kaputt, wenn der Cluster die
+# App nicht faehrt, die ihn zufaellig mitbringt.
+#
+# Ohne Ausnahmeliste, also auch `default` und `crossplane-system`, die es auf
+# jedem Zielcluster ohnehin gibt: das Object uebernimmt sie beim ersten Observe
+# und ruehrt sie nie wieder an. Eine Liste "die gibt es immer" waere
+# Kubernetes-Trivia im Modul und haette genau ein Loch — den Tag, an dem jemand
+# spec.namespace auf etwas Eigenes setzt.
+#
+# Dedupliziert, weil zwei Capabilities denselben Namespace nennen duerfen —
+# zweimal derselbe komponierte Objectname waere ein Render-Fehler, und zwar einer
+# der erst auftritt, wenn jemand die zweite Capability aktiviert. Sortiert, damit
+# die Reihenfolge nicht an der Iteration eines dicts haengt.
+targetNamespaces = lambda used: [str] -> [str] {
+    sorted([n for n in {u: True for u in used if u}])
 }

--- a/crossplane/xplane-capability/logic_test.k
+++ b/crossplane/xplane-capability/logic_test.k
@@ -108,7 +108,7 @@ test_no_capabilities_means_no_store_requirements = lambda {
 # present and correct — found on u26-rke2-1 on the first apply, and measured for
 # ClusterProviderConfig in crossplane-configurations#294.
 test_status_less_objects_do_not_derive_readiness_from_themselves = lambda {
-    _statusLess = ["EnvironmentConfig", "ClusterProviderConfig"]
+    _statusLess = ["EnvironmentConfig", "ClusterProviderConfig", "Namespace"]
     _wrong = [k for k in _statusLess if logic.readinessFor(k).policy == "DeriveFromObject"]
     assert _wrong == [], "these have no conditions to derive from: " + str(_wrong)
 }
@@ -185,4 +185,39 @@ test_two_environments_on_one_cluster_do_not_collide = lambda {
     _a = logic.resourceName("u26-rke2-1", "labul", "vspherevm-secret-store")
     _b = logic.resourceName("u26-rke2-1", "labda", "vspherevm-secret-store")
     assert _a != _b, "two environments on one cluster produced the same name: " + _a
+}
+
+# Der Fall, der das ausgeloest hat: ansible-run legt seine Credentials nach
+# `tekton-ci`, weil eine Tekton-Pipeline sie dort liest. Auf einem Cluster ohne
+# die tekton-App gibt es den Namespace nicht, und das Object bleibt auf
+# `create failed: namespaces "tekton-ci" not found` stehen — seed-labda-1,
+# 2026-08-21. Der Namespace muss also aus derselben placement fallen, aus der
+# auch die Credentials fallen.
+test_the_credentials_namespace_is_ensured = lambda {
+    _ap = logic.placement("ansible-run", {namespace = "tekton-ci", storageClass = "openebs-hostpath"})
+    _ns = logic.credentialsNamespace("ansible-run", _ap, "crossplane-system")
+    assert logic.targetNamespaces([_ns]) == ["tekton-ci"]
+}
+
+# Zwei Capabilities duerfen denselben Namespace nennen — der Regelfall, sobald
+# eine zweite ihre Credentials neben dem Provider ablegt. Ohne Deduplizierung
+# entstuenden zwei komponierte Objects mit demselben Namen, und zwar erst in dem
+# Moment, in dem jemand die zweite Capability aktiviert.
+test_a_shared_namespace_is_emitted_once = lambda {
+    assert logic.targetNamespaces(["crossplane-system", "crossplane-system", "tekton-ci"]) == ["crossplane-system", "tekton-ci"]
+}
+
+# Sortiert, damit die Reihenfolge nicht an der Iteration eines dicts haengt: ein
+# wechselndes Render ist fuer jeden Differ eine Aenderung.
+test_namespaces_come_out_in_a_stable_order = lambda {
+    assert logic.targetNamespaces(["tekton-ci", "default", "crossplane-system"]) == ["crossplane-system", "default", "tekton-ci"]
+}
+
+# Ein leerer Namespace ist kein Namespace. Ein XRD-Default oder eine halb
+# gefuellte values-Datei liefert "" statt eines fehlenden Schluessels, und ein
+# Object mit leerem metadata.name wuerde vom API-Server abgelehnt — mit einer
+# Meldung ueber den Namen, nicht ueber die Capability, aus der er stammt.
+test_an_empty_namespace_is_dropped = lambda {
+    assert logic.targetNamespaces(["", "tekton-ci"]) == ["tekton-ci"]
+    assert logic.targetNamespaces([]) == []
 }

--- a/crossplane/xplane-capability/main.k
+++ b/crossplane/xplane-capability/main.k
@@ -182,7 +182,7 @@ _validStores = logic.validateStores(_enabled, {n: _vaultOf(n) for n in _enabled}
 _readyOnCreate = {policy = "DeriveFromCelQuery", celQuery = "true"}
 _readyFromObject = {policy = "DeriveFromObject"}
 
-_object = lambda resName: str, manifest: {str:}, readiness: {str:str} = _readyFromObject -> {str:} {
+_object = lambda resName: str, manifest: {str:}, readiness: {str:str} = _readyFromObject, managementPolicies: [str] = [] -> {str:} {
     {
         apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
         kind = "Object"
@@ -198,9 +198,34 @@ _object = lambda resName: str, manifest: {str:}, readiness: {str:str} = _readyFr
             }
             forProvider = {manifest = manifest}
             readiness = readiness
+            # Leer heisst Default (volle Kontrolle) — nicht `[]`, was
+            # provider-kubernetes als "gar nichts tun" liest.
+            **({managementPolicies = managementPolicies} if managementPolicies else {})
         }
     }
 }
+
+# Der Zielnamespace, nicht die Objekte darin. Anders als alles andere hier hat er
+# einen moeglichen Vorbesitzer — er kann von der tekton-App, von einem anderen
+# Capability-XR oder von Hand stammen — also Observe+Create: uebernehmen wenn da,
+# anlegen wenn nicht, und niemals aendern oder loeschen. Ohne Delete ueberlebt der
+# Namespace samt Inhalt das Abraeumen der Capability; mit Delete wuerde das
+# Deaktivieren einer Capability die Tekton-Pipelines des Clusters mitnehmen.
+#
+# readyOnCreate aus demselben Grund wie bei EnvironmentConfig: ein Namespace hat
+# keine conditions, DeriveFromObject liesse das Object dauerhaft auf Ready=False.
+_namespaceObject = lambda ns: str -> {str:} {
+    _object(_resNameFor("namespace-" + ns), {
+        apiVersion = "v1"
+        kind = "Namespace"
+        metadata = {name = ns}
+    }, _readyOnCreate, ["Observe", "Create"])
+}
+
+# Wo dieses Modul ueberall hinschreibt: die Credentials jeder aktiven Capability
+# und — sofern eine davon welche deklariert — der Workload-Namespace.
+_usedNamespaces = [_credsNamespace(n) for n in _enabled] + [_workloadNs for n in _enabled if len(cat.get(n).workloadSecrets) > 0]
+_namespaceObjects = [_namespaceObject(ns) for ns in logic.targetNamespaces(_usedNamespaces)]
 
 _externalSecret = lambda capName: str -> {str:} {
     _c = cat.get(capName)
@@ -414,4 +439,7 @@ _xrStatus = _oxr | {
     }
 }
 
-items = _objects + [_xrStatus]
+# Namespaces zuerst. Crossplane garantiert keine Reihenfolge — provider-kubernetes
+# holt den Rueckstand ohnehin per Retry auf —, aber so steht im Render an erster
+# Stelle, was zuerst existieren muss.
+items = _namespaceObjects + _objects + [_xrStatus]


### PR DESCRIPTION
Jeder Namespace, in den `xplane-capability` auf dem Zielcluster schreibt, wird jetzt selbst als `Object` mit `managementPolicies: [Observe, Create]` emittiert.

## Warum

Aufgelaufen am 2026-08-21 auf `seed-labda-1`. Die `ansible-run`-Capability legt ihre Credentials nach `tekton-ci`, weil eine Tekton-Pipeline sie dort liest (`credentialsNamespaceField`). Auf `u26-rke2-1` existierte der Namespace, weil dessen Platform-XR die `tekton`-App installiert; `seed-labda-1` faehrt nur cert-manager, external-secrets und openebs:

```
create failed: cannot create object: namespaces "tekton-ci" not found
```

Die `vspherevm`-Haelfte desselben XR war gruen — eine Capability, die an einer Vorbedingung haengt, die nirgends deklariert ist.

Der Namespace gehoert in dieses Modul und nicht in die Plattform-Schicht: **welcher** es ist, weiss nur die Capability, denn er kommt aus ihrer `placement`.

## Observe+Create, kein Update, kein Delete

* **kein Delete** — der Namespace samt Inhalt ueberlebt das Abraeumen der Capability. Mit Delete wuerde das Deaktivieren von `ansible-run` die Tekton-Pipelines des Clusters mitnehmen.
* **kein Update** — ein Namespace, der schon einen Besitzer hat (die `tekton`-App, ein anderes Capability-XR, ein Mensch), behaelt ihn. Zwei Capability-XRs duerfen denselben Namespace nennen, ohne sich zu ueberschreiben.

Ohne Ausnahmeliste, also auch `default` und `crossplane-system` — beide werden beim ersten Observe uebernommen und nie wieder angefasst. Eine Liste "die gibt es immer" waere Kubernetes-Trivia im Modul mit genau einem Loch: dem Tag, an dem jemand `spec.namespace` auf etwas Eigenes setzt.

## Tests

`logic.targetNamespaces` dedupliziert und sortiert, damit beides testbar ist:

| Test | faengt |
|---|---|
| `test_the_credentials_namespace_is_ensured` | den `tekton-ci`-Fehler oben |
| `test_a_shared_namespace_is_emitted_once` | zwei Capabilities mit einem Namespace → zwei komponierte Objects mit demselben Namen, sichtbar erst beim Aktivieren der zweiten |
| `test_namespaces_come_out_in_a_stable_order` | ein Render, das mit der dict-Iteration wechselt |
| `test_an_empty_namespace_is_dropped` | `namespace: ""` als leerer `metadata.name` |

`PASS: 24/24`.

Readiness `DeriveFromCelQuery` wie bei `EnvironmentConfig`: ein Namespace hat keine conditions, nur `status.phase`.