### PR TITLE
chore(flux): claim-flux-kustomizations 0.3.33 veroeffentlichen

### DIFF
--- a/flux/claim-flux-kustomizations/kcl.mod
+++ b/flux/claim-flux-kustomizations/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "claim-flux-kustomizations"
 edition = "v0.11.2"
-version = "0.3.32"
+version = "0.3.33"
 
 [profile]
 entries = ["main.k"]

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-openebs.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-openebs.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: kustomization
   source: oci://ghcr.io/stuttgart-things/claim-flux-kustomizations
-  tag: 0.3.24
+  tag: 0.3.33
   parameters:
     - name: templateName
       title: Template


### PR DESCRIPTION
Zwei Schritte, ohne die der `OPENEBS_VERSION`-Fix aus #218 **niemanden erreicht**.

## 1. Modulversion 0.3.32 → 0.3.33

Der Publish-Job laeuft nur, wenn die Version im Registry noch nicht existiert:

```yaml
- if: steps.check-version.outputs.exists == 'false'
  run: kcl mod push ${{ steps.metadata.outputs.oci_ref }}
```

`0.3.32` ist bereits veroeffentlicht (im Registry nachgesehen). Der Schritt waere also uebersprungen worden — der Fix laege auf `main`, aber in **keinem Artefakt**.

## 2. ClaimTemplate-Tag 0.3.24 → 0.3.33

Das openebs-Template zeigte auf `tag: 0.3.24` — genau die Modulversion **mit** dem Bug. Selbst nach dem Publish waere ueber den Claim-Weg weiterhin die kaputte Variante gerendert worden.

Das ist die Stelle, die man leicht uebersieht: Version bumpen allein haette gereicht, damit alles gruen aussieht, ohne dass sich am Ergebnis etwas aendert.

## Nur openebs umgezogen

Die uebrigen Templates pinnen bewusst unterschiedliche Staende (`0.3.10` bis `0.3.32`), jeweils die Version, unter der sie zuletzt verifiziert wurden. Die alle mitzuziehen waere eine deutlich groessere Aenderung mit eigenem Testbedarf und gehoert nicht in einen Release-PR.

## Geprueft

`kcl fmt .` sauber, `kcl run .` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4Jmc5323ePZTDZ7XR19a