### PR TITLE
feat(capability): Katalog 0.5.0 — cloudInitDatastore reicht durch (0.8.0)

### DIFF
--- a/crossplane/xplane-capability/kcl.mod
+++ b/crossplane/xplane-capability/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "xplane-capability"
 edition = "v0.12.3"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
-xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.4.0" }
+xplane-capability-catalog = { oci = "oci://ghcr.io/stuttgart-things/xplane-capability-catalog", tag = "0.5.0" }

--- a/crossplane/xplane-capability/kcl.mod.lock
+++ b/crossplane/xplane-capability/kcl.mod.lock
@@ -1,9 +1,9 @@
 [dependencies]
   [dependencies.xplane-capability-catalog]
     name = "xplane-capability-catalog"
-    full_name = "xplane-capability-catalog_0.4.0"
-    version = "0.4.0"
-    sum = "2xGqERWAh/79km8+Dju3SNdUIaUq5pc/KZYIArx1/S0="
+    full_name = "xplane-capability-catalog_0.5.0"
+    version = "0.5.0"
+    sum = "JRB5so8cDIK9pb2F9yVzlsXDouk7hdmZyEgBRzrwmWg="
     reg = "ghcr.io"
     repo = "stuttgart-things/xplane-capability-catalog"
-    oci_tag = "0.4.0"
+    oci_tag = "0.5.0"


### PR DESCRIPTION
Dep-Bump auf [`xplane-capability-catalog` 0.5.0](https://github.com/stuttgart-things/kcl/pull/215), Modul 0.7.0 → 0.8.0.

Reiner Versionssprung, aber mit Wirkung: `cloudInitDatastore` ist seit dem Katalog-Release ein bekanntes `placement`-Feld für `proxmoxvm` — und damit kann die von dieser Capability erzeugte EnvironmentConfig es überhaupt erst tragen.

Vorher hätte ein XR den Schlüssel nicht einmal setzen *können*: `unknownFields()` hätte ihn als Tippfehler gemeldet und den ganzen Render abgebrochen. Ohne den Schlüssel löst die `proxmoxvm`-Composition den cloud-init-Datastore auf den Datastore der Rootplatte auf — auf LabUL also auf `V5010-01-1`, wo das cidata-Image den Stop/Start-Umlauf nicht überlebt und die VM beim ersten Neustart unbootbar wird.

Gegengeprüft statt angenommen — mit `cloudInitDatastore: DD-sthings` in der `placement` erscheint der Schlüssel im gerenderten EnvironmentConfig-Object:

```yaml
templateVmId: '211'
cloudInitDatastore: DD-sthings
providerConfigName: proxmoxvm-labul
```

`PASS: 24/24`.

Nächster Schritt: `capability` v0.7.0 in crossplane-configurations, dann der Wert in den XRs von `u26-rke2-1` und `seed-labda-1`.