### PR TITLE
fix(flux): openebs-Template setzte OPENEBS_VERSION nie

### DIFF
--- a/flux/claim-flux-kustomizations/main.k
+++ b/flux/claim-flux-kustomizations/main.k
@@ -186,7 +186,7 @@ _vaultIssuerName = _spec?.vaultIssuerName or option("vaultIssuerName") or "vault
 _vaultIssuerKind = _spec?.vaultIssuerKind or option("vaultIssuerKind") or "ClusterIssuer"
 
 # OpenEBS specific parameters (for openebs template)
-_openebsVersion = _spec?.openebsVersion or option("openebsVersion") or "4.2.0"
+_openebsVersion = _spec?.openebsVersion or option("openebsVersion") or "4.5.1"
 _openebsVolumesnapshotsEnabled = _spec?.openebsVolumesnapshotsEnabled or option("openebsVolumesnapshotsEnabled") or "false"
 _openebsCsiNodeInitContainersEnabled = _spec?.openebsCsiNodeInitContainersEnabled or option("openebsCsiNodeInitContainersEnabled") or "false"
 _openebsLocalLvmEnabled = _spec?.openebsLocalLvmEnabled or option("openebsLocalLvmEnabled") or "false"
@@ -1001,7 +1001,7 @@ if _templateName == "openebs":
                 } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
-                    "VERSION": str(_openebsVersion)
+                    "OPENEBS_VERSION": str(_openebsVersion)
                     "VOLUMESNAPSHOTS_ENABLED": str(_openebsVolumesnapshotsEnabled)
                     "CSI_NODE_INIT_CONTAINERS_ENABLED": str(_openebsCsiNodeInitContainersEnabled)
                     "LOCAL_LVM_ENABLED": str(_openebsLocalLvmEnabled)

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-openebs.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-openebs.yaml
@@ -89,8 +89,9 @@ spec:
     - name: openebsVersion
       title: OpenEBS Version
       type: string
-      default: "4.2.0"
-      description: "OpenEBS Helm chart version (VERSION)"
+      # renovate: datasource=helm depName=openebs registryUrl=https://openebs.github.io/openebs
+      default: "4.5.1"
+      description: "OpenEBS Helm chart version (OPENEBS_VERSION)"
 
     - name: openebsVolumesnapshotsEnabled
       title: Volume Snapshots Enabled


### PR DESCRIPTION
## Befund

Das `openebs`-Template schrieb die Chart-Version als **`VERSION`** in `postBuild.substitute`. Das flux-Repo liest in `infra/openebs/release.yaml` aber:

```yaml
version: ${OPENEBS_VERSION:-4.5.1}
```

Der Parameter lief also ins Leere — gesetzt wurde ein Schluessel, den niemand ausliest, und die HelmRelease fiel auf ihren eigenen Default zurueck.

**Das faellt nicht auf**, weil das Ergebnis meistens trotzdem stimmt: der Fallback ist aktuell genau die Version, die man haben will. Wer aber bewusst pinnt — `infra-sthings` steht auf `4.2.0` — bekommt still etwas anderes ausgerollt, als im Kustomization-Objekt steht.

## Warum der Default mitmuss

Mit dem umbenannten Schluessel **wirkt der Wert jetzt wirklich**. Der Default stand auf `4.2.0`, in `main.k` wie im ClaimTemplate. Bliebe er stehen, wuerde ausgerechnet die Korrektur beim naechsten Rendern ohne expliziten Wert von effektiv **4.5.1 auf echte 4.2.0 herunterstufen** — ein Downgrade als Nebenwirkung eines Bugfixes.

Beide Stellen daher auf `4.5.1` (aktueller Chart-Stand), plus `# renovate:`-Marker im ClaimTemplate, damit der Default nicht wieder einschlaeft.

Die Beschreibung im ClaimTemplate nannte ebenfalls `VERSION` und zeigte damit auf einen Schluessel, den es nicht gab.

## Gegengeprueft

Lokal gerendert:

```yaml
  postBuild:
    substitute:
      OPENEBS_VERSION: '4.5.1'
      VOLUMESNAPSHOTS_ENABLED: 'false'
      ...
```

Und abgeglichen, dass **jede** emittierte Substitution in `release.yaml` auch vorkommt:

```
emitted:  CSI_NODE_INIT_CONTAINERS_ENABLED LOCAL_LVM_ENABLED LOCAL_ZFS_ENABLED
          OPENEBS_VERSION REPLICATED_MAYASTOR_ENABLED VOLUMESNAPSHOTS_ENABLED
emitted but not consumed: (leer)
```

## Auswirkung auf bestehende Cluster

Nichts aendert sich, solange niemand neu rendert. Beim naechsten Rendern eines openebs-Kustomization greift die Version dann tatsaechlich — wer eine andere als 4.5.1 will, muss sie explizit setzen. Handgeschriebene Dateien wie die in `infra-sthings` sind nicht betroffen, die benutzen `OPENEBS_VERSION` bereits korrekt.

## Gefunden bei

Beim Bau von `bootstrap-infra` in `blueprints/flux`: die gerenderte Kustomization unterschied sich von der handgeschriebenen genau in diesem einen Schluessel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4Jmc5323ePZTDZ7XR19a