### PR TITLE
feat(capability-catalog): cloudInitDatastore fuer proxmoxvm (0.5.0)

### DIFF
--- a/crossplane/xplane-capability-catalog/README.md
+++ b/crossplane/xplane-capability-catalog/README.md
@@ -86,6 +86,20 @@ on an `EnvironmentConfig` rewrites the clone block of every VM already built
 under it, and the provider answers with destroy + recreate — unattended, under
 `compositionUpdatePolicy: Automatic`.
 
+**A field the catalog does not carry is not an error — it is silence, which is
+worse.** `proxmoxvm`'s Composition resolves the cloud-init drive as
+`spec.cloudInit.datastoreId` → EnvironmentConfig `cloudInitDatastore` → the root
+disk's datastore. Until 0.5.0 the catalog had no such key, so every
+capability-built EnvironmentConfig omitted it and every VM fell through to the
+last link — on LabUL that is `V5010-01-1`, where PVE's stop/start round trip on
+the cidata image is broken and the VM becomes unbootable on its first restart.
+Nothing failed and nothing said so. When a Composition reads an environment key,
+this catalog has to know it.
+
+It stays `optional` with no default: `DD-sthings` is a fact about LabUL, not a
+structural one, and a catalog default would be wrong on every other Proxmox
+cluster.
+
 ## Workload secrets
 
 `proxmoxvm` declares one. It is not a credential for the provider; it is the

--- a/crossplane/xplane-capability-catalog/capabilities/proxmoxvm.k
+++ b/crossplane/xplane-capability-catalog/capabilities/proxmoxvm.k
@@ -54,7 +54,29 @@ proxmoxvm: s.Capability = {
     # compositionUpdatePolicy Automatic. Requires proxmoxvm >= v0.11.0, whose
     # `none` sentinel is how an individual XR declines it.
     #
+    # cloudInitDatastore steuert das 4-MB-cidata-Image von der Datenplatte weg.
+    # Es ist die eine Platte, die PVE bei jedem Stop/Start freigibt und neu
+    # anlegt, und auf manchen Storages ist genau dieser Umlauf kaputt: auf LabULs
+    # `V5010-01-1` kann PVE `/dev/V5010-01-1/vm-<id>-cloudinit.qcow2` nicht
+    # statten, der Stop laesst das LV ohne Device-Node in den VG-Metadaten zurueck
+    # und der naechste Start stirbt an `lvcreate ... already exists`. Die VM ist
+    # dann nicht mehr bootbar. Am 2026-08-20 hostseitig bestaetigt: dieselbe VM
+    # mit cidata auf dem NFS-Store `DD-sthings` stoppt und startet sauber.
+    #
+    # HIER, WEIL DIE COMPOSITION ES HIER SUCHT. proxmoxvm loest
+    # `initialization.datastoreId` als spec.cloudInit.datastoreId ->
+    # EnvironmentConfig `cloudInitDatastore` -> Datastore der Rootplatte auf. Der
+    # Katalog kannte den Schluessel bis 0.5.0 nicht, also hat die von der
+    # Capability erzeugte EnvironmentConfig ihn nie getragen und JEDE so gebaute
+    # VM landete auf dem letzten Glied der Kette — dem kaputten Storage. Kein
+    # Fehler, kein Hinweis im Status: die VM entsteht und wird erst beim ersten
+    # Stop/Start unbootbar.
+    #
+    # Optional und ohne Default, obwohl LabUL `DD-sthings` will: ein
+    # Storage-Name ist eine Standort-Wahrheit, keine strukturelle. Ein Katalog-
+    # Default waere auf jedem anderen Proxmox-Cluster schlicht falsch.
+    #
     # snippetsDatastore is NOT the hostname lever (that is the PVE VM name);
     # it only pins the cloud-init instance-id.
-    optional = ["cloneDatastore", "snippetsDatastore", "smbiosManufacturer", "smbiosProduct", "ciPasswordSecretName"]
+    optional = ["cloneDatastore", "cloudInitDatastore", "snippetsDatastore", "smbiosManufacturer", "smbiosProduct", "ciPasswordSecretName"]
 }

--- a/crossplane/xplane-capability-catalog/catalog_test.k
+++ b/crossplane/xplane-capability-catalog/catalog_test.k
@@ -136,3 +136,19 @@ test_entry_names_match_their_consumers_selectors = lambda {
     assert _wrong == [], "these emit a label their Composition does not select: " + str(_wrong)
     assert sorted([n for n in _consumers]) == c.names, "a new entry needs its consumer's selector checked here"
 }
+
+# Die proxmoxvm-Composition loest ihren cloud-init-Datastore als
+# spec.cloudInit.datastoreId -> EnvironmentConfig `cloudInitDatastore` ->
+# Datastore der Rootplatte auf. Kennt der Katalog den Schluessel nicht, kann die
+# von der Capability erzeugte EnvironmentConfig ihn nicht tragen und jede so
+# gebaute VM faellt auf das letzte Glied der Kette durch — auf LabUL ist das der
+# Storage, auf dem der cidata-Umlauf kaputt ist und die VM beim ersten
+# Stop/Start unbootbar wird. Bis 0.5.0 war das der Fall, ohne Fehler und ohne
+# Hinweis im Status.
+#
+# Nagelt nur die Existenz fest, nicht den Wert: ein Storage-Name ist eine
+# Standort-Wahrheit und gehoert ins XR, nicht in den Katalog.
+test_proxmox_can_place_the_cloudinit_drive = lambda {
+    assert "cloudInitDatastore" in c.fields("proxmoxvm"), "die Composition liest den Schluessel; ohne Katalogeintrag wird er stillschweigend verworfen"
+    assert "cloudInitDatastore" not in c.get("proxmoxvm").defaults, "kein Default: DD-sthings gilt fuer LabUL, nicht fuer jeden Proxmox-Cluster"
+}

--- a/crossplane/xplane-capability-catalog/kcl.mod
+++ b/crossplane/xplane-capability-catalog/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "xplane-capability-catalog"
 edition = "v0.12.3"
-version = "0.4.0"
+version = "0.5.0"


### PR DESCRIPTION
Die `proxmoxvm`-Composition löst ihren cloud-init-Datastore in drei Stufen auf:

```
spec.cloudInit.datastoreId  ->  EnvironmentConfig cloudInitDatastore  ->  Datastore der Rootplatte
```

**Den mittleren Schlüssel kannte der Katalog nicht.** Die von der Capability erzeugte EnvironmentConfig konnte ihn also gar nicht tragen — und jede so gebaute VM fiel auf das letzte Glied durch.

## Warum das nicht kosmetisch ist

Auf LabUL ist das letzte Glied `V5010-01-1`, und dort ist genau der Umlauf kaputt, den das cidata-Image bei jedem Stop/Start macht: PVE kann `/dev/V5010-01-1/vm-<id>-cloudinit.qcow2` beim Stop nicht statten, lässt das LV ohne Device-Node in den VG-Metadaten zurück, und der nächste Start stirbt an

```
lvcreate ... error: Logical Volume "vm-<id>-cloudinit.qcow2" already exists in volume group "V5010-01-1"
```

Ab da ist die VM nicht mehr bootbar. Am 2026-08-20 hostseitig bestätigt: dieselbe VM mit cidata auf dem NFS-Store `DD-sthings` stoppt und startet sauber.

Beim **Bauen** fällt nichts davon auf. Die VM entsteht, der Status meldet Ready, der Schaden zeigt sich erst beim ersten Neustart. Genau deshalb bekommt die Lücke einen Test (`test_proxmox_can_place_the_cloudinit_drive`) statt nur einen Kommentar: er nagelt fest, dass der Katalog jeden Environment-Schlüssel kennt, den eine Composition liest.

## Betrifft bestehende Cluster

`u26-rke2-1` fährt heute eine EnvironmentConfig `proxmoxvm-labul` **ohne** den Schlüssel — sie stammt aus dieser Capability. Sie zieht den Wert erst nach, wenn die Kette durchgereicht ist:

| | |
|---|---|
| 1 | dieser PR — Katalog 0.5.0 |
| 2 | `xplane-capability` 0.8.0 (Dep-Bump) |
| 3 | `capability` v0.7.0 in crossplane-configurations |
| 4 | `cloudInitDatastore: DD-sthings` in den XRs von u26 und seed-labda-1 |

## Optional, ohne Default

`DD-sthings` ist eine Wahrheit über LabUL, keine strukturelle. Ein Katalog-Default wäre auf jedem anderen Proxmox-Cluster falsch — der Wert gehört ins XR.

`PASS: 17/17`.