### PR TITLE
chore(flux): main.k mit kcl fmt formatieren

### DIFF
--- a/flux/claim-flux-kustomizations/README.md
+++ b/flux/claim-flux-kustomizations/README.md
@@ -1,0 +1,60 @@
+# claim-flux-kustomizations
+
+Rendert Flux-`Kustomization`- und `GitRepository`-Objekte fuer die
+Cluster-Repositories. Die erzeugten Objekte tragen die Annotation
+`managed-by: kcl-flux-kustomizations` — daran erkennt man im Cluster-Repo,
+was aus diesem Modul stammt und was von Hand geschrieben wurde.
+
+## Benutzung
+
+Welches Objekt entsteht, entscheidet `templateName`:
+
+```bash
+kcl run . -D templateName=openebs -D sourceRefName=flux-infra
+kcl run . -D templateName=gitrepository -D name=flux-infra \
+          -D url=https://github.com/stuttgart-things/flux.git -D tag=v1.24.1
+```
+
+Als OCI-Modul, so rufen es die dagger-Module auf:
+
+```bash
+dagger call -m github.com/stuttgart-things/dagger/kcl run \
+  --oci-source ghcr.io/stuttgart-things/claim-flux-kustomizations \
+  --parameters "templateName=openebs,name=openebs,sourceRefName=flux-infra" \
+  --entrypoint main.k
+```
+
+## Templates
+
+| | |
+|---|---|
+| Basis | `gitops`, `infrastructure`, `gitrepository` |
+| Storage | `openebs`, `nfs-csi` |
+| Netzwerk | `cilium-gateway` |
+| Zertifikate | `cert-manager`, `cert-manager-selfsigned`, `trust-manager` |
+| Crossplane | `crossplane-install`, `crossplane-functions`, `crossplane-configs` |
+| Vault | `vault`, `vault-autounseal`, `vault-httproute` |
+| Apps | `minio`, `minio-httproute`, `clusterbook`, `flux-web`, `headlamp`, `uptime-kuma`, `prometheus` |
+
+Zu jedem Template liegt unter `templates/` eine `ClaimTemplate`-Datei, die
+die Parameter mit Titeln, Defaults und Enums beschreibt — das ist die
+Quelle fuer die Formulare, nicht dieses README.
+
+## Parameter
+
+Gemeinsam fuer alle Templates: `name`, `namespace`, `interval`,
+`retryInterval`, `timeout`, `prune`, `wait`, `force`, `suspend`,
+`sourceRefKind`, `sourceRefName`, `sourceRefNamespace`, `path`,
+`targetNamespace`, `dependsOnNames`.
+
+Template-spezifische Parameter landen in `spec.postBuild.substitute`.
+Dabei gilt: **der Schluessel muss zu dem passen, was die Manifeste im
+`flux`-Repo auslesen.** Weicht er ab, faellt die Substitution still aus
+und der Chart nimmt seinen eigenen Default — sichtbar wird das erst,
+wenn jemand eine Version bewusst pinnt und trotzdem eine andere bekommt.
+
+## Tests
+
+CI (`lint-and-test`) laeuft nur fuer geaenderte Module und prueft
+`kcl fmt .`, `kcl lint .`, `kcl run .` sowie die Modulstruktur —
+`kcl.mod`, `main.k` und dieses README muessen vorhanden sein.

--- a/flux/claim-flux-kustomizations/main.k
+++ b/flux/claim-flux-kustomizations/main.k
@@ -281,40 +281,29 @@ if _templateName == "gitops":
             wait = _wait
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path
-
             if _targetNamespace:
                 targetNamespace = _targetNamespace
-
             if _namePrefix:
                 namePrefix = _namePrefix
-
             if _nameSuffix:
                 nameSuffix = _nameSuffix
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             if _substitute:
                 postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                     substitute = _substitute
                 }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -322,7 +311,6 @@ if _templateName == "gitops":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -331,10 +319,8 @@ if _templateName == "gitops":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
-
             if _commonLabels or _commonAnnotations:
                 commonMetadata = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecCommonMetadata {
                     if _commonLabels:
@@ -379,14 +365,11 @@ if _templateName == "clusterbook":
             timeout = _timeout if _timeout else "5m"
             prune = _prune
             wait = True
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-apps"
             }
-
             path = _path if _path != "./" else "./apps/clusterbook"
-
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "CLUSTERBOOK_NAMESPACE": str(_clusterbookNamespace)
@@ -407,7 +390,6 @@ if _templateName == "clusterbook":
             }
         }
     }
-
 
 # Template: Uptime Kuma (app deployment with monitoring substitutions)
 if _templateName == "uptime-kuma":
@@ -440,14 +422,11 @@ if _templateName == "uptime-kuma":
             }
             path = _path if _path != "./" else "./apps/uptime-kuma"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "UPTIME_KUMA_NAMESPACE": str(_uptimeKumaNamespace)
@@ -504,14 +483,11 @@ if _templateName == "nfs-csi":
             }
             path = _path if _path != "./" else "./infra/nfs-csi"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "NFS_SERVER_FQDN": str(_nfsServerFqdn)
@@ -567,14 +543,11 @@ if _templateName == "trust-manager":
             }
             path = _path if _path != "./" else "./infra/trust-manager"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "TRUST_MANAGER_NAMESPACE": str(_trustManagerNamespace)
@@ -630,14 +603,11 @@ if _templateName == "flux-web":
             }
             path = _path if _path != "./" else "./apps/flux-web"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "FLUX_WEB_NAMESPACE": str(_fluxWebNamespace)
@@ -692,14 +662,11 @@ if _templateName == "headlamp":
             }
             path = _path if _path != "./" else "./apps/headlamp"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "HEADLAMP_NAMESPACE": str(_headlampNamespace)
@@ -754,14 +721,11 @@ if _templateName == "prometheus":
             }
             path = _path if _path != "./" else "./infra/prometheus"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "PROMETHEUS_NAMESPACE": str(_prometheusNamespace)
@@ -811,26 +775,19 @@ if _templateName == "vault-httproute":
             wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-apps"
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path if _path != "./" else "./apps/vault/httproute"
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "VAULT_NAMESPACE": str(_vaultHttprouteNamespace)
@@ -840,7 +797,6 @@ if _templateName == "vault-httproute":
                     "VAULT_DOMAIN": str(_vaultHttprouteDomain)
                 }
             }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -848,7 +804,6 @@ if _templateName == "vault-httproute":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -857,7 +812,6 @@ if _templateName == "vault-httproute":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
         }
@@ -886,26 +840,19 @@ if _templateName == "vault-autounseal":
             wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-apps"
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path if _path != "./" else "./apps/vault/autounseal"
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "VAULT_NAMESPACE": str(_vaultAutounsealNamespace)
@@ -915,7 +862,6 @@ if _templateName == "vault-autounseal":
                     "VAULT_AUTOUNSEAL_LABEL_SELECTOR": str(_vaultAutounsealLabelSelector)
                 }
             }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -923,7 +869,6 @@ if _templateName == "vault-autounseal":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -932,7 +877,6 @@ if _templateName == "vault-autounseal":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
         }
@@ -961,26 +905,19 @@ if _templateName == "vault":
             wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-apps"
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path if _path != "./" else "./apps/vault"
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "VAULT_VERSION": str(_vaultVersion)
@@ -1006,7 +943,6 @@ if _templateName == "vault":
                     "ISSUER_KIND": str(_vaultIssuerKind)
                 }
             }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -1014,7 +950,6 @@ if _templateName == "vault":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -1023,7 +958,6 @@ if _templateName == "vault":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
         }
@@ -1052,26 +986,19 @@ if _templateName == "openebs":
             wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-infra"
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path if _path != "./" else "./infra/openebs"
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "VERSION": str(_openebsVersion)
@@ -1082,7 +1009,6 @@ if _templateName == "openebs":
                     "REPLICATED_MAYASTOR_ENABLED": str(_openebsReplicatedMayastorEnabled)
                 }
             }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -1090,7 +1016,6 @@ if _templateName == "openebs":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -1099,7 +1024,6 @@ if _templateName == "openebs":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
         }
@@ -1128,26 +1052,19 @@ if _templateName == "cilium-gateway":
             wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-infra"
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path if _path != "./" else "./infra/cilium/components/gateway"
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "CILIUM_GATEWAY_NAME": str(_ciliumGatewayName)
@@ -1156,7 +1073,6 @@ if _templateName == "cilium-gateway":
                     "CILIUM_GATEWAY_TLS_SECRET": str(_ciliumGatewayTlsSecret)
                 }
             }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -1164,7 +1080,6 @@ if _templateName == "cilium-gateway":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -1173,7 +1088,6 @@ if _templateName == "cilium-gateway":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
         }
@@ -1202,26 +1116,19 @@ if _templateName == "cert-manager-selfsigned":
             wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-infra"
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path if _path != "./" else "./infra/cert-manager/components/selfsigned"
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "CERT_MANAGER_NAMESPACE": str(_certManagerNamespace)
@@ -1232,7 +1139,6 @@ if _templateName == "cert-manager-selfsigned":
                     "CERT_MANAGER_SELFSIGNED_ISSUER": str(_certManagerSelfsignedIssuer)
                 }
             }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -1240,7 +1146,6 @@ if _templateName == "cert-manager-selfsigned":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -1249,7 +1154,6 @@ if _templateName == "cert-manager-selfsigned":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
         }
@@ -1278,29 +1182,21 @@ if _templateName == "cert-manager":
             wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName if _sourceRefName else "flux-infra"
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path if _path != "./" else "./infra/cert-manager/components/install"
-
             if _targetNamespace:
                 targetNamespace = _targetNamespace
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "CERT_MANAGER_NAMESPACE": str(_certManagerNamespace)
@@ -1308,7 +1204,6 @@ if _templateName == "cert-manager":
                     "CERT_MANAGER_INSTALL_CRDS": str(_certManagerInstallCrds)
                 }
             }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -1316,7 +1211,6 @@ if _templateName == "cert-manager":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -1325,10 +1219,8 @@ if _templateName == "cert-manager":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
-
             if _commonLabels or _commonAnnotations:
                 commonMetadata = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecCommonMetadata {
                     if _commonLabels:
@@ -1359,43 +1251,33 @@ if _templateName == "infrastructure":
             retryInterval = _retryInterval if _retryInterval else "2m"
             timeout = _timeout if _timeout else "5m"
             prune = _prune
-            wait = True  # Infrastructure always waits for resources to be ready
+            # Infrastructure always waits for resources to be ready
+            wait = True
             force = _force
             suspend = _suspend
-
             sourceRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecSourceRef {
                 kind = _sourceRefKind
                 name = _sourceRefName
                 if _sourceRefNamespace:
                     namespace = _sourceRefNamespace
             }
-
             path = _path
-
             if _targetNamespace:
                 targetNamespace = _targetNamespace
-
             if _namePrefix:
                 namePrefix = _namePrefix
-
             if _nameSuffix:
                 nameSuffix = _nameSuffix
-
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
-
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             if _substitute:
                 postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                     substitute = _substitute
                 }
-
             if _decryptionProvider == "sops" and _decryptionSecretRef:
                 decryption = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDecryption {
                     provider = "sops"
@@ -1403,7 +1285,6 @@ if _templateName == "infrastructure":
                         name = _decryptionSecretRef
                     }
                 }
-
             if _kubeConfigSecretRef:
                 kubeConfig = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfig {
                     secretRef = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecKubeConfigSecretRef {
@@ -1412,10 +1293,8 @@ if _templateName == "infrastructure":
                             key = _kubeConfigSecretKey
                     }
                 }
-
             if _serviceAccountName:
                 serviceAccountName = _serviceAccountName
-
             if _commonLabels or _commonAnnotations:
                 commonMetadata = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecCommonMetadata {
                     if _commonLabels:
@@ -1457,14 +1336,11 @@ if _templateName == "crossplane-install":
             }
             path = _path if _path != "./" else "./cicd/crossplane/components/install"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "CROSSPLANE_NAMESPACE": str(_crossplaneNamespace)
@@ -1517,14 +1393,11 @@ if _templateName == "crossplane-functions":
             }
             path = _path if _path != "./" else "./cicd/crossplane/components/functions"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "CROSSPLANE_NAMESPACE": str(_crossplaneNamespace)
@@ -1574,14 +1447,11 @@ if _templateName == "crossplane-configs":
             }
             path = _path if _path != "./" else "./cicd/crossplane/components/configs"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "CROSSPLANE_CONFIG_CLOUD_CONFIG_VERSION": str(_crossplaneConfigCloudConfigVersion)
@@ -1636,14 +1506,11 @@ if _templateName == "minio":
             }
             path = _path if _path != "./" else "./apps/minio"
             if _dependsOnNames:
-                dependsOn = [
-                    flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                        name = depName
-                        if _dependsOnNamespace:
-                            namespace = _dependsOnNamespace
-                    }
-                    for depName in _dependsOnNames
-                ]
+                dependsOn = [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                    name = depName
+                    if _dependsOnNamespace:
+                        namespace = _dependsOnNamespace
+                } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "MINIO_NAMESPACE": str(_minioNamespace)
@@ -1710,14 +1577,11 @@ if _templateName == "minio-httproute":
                 flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
                     name = "minio"
                 }
-            ] + [
-                flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
-                    name = depName
-                    if _dependsOnNamespace:
-                        namespace = _dependsOnNamespace
-                }
-                for depName in _dependsOnNames
-            ]
+            ] + [flux.KustomizeToolkitFluxcdIoV1KustomizationSpecDependsOnItems0 {
+                name = depName
+                if _dependsOnNamespace:
+                    namespace = _dependsOnNamespace
+            } for depName in _dependsOnNames]
             postBuild = flux.KustomizeToolkitFluxcdIoV1KustomizationSpecPostBuild {
                 substitute = {
                     "MINIO_NAMESPACE": str(_minioNamespace)
@@ -1759,10 +1623,8 @@ if _templateName == "gitrepository":
             url = _gitRepoUrl
             interval = _interval
             timeout = _timeout if _timeout else "60s"
-
             if _suspend:
                 suspend = _suspend
-
             ref = source.SourceToolkitFluxcdIoV1GitRepositorySpecRef {
                 if _gitRepoCommit:
                     commit = _gitRepoCommit
@@ -1773,10 +1635,10 @@ if _templateName == "gitrepository":
                 else:
                     branch = _gitRepoBranch
             }
-
             if _gitRepoSecretRefName:
                 secretRef = source.SourceToolkitFluxcdIoV1GitRepositorySpecSecretRef {
                     name = _gitRepoSecretRefName
                 }
         }
     }
+


### PR DESCRIPTION
**Reine Formatierung, kein inhaltlicher Eingriff.**

`main.k` war **344 Zeilen** von `kcl fmt` entfernt. Auffallen konnte das bisher nicht: `lint-and-test` laeuft nur fuer **geaenderte Module**, und an diesem Modul hat seit dem Auseinanderdriften niemand mehr etwas geaendert. Der naechste inhaltliche PR erbt das rote Ergebnis, ohne es verursacht zu haben — deshalb steht die Formatierung hier fuer sich.

Was `kcl fmt` anfasst: Listen-Comprehensions werden zusammengezogen, Leerzeilen innerhalb von Bloecken entfernt.

## Gegengeprueft

Ein Formatierer, der 344 Zeilen anfasst, ist genau die Stelle, an der eine ungewollte Aenderung unbemerkt durchrutscht. Also vier Templates vor und nach der Formatierung gerendert und die Ausgaben verglichen:

```
openebs:        IDENTICAL output
cert-manager:   IDENTICAL output
gitrepository:  IDENTICAL output
infrastructure: IDENTICAL output
```

Byteweise identisch — die Formatierung ist semantikerhaltend.

## Danach

stuttgart-things/kcl#218 (`OPENEBS_VERSION`-Fix) wird hierauf rebased, damit dort nur die drei inhaltlichen Zeilen im Diff stehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4Jmc5323ePZTDZ7XR19a