### PR TITLE
fix(flux): chart version defaults drifted behind the flux bases

### DIFF
--- a/flux/claim-flux-kustomizations/kcl.mod
+++ b/flux/claim-flux-kustomizations/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "claim-flux-kustomizations"
 edition = "v0.11.2"
-version = "0.3.33"
+version = "0.3.34"
 
 [profile]
 entries = ["main.k"]

--- a/flux/claim-flux-kustomizations/main.k
+++ b/flux/claim-flux-kustomizations/main.k
@@ -108,13 +108,13 @@ _nfsServerFqdn = _spec?.nfsServerFqdn or option("nfsServerFqdn") or ""
 _nfsSharePath = _spec?.nfsSharePath or option("nfsSharePath") or "/data/nfs"
 _nfsCsiClusterName = _spec?.nfsCsiClusterName or option("nfsCsiClusterName") or ""
 _nfsCsiNamespace = _spec?.nfsCsiNamespace or option("nfsCsiNamespace") or "kube-system"
-_nfsCsiVersion = _spec?.nfsCsiVersion or option("nfsCsiVersion") or "v4.13.1"
+_nfsCsiVersion = _spec?.nfsCsiVersion or option("nfsCsiVersion") or "4.13.4"
 _nfsCsiEnableCrds = _spec?.nfsCsiEnableCrds or option("nfsCsiEnableCrds") or "false"
 _nfsCsiEnableSnapshotter = _spec?.nfsCsiEnableSnapshotter or option("nfsCsiEnableSnapshotter") or "true"
 
 # Trust Manager specific parameters (for trust-manager template)
 _trustManagerNamespace = _spec?.trustManagerNamespace or option("trustManagerNamespace") or "cert-manager"
-_trustManagerVersion = _spec?.trustManagerVersion or option("trustManagerVersion") or "0.22.0"
+_trustManagerVersion = _spec?.trustManagerVersion or option("trustManagerVersion") or "v0.24.0"
 _trustBundleCaSecret = _spec?.trustBundleCaSecret or option("trustBundleCaSecret") or "cluster-ca-secret"
 _trustBundleCaKey = _spec?.trustBundleCaKey or option("trustBundleCaKey") or "ca.crt"
 _trustBundleTargetKey = _spec?.trustBundleTargetKey or option("trustBundleTargetKey") or "trust-bundle.pem"
@@ -123,7 +123,7 @@ _trustBundleVaultCaKey = _spec?.trustBundleVaultCaKey or option("trustBundleVaul
 
 # Flux Web specific parameters (for flux-web template)
 _fluxWebNamespace = _spec?.fluxWebNamespace or option("fluxWebNamespace") or "flux-system"
-_fluxWebVersion = _spec?.fluxWebVersion or option("fluxWebVersion") or "0.43.0"
+_fluxWebVersion = _spec?.fluxWebVersion or option("fluxWebVersion") or "0.58.1"
 _fluxWebGatewayName = _spec?.fluxWebGatewayName or option("fluxWebGatewayName") or "gateway"
 _fluxWebGatewayNamespace = _spec?.fluxWebGatewayNamespace or option("fluxWebGatewayNamespace") or "default"
 _fluxWebHostname = _spec?.fluxWebHostname or option("fluxWebHostname") or "flux"
@@ -131,7 +131,7 @@ _fluxWebDomain = _spec?.fluxWebDomain or option("fluxWebDomain") or ""
 
 # Headlamp specific parameters (for headlamp template)
 _headlampNamespace = _spec?.headlampNamespace or option("headlampNamespace") or "headlamp"
-_headlampVersion = _spec?.headlampVersion or option("headlampVersion") or "0.40.0"
+_headlampVersion = _spec?.headlampVersion or option("headlampVersion") or "0.44.0"
 _headlampGatewayName = _spec?.headlampGatewayName or option("headlampGatewayName") or "gateway"
 _headlampGatewayNamespace = _spec?.headlampGatewayNamespace or option("headlampGatewayNamespace") or "default"
 _headlampHostname = _spec?.headlampHostname or option("headlampHostname") or "headlamp"
@@ -139,7 +139,7 @@ _headlampDomain = _spec?.headlampDomain or option("headlampDomain") or ""
 
 # Prometheus specific parameters (for prometheus template)
 _prometheusNamespace = _spec?.prometheusNamespace or option("prometheusNamespace") or "monitoring"
-_prometheusVersion = _spec?.prometheusVersion or option("prometheusVersion") or "28.13.0"
+_prometheusVersion = _spec?.prometheusVersion or option("prometheusVersion") or "28.16.0"
 _prometheusStorageClass = _spec?.prometheusStorageClass or option("prometheusStorageClass") or "openebs-hostpath"
 _prometheusStorageSize = _spec?.prometheusStorageSize or option("prometheusStorageSize") or "10Gi"
 _prometheusRetention = _spec?.prometheusRetention or option("prometheusRetention") or "15d"
@@ -208,7 +208,7 @@ _certManagerSelfsignedIssuer = _spec?.certManagerSelfsignedIssuer or option("cer
 
 # Cert-manager specific parameters (for cert-manager template)
 _certManagerNamespace = _spec?.certManagerNamespace or option("certManagerNamespace") or "cert-manager"
-_certManagerVersion = _spec?.certManagerVersion or option("certManagerVersion") or "v1.19.1"
+_certManagerVersion = _spec?.certManagerVersion or option("certManagerVersion") or "v1.21.1"
 _certManagerInstallCrds = _spec?.certManagerInstallCrds or option("certManagerInstallCrds") or "true"
 
 # Crossplane-specific parameters (for crossplane/crossplane-install template)

--- a/flux/claim-flux-kustomizations/templates/cert-manager.k
+++ b/flux/claim-flux-kustomizations/templates/cert-manager.k
@@ -6,7 +6,7 @@ wait enabled, prune, and post-build variable substitution.
 
 Usage:
     kcl run templates/cert-manager.k -D sourceRefName=flux-infra
-    kcl run templates/cert-manager.k -D sourceRefName=flux-infra -D certManagerVersion=v1.19.1
+    kcl run templates/cert-manager.k -D sourceRefName=flux-infra -D certManagerVersion=v1.21.1
 """
 
 import k8s.apimachinery.pkg.apis.meta.v1 as v1
@@ -42,7 +42,7 @@ _dependsOnNamespace = _spec?.dependsOnNamespace or option("dependsOnNamespace") 
 
 # Cert-manager specific substitution parameters
 _certManagerNamespace = _spec?.certManagerNamespace or option("certManagerNamespace") or "cert-manager"
-_certManagerVersion = _spec?.certManagerVersion or option("certManagerVersion") or "v1.19.1"
+_certManagerVersion = _spec?.certManagerVersion or option("certManagerVersion") or "v1.21.1"
 _certManagerInstallCrds = _spec?.certManagerInstallCrds or option("certManagerInstallCrds") or "true"
 
 # Additional post-build substitutions (comma-separated key=value pairs)

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-cert-manager-install.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-cert-manager-install.yaml
@@ -117,7 +117,7 @@ spec:
     - name: certManagerVersion
       title: Cert-Manager Version
       type: string
-      default: v1.19.1
+      default: v1.21.1
       description: "Cert-Manager chart version (CERT_MANAGER_VERSION)"
 
     - name: certManagerInstallCrds

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-flux-web.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-flux-web.yaml
@@ -63,7 +63,7 @@ spec:
     - name: fluxWebVersion
       title: Flux Web Version
       type: string
-      default: "0.43.0"
+      default: "0.58.1"
       description: "Flux Web Helm chart version (FLUX_WEB_VERSION)"
     - name: fluxWebGatewayName
       title: Gateway Name

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-headlamp.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-headlamp.yaml
@@ -63,7 +63,7 @@ spec:
     - name: headlampVersion
       title: Headlamp Version
       type: string
-      default: "0.40.0"
+      default: "0.44.0"
       description: "Headlamp Helm chart version (HEADLAMP_VERSION)"
     - name: headlampGatewayName
       title: Gateway Name

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-nfs-csi.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-nfs-csi.yaml
@@ -78,7 +78,7 @@ spec:
     - name: nfsCsiVersion
       title: NFS CSI Version
       type: string
-      default: "v4.13.1"
+      default: "4.13.4"
       description: "NFS CSI driver version (NFS_CSI_VERSION)"
     - name: nfsCsiEnableCrds
       title: Enable CRDs

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-prometheus.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-prometheus.yaml
@@ -64,7 +64,7 @@ spec:
     - name: prometheusVersion
       title: Prometheus Chart Version
       type: string
-      default: "28.13.0"
+      default: "28.16.0"
       description: "Prometheus Helm chart version (PROMETHEUS_VERSION)"
     - name: prometheusStorageClass
       title: Storage Class

--- a/flux/claim-flux-kustomizations/templates/flux-kustomization-trust-manager.yaml
+++ b/flux/claim-flux-kustomizations/templates/flux-kustomization-trust-manager.yaml
@@ -65,7 +65,7 @@ spec:
     - name: trustManagerVersion
       title: Trust Manager Version
       type: string
-      default: "0.22.0"
+      default: "v0.24.0"
       description: "Trust-manager Helm chart version (TRUST_MANAGER_VERSION)"
     - name: trustBundleCaSecret
       title: CA Bundle Secret


### PR DESCRIPTION
Every version default in this module is a **second copy** of one that lives in `stuttgart-things/flux`, and six of seven had fallen behind. Because the module writes them as **explicit substitutes**, they beat the base defaults — so rendering a cluster through `claim-flux-kustomizations` silently pinned older charts than the same cluster gets from Flux directly.

| parameter | was | now |
|---|---|---|
| `certManagerVersion` | `v1.19.1` | `v1.21.1` |
| `trustManagerVersion` | `0.22.0` | `v0.24.0` |
| `nfsCsiVersion` | `v4.13.1` | `4.13.4` |
| `prometheusVersion` | `28.13.0` | `28.16.0` |
| `headlampVersion` | `0.40.0` | `0.44.0` |
| `fluxWebVersion` | `0.43.0` | `0.58.1` |

`openebsVersion` was already correct.

## Two were not merely stale — they were unusable

The `v` prefix was on the wrong side:

- **trust-manager** charts carry one (`v0.24.0`); this module emitted `0.22.0`
- **csi-driver-nfs** charts carry none (`4.13.4`); this module emitted `v4.13.1`

Neither would have resolved to a real chart.

## How it surfaced

Rendering `test-infra1`'s own components through `render-infra` and diffing against what that cluster actually runs:

```
live kustomization : v1.21.1
rendered           : v1.19.1
actually running   : v1.21.1
```

That downgrade matters more than a version string: **v1.21 is the release that stopped shipping the `serviceaccounts/token` RBAC**, so crossing it in either direction changes whether a Vault kubernetes-auth ClusterIssuer can sign at all.

## Not addressed here

These defaults exist twice **by design**, and nothing keeps the copies together. The flux repo has a renovate `customManager` for its own pair; this module has no equivalent, so the drift will come back. Worth a follow-up — either a matching renovate rule, or having the module omit the version substitute entirely so the base default wins.

## Verified

Every affected template renders the corrected version:

```
cert-manager     CERT_MANAGER_VERSION=v1.21.1
trust-manager    TRUST_MANAGER_VERSION=v0.24.0
nfs-csi          NFS_CSI_VERSION=4.13.4
headlamp         HEADLAMP_VERSION=0.44.0
flux-web         FLUX_WEB_VERSION=0.58.1
prometheus       PROMETHEUS_VERSION=28.16.0
```

Part of stuttgart-things#2569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkrt9hhBe7ei2d6v3Wudv
